### PR TITLE
feat(inventory): pass react-redux to inventory

### DIFF
--- a/src/SmartComponents/AffectedSystems/AffectedSystems.js
+++ b/src/SmartComponents/AffectedSystems/AffectedSystems.js
@@ -6,6 +6,7 @@ import propTypes from 'prop-types';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import * as reactRouterDom from 'react-router-dom';
+import * as ReactRedux from 'react-redux';
 import searchFilter from '../../PresentationalComponents/Filters/SearchFilter';
 import Error from '../../PresentationalComponents/Snippets/Error';
 import { getStore, register } from '../../store';
@@ -71,6 +72,7 @@ const AffectedSystems = ({ advisoryName }) => {
             inventoryConnector,
             mergeWithEntities
         } = await insights.loadInventory({
+            ReactRedux,
             React,
             reactRouterDom,
             pfReactTable: {

--- a/src/SmartComponents/SystemDetail/InventoryPage.js
+++ b/src/SmartComponents/SystemDetail/InventoryPage.js
@@ -12,6 +12,7 @@ import {
 import { Main } from '@redhat-cloud-services/frontend-components/components/Main';
 import React from 'react';
 import { useSelector } from 'react-redux';
+import * as ReactRedux from 'react-redux';
 import * as reactRouterDom from 'react-router-dom';
 import Header from '../../PresentationalComponents/Header/Header';
 import { paths } from '../../Routes';
@@ -31,6 +32,7 @@ const InventoryDetail = () => {
             inventoryConnector,
             mergeWithDetail
         } = await insights.loadInventory({
+            ReactRedux,
             React,
             reactRouterDom,
             pfReactTable: {

--- a/src/SmartComponents/Systems/Systems.js
+++ b/src/SmartComponents/Systems/Systems.js
@@ -14,6 +14,7 @@ import { Main } from '@redhat-cloud-services/frontend-components/components/Main
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import * as reactRouterDom from 'react-router-dom';
+import * as ReactRedux from 'react-redux';
 import searchFilter from '../../PresentationalComponents/Filters/SearchFilter';
 import Header from '../../PresentationalComponents/Header/Header';
 import Error from '../../PresentationalComponents/Snippets/Error';
@@ -71,6 +72,7 @@ const Systems = () => {
             inventoryConnector,
             mergeWithEntities
         } = await insights.loadInventory({
+            ReactRedux,
             React,
             reactRouterDom,
             pfReactTable: {


### PR DESCRIPTION
We are working on inventory refactoring, since we'd like to fully use hooks and such we have to use App's react dependency. With this being used react-redux needs to be passed from application as well. If you are cautious about the size of your bundle I can pick only the functions really required by inventory.