### PR TITLE
Mark systems table as full view

### DIFF
--- a/src/SmartComponents/Systems/Systems.js
+++ b/src/SmartComponents/Systems/Systems.js
@@ -163,6 +163,7 @@ const Systems = () => {
                 {status === STATUS_REJECTED ? <Error message={error.detail}/> :
                     InventoryCmp && (
                         <InventoryCmp
+                            isFullView
                             items={hosts}
                             page={page}
                             total={metadata.total_items}


### PR DESCRIPTION
### Inventory full view [1]

In order to show proper RBAC state in systems table we need to pass `fullView` prop to inventory component. This applies only to systems page as it's the only place where inventory table is just one component on screen. Without this prop the `unAuthorized` component would be in table, which is not correct based on our mocks.

[1] https://github.com/RedHatInsights/frontend-components/blob/master/packages/inventory/doc/inventory.md#using-rbac-with-inventory