### PR TITLE
fix(ConditionalFilter): radio type filter empty value is fixed

### DIFF
--- a/src/PresentationalComponents/Filters/PublishDateFilter.js
+++ b/src/PresentationalComponents/Filters/PublishDateFilter.js
@@ -4,13 +4,8 @@ import { publicDateOptions } from '../../Utilities/constants';
 const publishDateFilter = (apply, currentFilter = {}) => {
     let { public_date: currentValue } = currentFilter;
 
-    // Empty string value is not supported by PF Radio at the moment
-    if (currentValue === '' || !currentValue) {
-        currentValue = '0';
-    }
-
     const filterByPublicDate = value => {
-        apply({ filter: { public_date: (value !== '0' && value) || '' } });
+        apply({ filter: { public_date: (value !== 'all' && value) || '' } });
     };
 
     return {

--- a/src/PresentationalComponents/Filters/PublishDateFilter.test.js
+++ b/src/PresentationalComponents/Filters/PublishDateFilter.test.js
@@ -6,7 +6,7 @@ const currentFilter = { public_date: 'filter' };
 describe('PublishDateFitler', () => {
     it('Should set currentValue to zero and init', () => {
         const response = publishDateFilter(apply);
-        expect(response.filterValues.value).toEqual('0');
+        expect(response.filterValues.value).toEqual(undefined);
         expect(response.label).toEqual('Publish date');
         expect(response.type).toEqual('radio');
     });
@@ -17,7 +17,7 @@ describe('PublishDateFitler', () => {
         expect(apply).toHaveBeenCalledWith({ filter: { public_date: 'testValue' } });
     });
 
-    it('Should call apply with 0 ', () => {
+    it('Should call apply with empty string ', () => {
         const response = publishDateFilter(apply);
         response.filterValues.onChange();
         expect(apply).toHaveBeenCalledWith({ filter: { public_date: '' } });

--- a/src/SmartComponents/Advisories/__snapshots__/Advisories.test.js.snap
+++ b/src/SmartComponents/Advisories/__snapshots__/Advisories.test.js.snap
@@ -198,7 +198,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                           "filterValues": Object {
                             "items": [MockFunction],
                             "onChange": [Function],
-                            "value": "0",
+                            "value": undefined,
                           },
                           "label": "Publish date",
                           "type": "radio",
@@ -340,7 +340,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                             "filterValues": Object {
                               "items": [MockFunction],
                               "onChange": [Function],
-                              "value": "0",
+                              "value": undefined,
                             },
                             "label": "Publish date",
                             "type": "radio",
@@ -438,7 +438,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                                 "filterValues": Object {
                                                   "items": [MockFunction],
                                                   "onChange": [Function],
-                                                  "value": "0",
+                                                  "value": undefined,
                                                 },
                                                 "label": "Publish date",
                                                 "type": "radio",

--- a/src/SmartComponents/SystemAdvisories/__snapshots__/SystemAdvisories.test.js.snap
+++ b/src/SmartComponents/SystemAdvisories/__snapshots__/SystemAdvisories.test.js.snap
@@ -155,7 +155,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                       "filterValues": Object {
                         "items": [MockFunction],
                         "onChange": [Function],
-                        "value": "0",
+                        "value": undefined,
                       },
                       "label": "Publish date",
                       "type": "radio",
@@ -332,7 +332,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                         "filterValues": Object {
                           "items": [MockFunction],
                           "onChange": [Function],
-                          "value": "0",
+                          "value": undefined,
                         },
                         "label": "Publish date",
                         "type": "radio",
@@ -831,7 +831,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                             "filterValues": Object {
                                               "items": [MockFunction],
                                               "onChange": [Function],
-                                              "value": "0",
+                                              "value": undefined,
                                             },
                                             "label": "Publish date",
                                             "type": "radio",

--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -26,7 +26,7 @@ export const storeListDefaults = {
 };
 
 export const publicDateOptions = [
-    { apiValue: '', label: 'All', value: '' },
+    { apiValue: '', label: 'All', value: 'all' },
     {
         apiValue: `gt:${subtractDate(7)}`,
         label: 'Last 7 days',


### PR DESCRIPTION
not a complete solution [SPM-614](https://issues.redhat.com/browse/SPM-614) 

But using this approach we could avoid 
`    // Empty string value is not supported by PF Radio at the moment
    if (currentValue === '' || !currentValue) {
        currentValue = '0';
    }`