### PR TITLE
Pass pf react core to inventory to properly render inventory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1955,9 +1955,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components-utilities": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-2.0.2.tgz",
-      "integrity": "sha512-9lnyigYilarMrdiXwFb+Yc0J7IXVLdcKbmA2EXckG74OWIsDWLsMtQnqg3IS+0/LqPwgd7ztw1q2wD1f16Towg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-2.1.2.tgz",
+      "integrity": "sha512-4q2CoR45ZODAn/bSaHiW7I8fKCRTRBNXHAsoimzkkQDRl7GJOjIlCuzvYpjX9gJitiQyolm7kzyksLS6KNAEkg==",
       "requires": {
         "@sentry/browser": "^5.4.0",
         "awesome-debounce-promise": "^2.1.0",
@@ -2261,59 +2261,59 @@
       }
     },
     "@sentry/browser": {
-      "version": "5.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.16.1.tgz",
-      "integrity": "sha512-uXXKRGLWDqwaKO09K1GTTV0Yj+OfELVs+0cDDYqPDow+DlIXyx0gSnZPd0caCqFllUy8JSxb4S9OprYinvks2A==",
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.20.1.tgz",
+      "integrity": "sha512-ClykuvrEsMKgAvifx5VHzRjchwYbJFX8YiIicYx+Wr3MXL2jLG6OEfHHJwJeyBL2C3vxd5O0KPK3pGMR9wPMLA==",
       "requires": {
-        "@sentry/core": "5.16.1",
-        "@sentry/types": "5.16.1",
-        "@sentry/utils": "5.16.1",
+        "@sentry/core": "5.20.1",
+        "@sentry/types": "5.20.1",
+        "@sentry/utils": "5.20.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/core": {
-      "version": "5.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.16.1.tgz",
-      "integrity": "sha512-CDKUAUWefZ+bx7tUGm7pgkuJbwn+onAlwzKkLGVg730IP+N/AWSpVtbvFTPiel2+NPiFhWX5/F0SpxDMLPRKfg==",
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.20.1.tgz",
+      "integrity": "sha512-gG622/UY2TePruF6iUzgVrbIX5vN8w2cjlWFo1Est8MvCfQsz8agGaLMCAyl5hCGJ6K2qTUZDOlbCNIKoMclxg==",
       "requires": {
-        "@sentry/hub": "5.16.1",
-        "@sentry/minimal": "5.16.1",
-        "@sentry/types": "5.16.1",
-        "@sentry/utils": "5.16.1",
+        "@sentry/hub": "5.20.1",
+        "@sentry/minimal": "5.20.1",
+        "@sentry/types": "5.20.1",
+        "@sentry/utils": "5.20.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "5.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.16.1.tgz",
-      "integrity": "sha512-Og4zxp0lM9yS6TyKbZ5lQR94f/fNOalodm71Dk4qfBWi0OzfFCVpO4fPOhHtbXEsvMNg5xh0Pe8ezqX3CZ3hTw==",
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.20.1.tgz",
+      "integrity": "sha512-Nv5BXf14BEc08acDguW6eSqkAJLVf8wki283FczEvTsQZZuSBHM9cJ5Hnehr6n+mr8wWpYLgUUYM0oXXigUmzQ==",
       "requires": {
-        "@sentry/types": "5.16.1",
-        "@sentry/utils": "5.16.1",
+        "@sentry/types": "5.20.1",
+        "@sentry/utils": "5.20.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "5.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.16.1.tgz",
-      "integrity": "sha512-RCwEKLneV5BQlv1MEmsCR3I5jajHgVGusBgwGgnFv+4Cn4cNC7OHWH4QbuZ3IHOEHJl7YS074BeluM+7jn0+Tw==",
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.20.1.tgz",
+      "integrity": "sha512-2PeJKDTHNsUd1jtSLQBJ6oRI+xrIJrYDQmsyK/qs9D7HqHfs+zNAMUjYseiVeSAFGas5IcNSuZbPRV4BnuoZ0w==",
       "requires": {
-        "@sentry/hub": "5.16.1",
-        "@sentry/types": "5.16.1",
+        "@sentry/hub": "5.20.1",
+        "@sentry/types": "5.20.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "5.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.16.1.tgz",
-      "integrity": "sha512-uERNhBdsiWvWG7qTC9QVsvFmOSL8rFfy8usEXeH3l4oCQao9TvGUvXJv6gRfiWmoiJZ1A0608Lj15CORygdbng=="
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.20.1.tgz",
+      "integrity": "sha512-OU+i/lcjGpDJv0XkNpsKrI2r1VPp8qX0H6Knq8NuZrlZe3AbvO3jRJJK0pH14xFv8Xok5jbZZpKKoQLxYfxqsw=="
     },
     "@sentry/utils": {
-      "version": "5.16.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.16.1.tgz",
-      "integrity": "sha512-hn2jTc6ZH1lXGij7yqkV6cGhEYxsdjqB5P4MjfrRHB5bk5opY9R89bsAhs1rpanTdwv6Ul0ieR1z18gdIgUf0g==",
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.20.1.tgz",
+      "integrity": "sha512-dhK6IdO6g7Q2CoxCbB+q8gwUapDUH5VjraFg0UBzgkrtNhtHLylqmwx0sWQvXCcp14Q/3MuzEbb4euvoh8o8oA==",
       "requires": {
-        "@sentry/types": "5.16.1",
+        "@sentry/types": "5.20.1",
         "tslib": "^1.9.3"
       }
     },
@@ -18404,9 +18404,9 @@
       }
     },
     "react-content-loader": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/react-content-loader/-/react-content-loader-5.0.4.tgz",
-      "integrity": "sha512-hxv4Td1kQxFOmIUbBZ2S3HGZ/jJr28aJvM+8fndm9TmNOE7tSde7WSTL6R68aTS6qE0BA3ptcWIErrP704pQSw=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-content-loader/-/react-content-loader-5.1.0.tgz",
+      "integrity": "sha512-80t5SYxLCXDvpaRRH/p4tV8RGGPBM7YAWwA+mARCJWRj4IkcEnJxkPGboBENgkBmyG4xsMAsa/dgy93DXoQ1dA=="
     },
     "react-dom": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@redhat-cloud-services/frontend-components": "^2.1.0-beta.6",
     "@redhat-cloud-services/frontend-components-notifications": "^2.0.3",
     "@redhat-cloud-services/frontend-components-remediations": "^2.0.4",
-    "@redhat-cloud-services/frontend-components-utilities": "^2.0.2",
+    "@redhat-cloud-services/frontend-components-utilities": "^2.1.2",
     "@semantic-release/npm": "^7.0.4",
     "axios": "^0.19.2",
     "classnames": "^2.2.5",

--- a/src/SmartComponents/AffectedSystems/AffectedSystems.js
+++ b/src/SmartComponents/AffectedSystems/AffectedSystems.js
@@ -7,6 +7,7 @@ import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import * as reactRouterDom from 'react-router-dom';
 import * as ReactRedux from 'react-redux';
+import { reactCore } from '@redhat-cloud-services/frontend-components-utilities/files/inventoryDependencies';
 import searchFilter from '../../PresentationalComponents/Filters/SearchFilter';
 import Error from '../../PresentationalComponents/Snippets/Error';
 import { getStore, register } from '../../store';
@@ -85,7 +86,8 @@ const AffectedSystems = ({ advisoryName }) => {
                 sortable,
                 expandable,
                 SortByDirection
-            }
+            },
+            pfReact: reactCore
         });
 
         register({

--- a/src/SmartComponents/SystemDetail/InventoryPage.js
+++ b/src/SmartComponents/SystemDetail/InventoryPage.js
@@ -14,6 +14,7 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import * as ReactRedux from 'react-redux';
 import * as reactRouterDom from 'react-router-dom';
+import { reactCore } from '@redhat-cloud-services/frontend-components-utilities/files/inventoryDependencies';
 import Header from '../../PresentationalComponents/Header/Header';
 import { paths } from '../../Routes';
 import { getStore, register } from '../../store';
@@ -22,6 +23,7 @@ import { SystemDetailStore } from '../../store/Reducers/SystemDetailStore';
 const InventoryDetail = () => {
     const [InventoryHeader, setInventoryHeader] = React.useState();
     const [InventoryBody, setInventoryBody] = React.useState();
+    const [InventoryWrapper, setInventoryWrapper] = React.useState();
 
     const entityDetails = useSelector(
         ({ entityDetails }) => entityDetails && entityDetails.entity
@@ -45,24 +47,27 @@ const InventoryDetail = () => {
                 sortable,
                 expandable,
                 SortByDirection
-            }
+            },
+            pfReact: reactCore
         });
 
         register({
             ...mergeWithDetail(SystemDetailStore)
         });
 
-        const { InventoryDetailHead, AppInfo } = inventoryConnector(getStore());
+        const { InventoryDetailHead, AppInfo, DetailWrapper } = inventoryConnector(getStore());
         setInventoryHeader(() => InventoryDetailHead);
         setInventoryBody(() => AppInfo);
+        setInventoryWrapper(() => DetailWrapper);
     };
 
     React.useEffect(() => {
         fetchInventory();
     }, []);
 
