### PR TITLE
chore(manifest): Fix travis workflow

### DIFF
--- a/.travis/create_manifest.sh
+++ b/.travis/create_manifest.sh
@@ -20,12 +20,18 @@ else
             $GENERATOR_PATH $PACKAGE_LOCK $LATEST_VERSION
         fi
 
-        git remote set-url origin $MANIFEST_REPO_TOKEN
-        git config user.email $MANIFEST_REPO_EMAIL
-        git config user.name "vmaas-bot"
-        git add .
-        git commit -m "Update manifest for System Patch Manager UI"
-        git push
+        if [[ `git status --porcelain` ]]; then
+            git remote set-url origin $MANIFEST_REPO_TOKEN
+            git config user.email $MANIFEST_REPO_EMAIL
+            git config user.name "vmaas-bot"
+            git add .
+            git commit -m "Update manifest for System Patch Manager UI"
+            git push
+        else
+            echo "Remote manifest is already up to date!"
+            exit 0
+        fi
+        
     else
         echo -e "Other branch than master or prod-stable, not pushing a build"
         exit 0


### PR DESCRIPTION
The PR will fix the problem 

> Your branch is up to date with 'origin/master'.
> nothing to commit, working tree clean
> The command ".travis/create_manifest.sh" exited with 1.