### PR TITLE
Remove debug enable function from patch component mount

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -21,7 +21,6 @@ class App extends Component {
     componentDidMount() {
         insights.chrome.init();
         insights.chrome.identifyApp('patch');
-        insights.chrome.enable.globalFilter();
 
         if (insights.chrome?.globalFilterScope) {
             insights.chrome.on('GLOBAL_FILTER_UPDATE', ({ data }) => {


### PR DESCRIPTION
### No need to use `insights.chrome.enable.globalFilter();`

When navigating to patch and then to any other app it shows the global filter no matter if we hid it or not. This is caused by using `insights.chrome.enable.globalFilter();`, this function should be used only for local debugging and not stored in your code, it'll set localStorage value which enables global filter everywhere.