+    const Wrapper = InventoryWrapper || React.Fragment;
     return (
-        <React.Fragment>
+        <Wrapper>
             <Header
                 title=""
                 breadcrumbs={[
@@ -89,7 +94,7 @@ const InventoryDetail = () => {
                     <InventoryBody />
                 </Main>
             )}
-        </React.Fragment>
+        </Wrapper>
     );
 };
 

--- a/src/SmartComponents/Systems/Systems.js
+++ b/src/SmartComponents/Systems/Systems.js
@@ -15,6 +15,7 @@ import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import * as reactRouterDom from 'react-router-dom';
 import * as ReactRedux from 'react-redux';
+import { reactCore } from '@redhat-cloud-services/frontend-components-utilities/files/inventoryDependencies';
 import searchFilter from '../../PresentationalComponents/Filters/SearchFilter';
 import Header from '../../PresentationalComponents/Header/Header';
 import Error from '../../PresentationalComponents/Snippets/Error';
@@ -85,7 +86,8 @@ const Systems = () => {
                 sortable,
                 expandable,
                 SortByDirection
-            }
+            },
+            pfReact: reactCore
         });
 
         register({


### PR DESCRIPTION
There is a new feature brewing in chrome, building chrome with webpack [1]. This PR passes newly required dependencies. In future we'll use Federated modules [2] so there won't be a need for these changes, but this is required as a mid-step solution.

Also, for enabling A/B testing of inventory detail we are working on new inventory component, for now this component will be undefined so use `React.Fragment` as fallback.

[1] https://github.com/RedHatInsights/insights-chrome/pull/842
[2] https://webpack.js.org/concepts/module-federation/