### PR TITLE
feat(OUIA): enable OUIA for Patch

### DIFF
--- a/src/PresentationalComponents/Header/Header.js
+++ b/src/PresentationalComponents/Header/Header.js
@@ -7,15 +7,17 @@ import React from 'react';
 import HeaderBreadcrumbs from './HeaderBreadcrumbs';
 import HeaderTabs from './HeaderTabs';
 
-const Header = ({ title, showTabs, breadcrumbs, children }) => {
+const Header = ({ title, showTabs, breadcrumbs, children, headerOUIA }) => {
     return (
         <React.Fragment>
-            <PageHeader>
-                {breadcrumbs && <HeaderBreadcrumbs items={breadcrumbs} />}
+            <PageHeader
+                data-ouia-component-type={`${headerOUIA}-page-header`}
+            >
+                {breadcrumbs && <HeaderBreadcrumbs items={breadcrumbs} headerOUIA={headerOUIA} />}
                 <PageHeaderTitle title={title} />
                 {children}
             </PageHeader>
-            {showTabs && <HeaderTabs />}
+            {showTabs && <HeaderTabs headerOUIA = {headerOUIA}/>}
         </React.Fragment>
     );
 };
@@ -24,7 +26,8 @@ Header.propTypes = {
     title: PropTypes.string,
     showTabs: PropTypes.bool,
     breadcrumbs: PropTypes.array,
-    children: PropTypes.any
+    children: PropTypes.any,
+    headerOUIA: PropTypes.string
 };
 
 export default Header;

--- a/src/PresentationalComponents/Header/HeaderBreadcrumbs.js
+++ b/src/PresentationalComponents/Header/HeaderBreadcrumbs.js
@@ -6,12 +6,15 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-const HeaderBreadcrumbs = ({ items }) => {
+const HeaderBreadcrumbs = ({ items, headerOUIA }) => {
     return (
         <Breadcrumb>
             {items.filter(Boolean).map(item => (
                 <BreadcrumbItem key={item.title} isActive={item.isActive}>
-                    {(item.to && <Link to={item.to}>{item.title}</Link>) ||
+                    {(item.to && <Link to={item.to}
+                        data-ouia-component-type={`${headerOUIA}-breadcrumb`}
+                        data-ouia-component-id={`breadcrumb-to-${item.title}`}
+                    >{item.title}</Link>) ||
                         item.title}
                 </BreadcrumbItem>
             ))}
@@ -26,7 +29,8 @@ HeaderBreadcrumbs.propTypes = {
             to: PropTypes.string,
             title: PropTypes.string
         })
-    )
+    ),
+    headerOUIA: PropTypes.string
 };
 
 export default HeaderBreadcrumbs;

--- a/src/PresentationalComponents/Header/HeaderTabs.js
+++ b/src/PresentationalComponents/Header/HeaderTabs.js
@@ -5,7 +5,7 @@ import { withRouter } from 'react-router-dom';
 import { paths } from '../../Routes';
 import './Header.scss';
 
-const HeaderTabs = ({ history }) => {
+const HeaderTabs = ({ history, headerOUIA }) => {
     const handleRedirect = (event, tabString) => {
         history.push(tabString);
     };
@@ -19,14 +19,22 @@ const HeaderTabs = ({ history }) => {
             <Tab
                 eventKey={paths.advisories.to}
                 title={paths.advisories.title}
+                data-ouia-component-type={`${headerOUIA}-tab`}
+                data-ouia-component-id={`${headerOUIA}-tab-${paths.advisories.title}`}
             />
-            <Tab eventKey={paths.systems.to} title={paths.systems.title} />
+            <Tab
+                eventKey={paths.systems.to}
+                title={paths.systems.title}
+                data-ouia-component-type={`${headerOUIA}-tab`}
+                data-ouia-component-id={`${headerOUIA}-tab-${paths.systems.title}`}
+            />
         </Tabs>
     );
 };
 
 HeaderTabs.propTypes = {
-    history: propTypes.object
+    history: propTypes.object,
+    headerOUIA: propTypes.string
 };
 
 export default withRouter(HeaderTabs);

--- a/src/PresentationalComponents/Header/__snapshots__/Header.test.js.snap
+++ b/src/PresentationalComponents/Header/__snapshots__/Header.test.js.snap
@@ -39,9 +39,12 @@ exports[`Header component should render with 1 breadcrumb item and last is activ
       }
       title=""
     >
-      <PageHeader>
+      <PageHeader
+        data-ouia-component-type="undefined-page-header"
+      >
         <section
           className="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
+          data-ouia-component-type="undefined-page-header"
           widget-type="InsightsPageHeader"
         >
           <HeaderBreadcrumbs
@@ -75,13 +78,19 @@ exports[`Header component should render with 1 breadcrumb item and last is activ
                       className="pf-c-breadcrumb__item"
                     >
                       <Link
+                        data-ouia-component-id="breadcrumb-to-First item"
+                        data-ouia-component-type="undefined-breadcrumb"
                         to="#"
                       >
                         <LinkAnchor
+                          data-ouia-component-id="breadcrumb-to-First item"
+                          data-ouia-component-type="undefined-breadcrumb"
                           href="/"
                           navigate={[Function]}
                         >
                           <a
+                            data-ouia-component-id="breadcrumb-to-First item"
+                            data-ouia-component-type="undefined-breadcrumb"
                             href="/"
                             onClick={[Function]}
                           >
@@ -164,9 +173,12 @@ exports[`Header component should render with 2 breadcrumb items and last is acti
       }
       title=""
     >
-      <PageHeader>
+      <PageHeader
+        data-ouia-component-type="undefined-page-header"
+      >
         <section
           className="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
+          data-ouia-component-type="undefined-page-header"
           widget-type="InsightsPageHeader"
         >
           <HeaderBreadcrumbs
@@ -205,13 +217,19 @@ exports[`Header component should render with 2 breadcrumb items and last is acti
                       className="pf-c-breadcrumb__item"
                     >
                       <Link
+                        data-ouia-component-id="breadcrumb-to-First item"
+                        data-ouia-component-type="undefined-breadcrumb"
                         to="#"
                       >
                         <LinkAnchor
+                          data-ouia-component-id="breadcrumb-to-First item"
+                          data-ouia-component-type="undefined-breadcrumb"
                           href="/"
                           navigate={[Function]}
                         >
                           <a
+                            data-ouia-component-id="breadcrumb-to-First item"
+                            data-ouia-component-type="undefined-breadcrumb"
                             href="/"
                             onClick={[Function]}
                           >
@@ -259,13 +277,19 @@ exports[`Header component should render with 2 breadcrumb items and last is acti
                         </AngleRightIcon>
                       </span>
                       <Link
+                        data-ouia-component-id="breadcrumb-to-Second item"
+                        data-ouia-component-type="undefined-breadcrumb"
                         to="#"
                       >
                         <LinkAnchor
+                          data-ouia-component-id="breadcrumb-to-Second item"
+                          data-ouia-component-type="undefined-breadcrumb"
                           href="/"
                           navigate={[Function]}
                         >
                           <a
+                            data-ouia-component-id="breadcrumb-to-Second item"
+                            data-ouia-component-type="undefined-breadcrumb"
                             href="/"
                             onClick={[Function]}
                           >
@@ -354,9 +378,12 @@ exports[`Header component should render with 3 breadcrumb items and last is acti
       showTabs={false}
       title=""
     >
-      <PageHeader>
+      <PageHeader
+        data-ouia-component-type="undefined-page-header"
+      >
         <section
           className="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
+          data-ouia-component-type="undefined-page-header"
           widget-type="InsightsPageHeader"
         >
           <HeaderBreadcrumbs
@@ -400,13 +427,19 @@ exports[`Header component should render with 3 breadcrumb items and last is acti
                       className="pf-c-breadcrumb__item"
                     >
                       <Link
+                        data-ouia-component-id="breadcrumb-to-First item"
+                        data-ouia-component-type="undefined-breadcrumb"
                         to="#"
                       >
                         <LinkAnchor
+                          data-ouia-component-id="breadcrumb-to-First item"
+                          data-ouia-component-type="undefined-breadcrumb"
                           href="/"
                           navigate={[Function]}
                         >
                           <a
+                            data-ouia-component-id="breadcrumb-to-First item"
+                            data-ouia-component-type="undefined-breadcrumb"
                             href="/"
                             onClick={[Function]}
                           >
@@ -454,13 +487,19 @@ exports[`Header component should render with 3 breadcrumb items and last is acti
                         </AngleRightIcon>
                       </span>
                       <Link
+                        data-ouia-component-id="breadcrumb-to-Second item"
+                        data-ouia-component-type="undefined-breadcrumb"
                         to="#"
                       >
                         <LinkAnchor
+                          data-ouia-component-id="breadcrumb-to-Second item"
+                          data-ouia-component-type="undefined-breadcrumb"
                           href="/"
                           navigate={[Function]}
                         >
                           <a
+                            data-ouia-component-id="breadcrumb-to-Second item"
+                            data-ouia-component-type="undefined-breadcrumb"
                             href="/"
                             onClick={[Function]}
                           >
@@ -508,13 +547,19 @@ exports[`Header component should render with 3 breadcrumb items and last is acti
                         </AngleRightIcon>
                       </span>
                       <Link
+                        data-ouia-component-id="breadcrumb-to-Third item"
+                        data-ouia-component-type="undefined-breadcrumb"
                         to="#"
                       >
                         <LinkAnchor
+                          data-ouia-component-id="breadcrumb-to-Third item"
+                          data-ouia-component-type="undefined-breadcrumb"
                           href="/"
                           navigate={[Function]}
                         >
                           <a
+                            data-ouia-component-id="breadcrumb-to-Third item"
+                            data-ouia-component-type="undefined-breadcrumb"
                             href="/"
                             onClick={[Function]}
                           >
@@ -584,9 +629,12 @@ exports[`Header component should render with empty breadcrumb 1`] = `
       breadcrumbs={Array []}
       title=""
     >
-      <PageHeader>
+      <PageHeader
+        data-ouia-component-type="undefined-page-header"
+      >
         <section
           className="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
+          data-ouia-component-type="undefined-page-header"
           widget-type="InsightsPageHeader"
         >
           <HeaderBreadcrumbs
@@ -661,9 +709,12 @@ exports[`Header component should render with header Hello world 1`] = `
     <Header
       title="Hello world"
     >
-      <PageHeader>
+      <PageHeader
+        data-ouia-component-type="undefined-page-header"
+      >
         <section
           className="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
+          data-ouia-component-type="undefined-page-header"
           widget-type="InsightsPageHeader"
         >
           <PageHeaderTitle
@@ -722,9 +773,12 @@ exports[`Header component should render with header as empty string 1`] = `
     <Header
       title=""
     >
-      <PageHeader>
+      <PageHeader
+        data-ouia-component-type="undefined-page-header"
+      >
         <section
           className="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
+          data-ouia-component-type="undefined-page-header"
           widget-type="InsightsPageHeader"
         >
           <PageHeaderTitle
@@ -790,9 +844,12 @@ exports[`Header component should render without to attribute 1`] = `
       }
       title=""
     >
-      <PageHeader>
+      <PageHeader
+        data-ouia-component-type="undefined-page-header"
+      >
         <section
           className="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
+          data-ouia-component-type="undefined-page-header"
           widget-type="InsightsPageHeader"
         >
           <HeaderBreadcrumbs

--- a/src/PresentationalComponents/TableView/TableFooter.js
+++ b/src/PresentationalComponents/TableView/TableFooter.js
@@ -3,7 +3,7 @@ import { TableToolbar } from '@redhat-cloud-services/frontend-components/compone
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const TableFooter = ({ page, perPage, onSetPage, totalItems, onPerPageSelect }) => {
+const TableFooter = ({ page, perPage, onSetPage, totalItems, onPerPageSelect, paginationOUIA }) => {
     return (
         <TableToolbar>
             <Pagination
@@ -14,6 +14,7 @@ const TableFooter = ({ page, perPage, onSetPage, totalItems, onPerPageSelect }) 
                 onPerPageSelect={onPerPageSelect}
                 widgetId={`pagination-options-menu-bottom`}
                 variant={PaginationVariant.bottom}
+                ouiaId={paginationOUIA}
             />
         </TableToolbar>
     );
@@ -24,7 +25,8 @@ TableFooter.propTypes = {
     onPerPageSelect: PropTypes.func,
     page: PropTypes.number,
     perPage: PropTypes.number,
-    totalItems: PropTypes.number
+    totalItems: PropTypes.number,
+    paginationOUIA: PropTypes.string
 };
 
 export default TableFooter;

--- a/src/PresentationalComponents/TableView/TableView.js
+++ b/src/PresentationalComponents/TableView/TableView.js
@@ -31,7 +31,10 @@ const TableView = ({
     remediationProvider,
     selectedRows,
     compact,
-    apply
+    apply,
+    remediationButtonOUIA,
+    tableOUIA,
+    paginationOUIA
 }) => {
     const [
         RemediationModalCmp,
@@ -57,7 +60,8 @@ const TableView = ({
                     perPage,
                     isCompact: true,
                     onSetPage,
-                    onPerPageSelect
+                    onPerPageSelect,
+                    ouiaId: `top-${paginationOUIA}`
                 }}
                 filterConfig={filterConfig}
                 activeFiltersConfig={{
@@ -72,6 +76,7 @@ const TableView = ({
                             onClick={() =>
                                 showRemediationModal(remediationProvider())
                             }
+                            ouiaId={remediationButtonOUIA}
                         >
                             <AnsibeTowerIcon color={globalPaletteWhite.value} />&nbsp;Remediate
                         </Button>
@@ -101,6 +106,9 @@ const TableView = ({
                     onSelect: (value) => {
                         value ? onSelect('all') : onSelect('none');
                     },
+                    toggleProps: {
+                        'data-ouia-component-type': 'bulk-select-toggle-button'
+                    },
                     checked: selectedCount === metadata.total_items ? true : selectedCount === 0 ? false : null
                 }}
 
@@ -117,6 +125,7 @@ const TableView = ({
                         onCollapse={metadata.total_items && onCollapse}
                         canSelectAll={false}
                         onSort={onSort}
+                        ouiaId={tableOUIA}
                         sortBy={metadata.total_items && sortBy}
                         variant={compact && TableVariant.compact}
                     >
@@ -129,6 +138,7 @@ const TableView = ({
                         page={page}
                         onSetPage={onSetPage}
                         onPerPageSelect={onPerPageSelect}
+                        paginationOUIA={`bottom-${paginationOUIA}`}
                     />
                 </React.Fragment>)}
         </React.Fragment>
@@ -149,7 +159,10 @@ TableView.propTypes = {
     sortBy: PropTypes.object,
     filterConfig: PropTypes.object,
     store: PropTypes.object,
-    compact: PropTypes.bool
+    compact: PropTypes.bool,
+    remediationButtonOUIA: PropTypes.string,
+    tableOUIA: PropTypes.string,
+    paginationOUIA: PropTypes.string
 };
 
 export default TableView;

--- a/src/PresentationalComponents/TableView/__snapshots__/TableView.test.js.snap
+++ b/src/PresentationalComponents/TableView/__snapshots__/TableView.test.js.snap
@@ -49,6 +49,9 @@ exports[`TableView TableView 1`] = `
           },
         ],
         "onSelect": [Function],
+        "toggleProps": Object {
+          "data-ouia-component-type": "bulk-select-toggle-button",
+        },
       }
     }
     exportConfig={
@@ -82,6 +85,7 @@ exports[`TableView TableView 1`] = `
         "itemCount": undefined,
         "onPerPageSelect": [MockFunction],
         "onSetPage": [MockFunction],
+        "ouiaId": "top-undefined",
         "page": NaN,
         "perPage": undefined,
       }
@@ -140,6 +144,9 @@ exports[`TableView TableView 2`] = `
           },
         ],
         "onSelect": [Function],
+        "toggleProps": Object {
+          "data-ouia-component-type": "bulk-select-toggle-button",
+        },
       }
     }
     exportConfig={
@@ -173,6 +180,7 @@ exports[`TableView TableView 2`] = `
         "itemCount": undefined,
         "onPerPageSelect": [MockFunction],
         "onSetPage": [MockFunction],
+        "ouiaId": "top-undefined",
         "page": NaN,
         "perPage": undefined,
       }
@@ -236,6 +244,9 @@ exports[`TableView test table props TableView 1`] = `
           },
         ],
         "onSelect": [Function],
+        "toggleProps": Object {
+          "data-ouia-component-type": "bulk-select-toggle-button",
+        },
       }
     }
     exportConfig={
@@ -269,6 +280,7 @@ exports[`TableView test table props TableView 1`] = `
         "itemCount": 10,
         "onPerPageSelect": [MockFunction],
         "onSetPage": [MockFunction],
+        "ouiaId": "top-undefined",
         "page": NaN,
         "perPage": undefined,
       }
@@ -304,6 +316,7 @@ exports[`TableView test table props TableView 1`] = `
     onPerPageSelect={[MockFunction]}
     onSetPage={[MockFunction]}
     page={NaN}
+    paginationOUIA="bottom-undefined"
     totalItems={10}
   />
 </Fragment>

--- a/src/SmartComponents/Advisories/Advisories.js
+++ b/src/SmartComponents/Advisories/Advisories.js
@@ -92,7 +92,7 @@ const Advisories = ({ history }) => {
 
     return (
         <React.Fragment>
-            <Header title={'Advisories'} />
+            <Header title={'Advisories'} headerOUIA={'advisories'}/>
             <Main>
                 {status === STATUS_REJECTED ? <Error message={error.detail}/> :
                     <TableView
@@ -104,6 +104,9 @@ const Advisories = ({ history }) => {
                         onExport={onExport}
                         sortBy={sortBy}
                         apply={apply}
+                        remediationButtonOUIA={'toolbar-remediation-button'}
+                        tableOUIA={'advisories-table'}
+                        paginationOUIA={'advisories-pagination'}
                         store={{ rows, metadata, status, queryParams }}
                         filterConfig={{
                             items: [

--- a/src/SmartComponents/Advisories/__snapshots__/Advisories.test.js.snap
+++ b/src/SmartComponents/Advisories/__snapshots__/Advisories.test.js.snap
@@ -76,11 +76,15 @@ exports[`Advisories.js Should match the snapshots 1`] = `
           }
         >
           <Header
+            headerOUIA="advisories"
             title="Advisories"
           >
-            <PageHeader>
+            <PageHeader
+              data-ouia-component-type="advisories-page-header"
+            >
               <section
                 className="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
+                data-ouia-component-type="advisories-page-header"
                 widget-type="InsightsPageHeader"
               >
                 <PageHeaderTitle
@@ -211,6 +215,8 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                   onPerPageSelect={[Function]}
                   onSetPage={[Function]}
                   onSort={[Function]}
+                  paginationOUIA="advisories-pagination"
+                  remediationButtonOUIA="toolbar-remediation-button"
                   sortBy={Object {}}
                   store={
                     Object {
@@ -278,6 +284,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                       "status": undefined,
                     }
                   }
+                  tableOUIA="advisories-table"
                 >
                   <PrimaryToolbar
                     actionsConfig={
@@ -351,6 +358,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                         "itemCount": 0,
                         "onPerPageSelect": [Function],
                         "onSetPage": [Function],
+                        "ouiaId": "top-advisories-pagination",
                         "page": 1,
                         "perPage": 25,
                       }
@@ -558,7 +566,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                                     >
                                                       <div
                                                         className="pf-c-dropdown ins-c-conditional-filter__group"
-                                                        data-ouia-component-id={7}
+                                                        data-ouia-component-id={6}
                                                         data-ouia-component-type="PF4/Dropdown"
                                                         data-ouia-safe={true}
                                                       >
@@ -577,7 +585,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                                             Object {
                                                               "current": <div
                                                                 class="pf-c-dropdown ins-c-conditional-filter__group"
-                                                                data-ouia-component-id="7"
+                                                                data-ouia-component-id="6"
                                                                 data-ouia-component-type="PF4/Dropdown"
                                                                 data-ouia-safe="true"
                                                               >
@@ -652,7 +660,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                                               Object {
                                                                 "current": <div
                                                                   class="pf-c-dropdown ins-c-conditional-filter__group"
-                                                                  data-ouia-component-id="7"
+                                                                  data-ouia-component-id="6"
                                                                   data-ouia-component-type="PF4/Dropdown"
                                                                   data-ouia-safe="true"
                                                                 >
@@ -985,7 +993,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                         >
                                           <div
                                             className="pf-c-dropdown"
-                                            data-ouia-component-id={8}
+                                            data-ouia-component-id={7}
                                             data-ouia-component-type="PF4/Dropdown"
                                             data-ouia-safe={true}
                                           >
@@ -1002,7 +1010,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                                 Object {
                                                   "current": <div
                                                     class="pf-c-dropdown"
-                                                    data-ouia-component-id="8"
+                                                    data-ouia-component-id="7"
                                                     data-ouia-component-type="PF4/Dropdown"
                                                     data-ouia-safe="true"
                                                   >
@@ -1053,7 +1061,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                                   Object {
                                                     "current": <div
                                                       class="pf-c-dropdown"
-                                                      data-ouia-component-id="8"
+                                                      data-ouia-component-id="7"
                                                       data-ouia-component-type="PF4/Dropdown"
                                                       data-ouia-safe="true"
                                                     >
@@ -1169,7 +1177,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                       >
                                         <div
                                           className="pf-c-dropdown"
-                                          data-ouia-component-id={9}
+                                          data-ouia-component-id={8}
                                           data-ouia-component-type="PF4/Dropdown"
                                           data-ouia-safe={true}
                                         >
@@ -1186,7 +1194,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                               Object {
                                                 "current": <div
                                                   class="pf-c-dropdown"
-                                                  data-ouia-component-id="9"
+                                                  data-ouia-component-id="8"
                                                   data-ouia-component-type="PF4/Dropdown"
                                                   data-ouia-safe="true"
                                                 >
@@ -1236,7 +1244,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                                 Object {
                                                   "current": <div
                                                     class="pf-c-dropdown"
-                                                    data-ouia-component-id="9"
+                                                    data-ouia-component-id="8"
                                                     data-ouia-component-type="PF4/Dropdown"
                                                     data-ouia-safe="true"
                                                   >
@@ -1335,6 +1343,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                     onPerPageSelect={[Function]}
                                     onPreviousClick={[Function]}
                                     onSetPage={[Function]}
+                                    ouiaId="top-advisories-pagination"
                                     ouiaSafe={true}
                                     page={1}
                                     perPage={25}
@@ -1379,7 +1388,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                   >
                                     <div
                                       className="pf-c-pagination pf-m-compact"
-                                      data-ouia-component-id={10}
+                                      data-ouia-component-id="top-advisories-pagination"
                                       data-ouia-component-type="PF4/Pagination"
                                       data-ouia-safe={true}
                                       id="pagination-options-menu-1"
@@ -1515,7 +1524,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                         >
                                           <div
                                             className="pf-c-options-menu"
-                                            data-ouia-component-id={11}
+                                            data-ouia-component-id={9}
                                             data-ouia-component-type="PF4/PaginationOptionsMenu"
                                             data-ouia-safe={true}
                                           >
@@ -1539,7 +1548,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                                 Object {
                                                   "current": <div
                                                     class="pf-c-options-menu"
-                                                    data-ouia-component-id="11"
+                                                    data-ouia-component-id="9"
                                                     data-ouia-component-type="PF4/PaginationOptionsMenu"
                                                     data-ouia-safe="true"
                                                   >
@@ -1634,7 +1643,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                                     Object {
                                                       "current": <div
                                                         class="pf-c-options-menu"
-                                                        data-ouia-component-id="11"
+                                                        data-ouia-component-id="9"
                                                         data-ouia-component-type="PF4/PaginationOptionsMenu"
                                                         data-ouia-safe="true"
                                                       >
@@ -1707,7 +1716,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                                       Object {
                                                         "current": <div
                                                           class="pf-c-options-menu"
-                                                          data-ouia-component-id="11"
+                                                          data-ouia-component-id="9"
                                                           data-ouia-component-type="PF4/PaginationOptionsMenu"
                                                           data-ouia-safe="true"
                                                         >
@@ -1850,7 +1859,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                                 aria-label="Go to previous page"
                                                 className="pf-c-button pf-m-plain pf-m-disabled"
                                                 data-action="previous"
-                                                data-ouia-component-id={12}
+                                                data-ouia-component-id={10}
                                                 data-ouia-component-type="PF4/Button"
                                                 data-ouia-safe={true}
                                                 disabled={true}
@@ -1901,7 +1910,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                                 aria-label="Go to next page"
                                                 className="pf-c-button pf-m-plain pf-m-disabled"
                                                 data-action="next"
-                                                data-ouia-component-id={13}
+                                                data-ouia-component-id={11}
                                                 data-ouia-component-type="PF4/Button"
                                                 data-ouia-safe={true}
                                                 disabled={true}

--- a/src/SmartComponents/AdvisoryDetail/AdvisoryDetail.js
+++ b/src/SmartComponents/AdvisoryDetail/AdvisoryDetail.js
@@ -40,6 +40,7 @@ const AdvisoryDetail = ({ match }) => {
         <React.Fragment>
             <Header
                 title={advisoryName}
+                headerOUIA={'advisory-details'}
                 breadcrumbs={[
                     {
                         title: 'Patch',

--- a/src/SmartComponents/AdvisoryDetail/__snapshots__/AdvisoryDetail.test.js.snap
+++ b/src/SmartComponents/AdvisoryDetail/__snapshots__/AdvisoryDetail.test.js.snap
@@ -94,13 +94,18 @@ exports[`AdvisoryDetail.js Should match the snapshots 1`] = `
                 },
               ]
             }
+            headerOUIA="advisory-details"
           >
-            <PageHeader>
+            <PageHeader
+              data-ouia-component-type="advisory-details-page-header"
+            >
               <section
                 className="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
+                data-ouia-component-type="advisory-details-page-header"
                 widget-type="InsightsPageHeader"
               >
                 <HeaderBreadcrumbs
+                  headerOUIA="advisory-details"
                   items={
                     Array [
                       Object {
@@ -140,13 +145,19 @@ exports[`AdvisoryDetail.js Should match the snapshots 1`] = `
                             className="pf-c-breadcrumb__item"
                           >
                             <Link
+                              data-ouia-component-id="breadcrumb-to-Patch"
+                              data-ouia-component-type="advisory-details-breadcrumb"
                               to="/"
                             >
                               <LinkAnchor
+                                data-ouia-component-id="breadcrumb-to-Patch"
+                                data-ouia-component-type="advisory-details-breadcrumb"
                                 href="/"
                                 navigate={[Function]}
                               >
                                 <a
+                                  data-ouia-component-id="breadcrumb-to-Patch"
+                                  data-ouia-component-type="advisory-details-breadcrumb"
                                   href="/"
                                   onClick={[Function]}
                                 >
@@ -194,13 +205,19 @@ exports[`AdvisoryDetail.js Should match the snapshots 1`] = `
                               </AngleRightIcon>
                             </span>
                             <Link
+                              data-ouia-component-id="breadcrumb-to-Advisories"
+                              data-ouia-component-type="advisory-details-breadcrumb"
                               to="/"
                             >
                               <LinkAnchor
+                                data-ouia-component-id="breadcrumb-to-Advisories"
+                                data-ouia-component-type="advisory-details-breadcrumb"
                                 href="/"
                                 navigate={[Function]}
                               >
                                 <a
+                                  data-ouia-component-id="breadcrumb-to-Advisories"
+                                  data-ouia-component-type="advisory-details-breadcrumb"
                                   href="/"
                                   onClick={[Function]}
                                 >

--- a/src/SmartComponents/AdvisorySystems/AdvisorySystems.js
+++ b/src/SmartComponents/AdvisorySystems/AdvisorySystems.js
@@ -190,6 +190,9 @@ const AdvisorySystems = ({ advisoryName }) => {
                         onSelect: (value) => {
                             value ? onSelect('all') : onSelect('none');
                         },
+                        toggleProps: {
+                            'data-ouia-component-type': 'bulk-select-toggle-button'
+                        },
                         checked: selectedCount === metadata.total_items ? true : selectedCount === 0 ? false : null
                     }}
                 >
@@ -208,6 +211,7 @@ const AdvisorySystems = ({ advisoryName }) => {
                                         )
                                     )
                                 }
+                                ouiaId={'toolbar-remediation-button'}
                             >
                                 <AnsibeTowerIcon/>&nbsp;Remediate
                             </Button>

--- a/src/SmartComponents/PackageDetail/PackageDetail.js
+++ b/src/SmartComponents/PackageDetail/PackageDetail.js
@@ -40,6 +40,7 @@ const PackageDetail = ({ match }) => {
         <React.Fragment>
             <Header
                 title={packageName}
+                headerOUIA={'package-details'}
                 breadcrumbs={[
                     {
                         title: 'Patch',

--- a/src/SmartComponents/PackageSystems/PackageSystems.js
+++ b/src/SmartComponents/PackageSystems/PackageSystems.js
@@ -195,6 +195,9 @@ const PackageSystems = ({ packageName }) => {
                         onSelect: (value) => {
                             value ? onSelect('all') : onSelect('none');
                         },
+                        toggleProps: {
+                            'data-ouia-component-type': 'bulk-select-toggle-button'
+                        },
                         checked: selectedCount === metadata.total_items ? true : selectedCount === 0 ? false : null
                     }}
                 >
@@ -214,6 +217,7 @@ const PackageSystems = ({ packageName }) => {
                                         )
                                     )
                                 }
+                                ouiaId={'toolbar-remediation-button'}
                             >
                                 <AnsibeTowerIcon/>&nbsp;Remediate
                             </Button>

--- a/src/SmartComponents/Packages/Packages.js
+++ b/src/SmartComponents/Packages/Packages.js
@@ -71,7 +71,7 @@ const Packages = () => {
 
     return (
         <React.Fragment>
-            <Header title={'Package Updates'} />
+            <Header title={'Package Updates'} headerOUIA={'packages'}/>
             <Main>
                 {status === STATUS_REJECTED ? errorState :
                     <TableView
@@ -88,6 +88,9 @@ const Packages = () => {
                                 searchFilter(apply, queryParams.search, 'Search packages')
                             ]
                         }}
+                        remediationButtonOUIA={'toolbar-remediation-button'}
+                        tableOUIA={'package-details-table'}
+                        paginationOUIA={'package-details-pagination'}
                     />
                 }
             </Main>

--- a/src/SmartComponents/SystemAdvisories/SystemAdvisories.js
+++ b/src/SmartComponents/SystemAdvisories/SystemAdvisories.js
@@ -131,6 +131,9 @@ const SystemAdvisories = ({ history }) => {
                 systemId={entity.id}
                 apply={apply}
                 store={{ rows, metadata, status, queryParams }}
+                remediationButtonOUIA={'toolbar-remediation-button'}
+                tableOUIA={'system-advisories-table'}
+                paginationOUIA={'system-advisories-pagination'}
                 filterConfig={{
                     items: [
                         searchFilter(apply, queryParams.search),

--- a/src/SmartComponents/SystemAdvisories/__snapshots__/SystemAdvisories.test.js.snap
+++ b/src/SmartComponents/SystemAdvisories/__snapshots__/SystemAdvisories.test.js.snap
@@ -168,6 +168,8 @@ exports[`Advisories.js Should match the snapshots 1`] = `
               onSelect={[Function]}
               onSetPage={[Function]}
               onSort={[Function]}
+              paginationOUIA="system-advisories-pagination"
+              remediationButtonOUIA="toolbar-remediation-button"
               remediationProvider={[Function]}
               selectedRows={
                 Object {
@@ -234,6 +236,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                 }
               }
               systemId="test"
+              tableOUIA="system-advisories-table"
             >
               <PrimaryToolbar
                 actionsConfig={
@@ -244,6 +247,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                           className="remediationButtonPatch"
                           isDisabled={false}
                           onClick={[Function]}
+                          ouiaId="toolbar-remediation-button"
                         >
                           <AnsibeTowerIcon
                             color="#fff"
@@ -282,6 +286,9 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                       },
                     ],
                     "onSelect": [Function],
+                    "toggleProps": Object {
+                      "data-ouia-component-type": "bulk-select-toggle-button",
+                    },
                   }
                 }
                 exportConfig={
@@ -342,6 +349,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                     "itemCount": 10,
                     "onPerPageSelect": [Function],
                     "onSetPage": [Function],
+                    "ouiaId": "top-system-advisories-pagination",
                     "page": 1,
                     "perPage": 25,
                   }
@@ -405,6 +413,11 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                         ]
                                       }
                                       onSelect={[Function]}
+                                      toggleProps={
+                                        Object {
+                                          "data-ouia-component-type": "bulk-select-toggle-button",
+                                        }
+                                      }
                                     >
                                       <Dropdown
                                         className="ins-c-bulk-select"
@@ -441,6 +454,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                         onSelect={[Function]}
                                         toggle={
                                           <DropdownToggle
+                                            data-ouia-component-type="bulk-select-toggle-button"
                                             isDisabled={false}
                                             onToggle={[Function]}
                                             splitButtonItems={
@@ -504,6 +518,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                           position="left"
                                           toggle={
                                             <DropdownToggle
+                                              data-ouia-component-type="bulk-select-toggle-button"
                                               isDisabled={false}
                                               onToggle={[Function]}
                                               splitButtonItems={
@@ -528,12 +543,13 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                         >
                                           <div
                                             className="pf-c-dropdown ins-c-bulk-select"
-                                            data-ouia-component-id={18}
+                                            data-ouia-component-id={14}
                                             data-ouia-component-type="PF4/Dropdown"
                                             data-ouia-safe={true}
                                           >
                                             <DropdownToggle
                                               aria-haspopup={true}
+                                              data-ouia-component-type="bulk-select-toggle-button"
                                               getMenuRef={[Function]}
                                               id="pf-dropdown-toggle-id-5"
                                               isDisabled={false}
@@ -546,7 +562,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                                 Object {
                                                   "current": <div
                                                     class="pf-c-dropdown ins-c-bulk-select"
-                                                    data-ouia-component-id="18"
+                                                    data-ouia-component-id="14"
                                                     data-ouia-component-type="PF4/Dropdown"
                                                     data-ouia-safe="true"
                                                   >
@@ -576,6 +592,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                                         aria-haspopup="true"
                                                         aria-label="Select"
                                                         class="pf-c-dropdown__toggle-button"
+                                                        data-ouia-component-type="bulk-select-toggle-button"
                                                         id="pf-dropdown-toggle-id-5"
                                                         type="button"
                                                       >
@@ -659,6 +676,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                                   aria-label="Select"
                                                   bubbleEvent={false}
                                                   className=""
+                                                  data-ouia-component-type="bulk-select-toggle-button"
                                                   getMenuRef={[Function]}
                                                   id="pf-dropdown-toggle-id-5"
                                                   isActive={false}
@@ -673,7 +691,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                                     Object {
                                                       "current": <div
                                                         class="pf-c-dropdown ins-c-bulk-select"
-                                                        data-ouia-component-id="18"
+                                                        data-ouia-component-id="14"
                                                         data-ouia-component-type="PF4/Dropdown"
                                                         data-ouia-safe="true"
                                                       >
@@ -703,6 +721,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                                             aria-haspopup="true"
                                                             aria-label="Select"
                                                             class="pf-c-dropdown__toggle-button"
+                                                            data-ouia-component-type="bulk-select-toggle-button"
                                                             id="pf-dropdown-toggle-id-5"
                                                             type="button"
                                                           >
@@ -735,6 +754,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                                     aria-haspopup={true}
                                                     aria-label="Select"
                                                     className="pf-c-dropdown__toggle-button"
+                                                    data-ouia-component-type="bulk-select-toggle-button"
                                                     disabled={false}
                                                     id="pf-dropdown-toggle-id-5"
                                                     onClick={[Function]}
@@ -950,7 +970,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                                 >
                                                   <div
                                                     className="pf-c-dropdown ins-c-conditional-filter__group"
-                                                    data-ouia-component-id={19}
+                                                    data-ouia-component-id={15}
                                                     data-ouia-component-type="PF4/Dropdown"
                                                     data-ouia-safe={true}
                                                   >
@@ -969,7 +989,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                                         Object {
                                                           "current": <div
                                                             class="pf-c-dropdown ins-c-conditional-filter__group"
-                                                            data-ouia-component-id="19"
+                                                            data-ouia-component-id="15"
                                                             data-ouia-component-type="PF4/Dropdown"
                                                             data-ouia-safe="true"
                                                           >
@@ -1044,7 +1064,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                                           Object {
                                                             "current": <div
                                                               class="pf-c-dropdown ins-c-conditional-filter__group"
-                                                              data-ouia-component-id="19"
+                                                              data-ouia-component-id="15"
                                                               data-ouia-component-type="PF4/Dropdown"
                                                               data-ouia-safe="true"
                                                             >
@@ -1286,6 +1306,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                     className="remediationButtonPatch"
                                     isDisabled={false}
                                     onClick={[Function]}
+                                    ouiaId="toolbar-remediation-button"
                                   >
                                     <AnsibeTowerIcon
                                       color="#fff"
@@ -1317,12 +1338,13 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                   className="remediationButtonPatch"
                                   isDisabled={false}
                                   onClick={[Function]}
+                                  ouiaId="toolbar-remediation-button"
                                 >
                                   <button
                                     aria-disabled={false}
                                     aria-label={null}
                                     className="pf-c-button pf-m-primary remediationButtonPatch"
-                                    data-ouia-component-id={20}
+                                    data-ouia-component-id="toolbar-remediation-button"
                                     data-ouia-component-type="PF4/Button"
                                     data-ouia-safe={true}
                                     disabled={false}
@@ -1379,6 +1401,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                             className="remediationButtonPatch"
                                             isDisabled={false}
                                             onClick={[Function]}
+                                            ouiaId="toolbar-remediation-button"
                                           >
                                             <AnsibeTowerIcon
                                               color="#fff"
@@ -1417,6 +1440,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                               className="remediationButtonPatch"
                                               isDisabled={false}
                                               onClick={[Function]}
+                                              ouiaId="toolbar-remediation-button"
                                             >
                                               <AnsibeTowerIcon
                                                 color="#fff"
@@ -1444,7 +1468,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                   >
                                     <div
                                       className="pf-c-dropdown"
-                                      data-ouia-component-id={21}
+                                      data-ouia-component-id={16}
                                       data-ouia-component-type="PF4/Dropdown"
                                       data-ouia-safe={true}
                                     >
@@ -1461,7 +1485,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                           Object {
                                             "current": <div
                                               class="pf-c-dropdown"
-                                              data-ouia-component-id="21"
+                                              data-ouia-component-id="16"
                                               data-ouia-component-type="PF4/Dropdown"
                                               data-ouia-safe="true"
                                             >
@@ -1511,7 +1535,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                             Object {
                                               "current": <div
                                                 class="pf-c-dropdown"
-                                                data-ouia-component-id="21"
+                                                data-ouia-component-id="16"
                                                 data-ouia-component-type="PF4/Dropdown"
                                                 data-ouia-safe="true"
                                               >
@@ -1610,6 +1634,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                 onPerPageSelect={[Function]}
                                 onPreviousClick={[Function]}
                                 onSetPage={[Function]}
+                                ouiaId="top-system-advisories-pagination"
                                 ouiaSafe={true}
                                 page={1}
                                 perPage={25}
@@ -1654,7 +1679,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                               >
                                 <div
                                   className="pf-c-pagination pf-m-compact"
-                                  data-ouia-component-id={22}
+                                  data-ouia-component-id="top-system-advisories-pagination"
                                   data-ouia-component-type="PF4/Pagination"
                                   data-ouia-safe={true}
                                   id="pagination-options-menu-2"
@@ -1790,7 +1815,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                     >
                                       <div
                                         className="pf-c-options-menu"
-                                        data-ouia-component-id={23}
+                                        data-ouia-component-id={17}
                                         data-ouia-component-type="PF4/PaginationOptionsMenu"
                                         data-ouia-safe={true}
                                       >
@@ -1814,7 +1839,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                             Object {
                                               "current": <div
                                                 class="pf-c-options-menu"
-                                                data-ouia-component-id="23"
+                                                data-ouia-component-id="17"
                                                 data-ouia-component-type="PF4/PaginationOptionsMenu"
                                                 data-ouia-safe="true"
                                               >
@@ -1908,7 +1933,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                                 Object {
                                                   "current": <div
                                                     class="pf-c-options-menu"
-                                                    data-ouia-component-id="23"
+                                                    data-ouia-component-id="17"
                                                     data-ouia-component-type="PF4/PaginationOptionsMenu"
                                                     data-ouia-safe="true"
                                                   >
@@ -1980,7 +2005,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                                   Object {
                                                     "current": <div
                                                       class="pf-c-options-menu"
-                                                      data-ouia-component-id="23"
+                                                      data-ouia-component-id="17"
                                                       data-ouia-component-type="PF4/PaginationOptionsMenu"
                                                       data-ouia-safe="true"
                                                     >
@@ -2122,7 +2147,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                             aria-label="Go to previous page"
                                             className="pf-c-button pf-m-plain pf-m-disabled"
                                             data-action="previous"
-                                            data-ouia-component-id={24}
+                                            data-ouia-component-id={18}
                                             data-ouia-component-type="PF4/Button"
                                             data-ouia-safe={true}
                                             disabled={true}
@@ -2173,7 +2198,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                             aria-label="Go to next page"
                                             className="pf-c-button pf-m-plain pf-m-disabled"
                                             data-action="next"
-                                            data-ouia-component-id={25}
+                                            data-ouia-component-id={19}
                                             data-ouia-component-type="PF4/Button"
                                             data-ouia-safe={true}
                                             disabled={true}
@@ -2347,6 +2372,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                 onCollapse={[Function]}
                 onSelect={[Function]}
                 onSort={[Function]}
+                ouiaId="system-advisories-table"
                 ouiaSafe={true}
                 role="grid"
                 rowLabeledBy="simple-node"
@@ -2683,7 +2709,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                       },
                     ]
                   }
-                  data-ouia-component-id={26}
+                  data-ouia-component-id="system-advisories-table"
                   data-ouia-component-type="PF4/Table"
                   data-ouia-safe={true}
                   renderers={
@@ -2703,7 +2729,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                   <table
                     aria-label="Patch table view"
                     className="pf-c-table pf-m-grid-md"
-                    data-ouia-component-id={26}
+                    data-ouia-component-id="system-advisories-table"
                     data-ouia-component-type="PF4/Table"
                     data-ouia-safe={true}
                     role="grid"
@@ -5257,7 +5283,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                   >
                                     <tr
                                       className=""
-                                      data-ouia-component-id={27}
+                                      data-ouia-component-id={20}
                                       data-ouia-component-type="PF4/TableRow"
                                       data-ouia-safe={true}
                                       hidden={false}
@@ -5296,7 +5322,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                                 aria-label="Details"
                                                 aria-labelledby="simple-node0 expandable-toggle0"
                                                 className="pf-c-button pf-m-plain"
-                                                data-ouia-component-id={28}
+                                                data-ouia-component-id={21}
                                                 data-ouia-component-type="PF4/Button"
                                                 data-ouia-safe={true}
                                                 disabled={false}
@@ -5908,7 +5934,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                   >
                                     <tr
                                       className="pf-c-table__expandable-row"
-                                      data-ouia-component-id={29}
+                                      data-ouia-component-id={22}
                                       data-ouia-component-type="PF4/TableRow"
                                       data-ouia-safe={true}
                                       hidden={true}
@@ -6127,6 +6153,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                 onPerPageSelect={[Function]}
                 onSetPage={[Function]}
                 page={1}
+                paginationOUIA="bottom-system-advisories-pagination"
                 perPage={25}
                 totalItems={10}
               >
@@ -6161,6 +6188,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                           onPerPageSelect={[Function]}
                           onPreviousClick={[Function]}
                           onSetPage={[Function]}
+                          ouiaId="bottom-system-advisories-pagination"
                           ouiaSafe={true}
                           page={1}
                           perPage={25}
@@ -6205,7 +6233,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                         >
                           <div
                             className="pf-c-pagination pf-m-bottom"
-                            data-ouia-component-id={30}
+                            data-ouia-component-id="bottom-system-advisories-pagination"
                             data-ouia-component-type="PF4/Pagination"
                             data-ouia-safe={true}
                             id="pagination-options-menu-bottom-3"
@@ -6319,7 +6347,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                               >
                                 <div
                                   className="pf-c-options-menu pf-m-top"
-                                  data-ouia-component-id={31}
+                                  data-ouia-component-id={23}
                                   data-ouia-component-type="PF4/PaginationOptionsMenu"
                                   data-ouia-safe={true}
                                 >
@@ -6343,7 +6371,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                       Object {
                                         "current": <div
                                           class="pf-c-options-menu pf-m-top"
-                                          data-ouia-component-id="31"
+                                          data-ouia-component-id="23"
                                           data-ouia-component-type="PF4/PaginationOptionsMenu"
                                           data-ouia-safe="true"
                                         >
@@ -6437,7 +6465,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                           Object {
                                             "current": <div
                                               class="pf-c-options-menu pf-m-top"
-                                              data-ouia-component-id="31"
+                                              data-ouia-component-id="23"
                                               data-ouia-component-type="PF4/PaginationOptionsMenu"
                                               data-ouia-safe="true"
                                             >
@@ -6509,7 +6537,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                             Object {
                                               "current": <div
                                                 class="pf-c-options-menu pf-m-top"
-                                                data-ouia-component-id="31"
+                                                data-ouia-component-id="23"
                                                 data-ouia-component-type="PF4/PaginationOptionsMenu"
                                                 data-ouia-safe="true"
                                               >
@@ -6651,7 +6679,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                       aria-label="Go to first page"
                                       className="pf-c-button pf-m-plain pf-m-disabled"
                                       data-action="first"
-                                      data-ouia-component-id={32}
+                                      data-ouia-component-id={24}
                                       data-ouia-component-type="PF4/Button"
                                       data-ouia-safe={true}
                                       disabled={true}
@@ -6702,7 +6730,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                       aria-label="Go to previous page"
                                       className="pf-c-button pf-m-plain pf-m-disabled"
                                       data-action="previous"
-                                      data-ouia-component-id={33}
+                                      data-ouia-component-id={25}
                                       data-ouia-component-type="PF4/Button"
                                       data-ouia-safe={true}
                                       disabled={true}
@@ -6774,7 +6802,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                       aria-label="Go to next page"
                                       className="pf-c-button pf-m-plain pf-m-disabled"
                                       data-action="next"
-                                      data-ouia-component-id={34}
+                                      data-ouia-component-id={26}
                                       data-ouia-component-type="PF4/Button"
                                       data-ouia-safe={true}
                                       disabled={true}
@@ -6825,7 +6853,7 @@ exports[`Advisories.js Should match the snapshots 1`] = `
                                       aria-label="Go to last page"
                                       className="pf-c-button pf-m-plain pf-m-disabled"
                                       data-action="last"
-                                      data-ouia-component-id={35}
+                                      data-ouia-component-id={27}
                                       data-ouia-component-type="PF4/Button"
                                       data-ouia-safe={true}
                                       disabled={true}

--- a/src/SmartComponents/SystemDetail/InventoryPage.js
+++ b/src/SmartComponents/SystemDetail/InventoryPage.js
@@ -58,6 +58,7 @@ const InventoryDetail = () => {
         <React.Fragment>
             <Header
                 title=""
+                headerOUIA={'inventory-details'}
                 breadcrumbs={[
                     {
                         title: 'Patch',

--- a/src/SmartComponents/SystemDetail/SystemDetail.js
+++ b/src/SmartComponents/SystemDetail/SystemDetail.js
@@ -12,10 +12,18 @@ const SystemDetail = () => {
 
     return (
         <Tabs activeKey={activeTabKey} onSelect={onTabSelect} className={'patchTabSelect'}>
-            <Tab eventKey={0} title={<TabTitleText>Advisories</TabTitleText>}>
+            <Tab eventKey={0} title={<TabTitleText>Advisories</TabTitleText>}
+                data-ouia-component-type={`system-advisories-tab`}
+                data-ouia-component-id={`system-advisories-tab`}
+            >
                 <SystemAdvisories/>
             </Tab>
-            <Tab eventKey={1} title={<TabTitleText>Packages</TabTitleText>}>
+            <Tab
+                eventKey={1}
+                title={<TabTitleText>Packages</TabTitleText>}
+                data-ouia-component-type={`system-packages-tab`}
+                data-ouia-component-id={`system-packages-tab`}
+            >
                 <SystemPackages/>
             </Tab>
         </Tabs>

--- a/src/SmartComponents/SystemDetail/__snapshots__/InventoryPage.test.js.snap
+++ b/src/SmartComponents/SystemDetail/__snapshots__/InventoryPage.test.js.snap
@@ -56,14 +56,19 @@ exports[`InventoryPage.js Should match the snapshots 1`] = `
               },
             ]
           }
+          headerOUIA="inventory-details"
           title=""
         >
-          <PageHeader>
+          <PageHeader
+            data-ouia-component-type="inventory-details-page-header"
+          >
             <section
               className="pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light"
+              data-ouia-component-type="inventory-details-page-header"
               widget-type="InsightsPageHeader"
             >
               <HeaderBreadcrumbs
+                headerOUIA="inventory-details"
                 items={
                   Array [
                     Object {
@@ -103,13 +108,19 @@ exports[`InventoryPage.js Should match the snapshots 1`] = `
                           className="pf-c-breadcrumb__item"
                         >
                           <Link
+                            data-ouia-component-id="breadcrumb-to-Patch"
+                            data-ouia-component-type="inventory-details-breadcrumb"
                             to="/"
                           >
                             <LinkAnchor
+                              data-ouia-component-id="breadcrumb-to-Patch"
+                              data-ouia-component-type="inventory-details-breadcrumb"
                               href="/"
                               navigate={[Function]}
                             >
                               <a
+                                data-ouia-component-id="breadcrumb-to-Patch"
+                                data-ouia-component-type="inventory-details-breadcrumb"
                                 href="/"
                                 onClick={[Function]}
                               >
@@ -157,13 +168,19 @@ exports[`InventoryPage.js Should match the snapshots 1`] = `
                             </AngleRightIcon>
                           </span>
                           <Link
+                            data-ouia-component-id="breadcrumb-to-Systems"
+                            data-ouia-component-type="inventory-details-breadcrumb"
                             to="/systems/"
                           >
                             <LinkAnchor
+                              data-ouia-component-id="breadcrumb-to-Systems"
+                              data-ouia-component-type="inventory-details-breadcrumb"
                               href="/systems/"
                               navigate={[Function]}
                             >
                               <a
+                                data-ouia-component-id="breadcrumb-to-Systems"
+                                data-ouia-component-type="inventory-details-breadcrumb"
                                 href="/systems/"
                                 onClick={[Function]}
                               >

--- a/src/SmartComponents/SystemDetail/__snapshots__/SystemDetail.test.js.snap
+++ b/src/SmartComponents/SystemDetail/__snapshots__/SystemDetail.test.js.snap
@@ -17,6 +17,8 @@ exports[`SystemDetail.js Should match the snapshots 1`] = `
   unmountOnExit={false}
 >
   <Tab
+    data-ouia-component-id="system-advisories-tab"
+    data-ouia-component-type="system-advisories-tab"
     eventKey={0}
     title={
       <TabTitleText>
@@ -27,6 +29,8 @@ exports[`SystemDetail.js Should match the snapshots 1`] = `
     <withRouter(SystemAdvisories) />
   </Tab>
   <Tab
+    data-ouia-component-id="system-packages-tab"
+    data-ouia-component-type="system-packages-tab"
     eventKey={1}
     title={
       <TabTitleText>

--- a/src/SmartComponents/SystemPackages/SystemPackages.js
+++ b/src/SmartComponents/SystemPackages/SystemPackages.js
@@ -112,6 +112,9 @@ const SystemPackages = () => {
                     statusFilter(apply, queryParams.filter)
                 ]
             }}
+            remediationButtonOUIA={'toolbar-remediation-button'}
+            tableOUIA={'system-packages-table'}
+            paginationOUIA={'system-packages-pagination'}
         />);
 
     };

--- a/src/SmartComponents/SystemPackages/__snapshots__/SystemPackages.test.js.snap
+++ b/src/SmartComponents/SystemPackages/__snapshots__/SystemPackages.test.js.snap
@@ -121,6 +121,8 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
             onSelect={[Function]}
             onSetPage={[Function]}
             onSort={[Function]}
+            paginationOUIA="system-packages-pagination"
+            remediationButtonOUIA="toolbar-remediation-button"
             remediationProvider={[Function]}
             selectedRows={Object {}}
             sortBy={Object {}}
@@ -191,6 +193,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                 "status": undefined,
               }
             }
+            tableOUIA="system-packages-table"
           >
             <PrimaryToolbar
               actionsConfig={
@@ -201,6 +204,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                         className="remediationButtonPatch"
                         isDisabled={true}
                         onClick={[Function]}
+                        ouiaId="toolbar-remediation-button"
                       >
                         <AnsibeTowerIcon
                           color="#fff"
@@ -239,6 +243,9 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                     },
                   ],
                   "onSelect": [Function],
+                  "toggleProps": Object {
+                    "data-ouia-component-type": "bulk-select-toggle-button",
+                  },
                 }
               }
               exportConfig={
@@ -286,6 +293,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                   "itemCount": 0,
                   "onPerPageSelect": [Function],
                   "onSetPage": [Function],
+                  "ouiaId": "top-system-packages-pagination",
                   "page": 1,
                   "perPage": 25,
                 }
@@ -349,6 +357,11 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                       ]
                                     }
                                     onSelect={[Function]}
+                                    toggleProps={
+                                      Object {
+                                        "data-ouia-component-type": "bulk-select-toggle-button",
+                                      }
+                                    }
                                   >
                                     <Dropdown
                                       className="ins-c-bulk-select"
@@ -378,6 +391,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                       onSelect={[Function]}
                                       toggle={
                                         <DropdownToggle
+                                          data-ouia-component-type="bulk-select-toggle-button"
                                           isDisabled={false}
                                           onToggle={[Function]}
                                           splitButtonItems={
@@ -434,6 +448,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                         position="left"
                                         toggle={
                                           <DropdownToggle
+                                            data-ouia-component-type="bulk-select-toggle-button"
                                             isDisabled={false}
                                             onToggle={[Function]}
                                             splitButtonItems={
@@ -464,6 +479,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                         >
                                           <DropdownToggle
                                             aria-haspopup={true}
+                                            data-ouia-component-type="bulk-select-toggle-button"
                                             getMenuRef={[Function]}
                                             id="pf-dropdown-toggle-id-0"
                                             isDisabled={false}
@@ -501,6 +517,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                                       aria-haspopup="true"
                                                       aria-label="Select"
                                                       class="pf-c-dropdown__toggle-button"
+                                                      data-ouia-component-type="bulk-select-toggle-button"
                                                       id="pf-dropdown-toggle-id-0"
                                                       type="button"
                                                     >
@@ -577,6 +594,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                                 aria-label="Select"
                                                 bubbleEvent={false}
                                                 className=""
+                                                data-ouia-component-type="bulk-select-toggle-button"
                                                 getMenuRef={[Function]}
                                                 id="pf-dropdown-toggle-id-0"
                                                 isActive={false}
@@ -616,6 +634,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                                           aria-haspopup="true"
                                                           aria-label="Select"
                                                           class="pf-c-dropdown__toggle-button"
+                                                          data-ouia-component-type="bulk-select-toggle-button"
                                                           id="pf-dropdown-toggle-id-0"
                                                           type="button"
                                                         >
@@ -648,6 +667,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                                   aria-haspopup={true}
                                                   aria-label="Select"
                                                   className="pf-c-dropdown__toggle-button"
+                                                  data-ouia-component-type="bulk-select-toggle-button"
                                                   disabled={false}
                                                   id="pf-dropdown-toggle-id-0"
                                                   onClick={[Function]}
@@ -1172,6 +1192,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                   className="remediationButtonPatch"
                                   isDisabled={true}
                                   onClick={[Function]}
+                                  ouiaId="toolbar-remediation-button"
                                 >
                                   <AnsibeTowerIcon
                                     color="#fff"
@@ -1203,12 +1224,13 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                 className="remediationButtonPatch"
                                 isDisabled={true}
                                 onClick={[Function]}
+                                ouiaId="toolbar-remediation-button"
                               >
                                 <button
                                   aria-disabled={true}
                                   aria-label={null}
                                   className="pf-c-button pf-m-primary pf-m-disabled remediationButtonPatch"
-                                  data-ouia-component-id={2}
+                                  data-ouia-component-id="toolbar-remediation-button"
                                   data-ouia-component-type="PF4/Button"
                                   data-ouia-safe={true}
                                   disabled={true}
@@ -1266,6 +1288,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                           className="remediationButtonPatch"
                                           isDisabled={true}
                                           onClick={[Function]}
+                                          ouiaId="toolbar-remediation-button"
                                         >
                                           <AnsibeTowerIcon
                                             color="#fff"
@@ -1304,6 +1327,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                             className="remediationButtonPatch"
                                             isDisabled={true}
                                             onClick={[Function]}
+                                            ouiaId="toolbar-remediation-button"
                                           >
                                             <AnsibeTowerIcon
                                               color="#fff"
@@ -1331,7 +1355,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                 >
                                   <div
                                     className="pf-c-dropdown"
-                                    data-ouia-component-id={3}
+                                    data-ouia-component-id={2}
                                     data-ouia-component-type="PF4/Dropdown"
                                     data-ouia-safe={true}
                                   >
@@ -1348,7 +1372,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                         Object {
                                           "current": <div
                                             class="pf-c-dropdown"
-                                            data-ouia-component-id="3"
+                                            data-ouia-component-id="2"
                                             data-ouia-component-type="PF4/Dropdown"
                                             data-ouia-safe="true"
                                           >
@@ -1398,7 +1422,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                           Object {
                                             "current": <div
                                               class="pf-c-dropdown"
-                                              data-ouia-component-id="3"
+                                              data-ouia-component-id="2"
                                               data-ouia-component-type="PF4/Dropdown"
                                               data-ouia-safe="true"
                                             >
@@ -1497,6 +1521,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                               onPerPageSelect={[Function]}
                               onPreviousClick={[Function]}
                               onSetPage={[Function]}
+                              ouiaId="top-system-packages-pagination"
                               ouiaSafe={true}
                               page={1}
                               perPage={25}
@@ -1541,7 +1566,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                             >
                               <div
                                 className="pf-c-pagination pf-m-compact"
-                                data-ouia-component-id={4}
+                                data-ouia-component-id="top-system-packages-pagination"
                                 data-ouia-component-type="PF4/Pagination"
                                 data-ouia-safe={true}
                                 id="pagination-options-menu-0"
@@ -1677,7 +1702,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                   >
                                     <div
                                       className="pf-c-options-menu"
-                                      data-ouia-component-id={5}
+                                      data-ouia-component-id={3}
                                       data-ouia-component-type="PF4/PaginationOptionsMenu"
                                       data-ouia-safe={true}
                                     >
@@ -1701,7 +1726,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                           Object {
                                             "current": <div
                                               class="pf-c-options-menu"
-                                              data-ouia-component-id="5"
+                                              data-ouia-component-id="3"
                                               data-ouia-component-type="PF4/PaginationOptionsMenu"
                                               data-ouia-safe="true"
                                             >
@@ -1796,7 +1821,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                               Object {
                                                 "current": <div
                                                   class="pf-c-options-menu"
-                                                  data-ouia-component-id="5"
+                                                  data-ouia-component-id="3"
                                                   data-ouia-component-type="PF4/PaginationOptionsMenu"
                                                   data-ouia-safe="true"
                                                 >
@@ -1869,7 +1894,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                                 Object {
                                                   "current": <div
                                                     class="pf-c-options-menu"
-                                                    data-ouia-component-id="5"
+                                                    data-ouia-component-id="3"
                                                     data-ouia-component-type="PF4/PaginationOptionsMenu"
                                                     data-ouia-safe="true"
                                                   >
@@ -2012,7 +2037,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                           aria-label="Go to previous page"
                                           className="pf-c-button pf-m-plain pf-m-disabled"
                                           data-action="previous"
-                                          data-ouia-component-id={6}
+                                          data-ouia-component-id={4}
                                           data-ouia-component-type="PF4/Button"
                                           data-ouia-safe={true}
                                           disabled={true}
@@ -2063,7 +2088,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                           aria-label="Go to next page"
                                           className="pf-c-button pf-m-plain pf-m-disabled"
                                           data-action="next"
-                                          data-ouia-component-id={7}
+                                          data-ouia-component-id={5}
                                           data-ouia-component-type="PF4/Button"
                                           data-ouia-safe={true}
                                           disabled={true}

--- a/src/SmartComponents/Systems/Systems.js
+++ b/src/SmartComponents/Systems/Systems.js
@@ -161,7 +161,7 @@ const Systems = () => {
     return (
         <React.Fragment>
 
-            <Header title={'Systems'} />
+            <Header title={'Systems'} headerOUIA={'systems'}/>
             <RemediationModalCmp />
             <Main>
                 {status === STATUS_REJECTED ? <Error message={error.detail}/> :


### PR DESCRIPTION
Partial work for: [SPM-580](https://issues.redhat.com/browse/SPM-580)

What components have OUIA enabled:
1.  Tables not including Inventory. e.g `data-ouia-component-id="advisories-table"`
2.  actionsConfig of PrimaryToolbar. e.g remediation button `data-ouia-component-id="toolbar-remediation-button"`  
3. bulkSelect toggle button of PrimaryToolbar.  `data-ouia-component-type="bulk-select-toggle-button"`
4. Header of all pages. e.g `data-ouia-component-type="advisory-details-page-header"`
5. Header breadcrumbs. e.g `data-ouia-component-type="advisory-details-breadcrumb" ` `data-ouia-component-id="breadcrumb-to-Advisories"` 
6. Header tabs. e.g `data-ouia-component-type="advisory-details-breadcrumb" ` `data-ouia-component-id="breadcrumb-to-Advisories"`

What is missing : 
1. Primary toolbar bulk select items.
2. Primary toolbar active filter config chips.
3. Primary toolbar filter config dropdown items.
4. OUIA for Inventory table
5. OUIA for pagination button 
