### PR TITLE
fix(InventoryEntitiesReducer): remove extra store utilization

### DIFF
--- a/src/store/Reducers/InventoryEntitiesReducer.js
+++ b/src/store/Reducers/InventoryEntitiesReducer.js
@@ -46,13 +46,13 @@ function modifyPackageSystems(columns, hosts, state) {
     return state;
 }
 
-export const inventoryEntitiesReducer = (columns, currentPage) => (state = init, action) => {
-    const store = action.store && action.store.getState();
+export const inventoryEntitiesReducer = (columns, currentPage) => (state = init, { type, store }) => {
 
     //display patch 'last_upload' instead of Inventory 'updated' column
-    const PatchStore  = store && (currentPage === 'SYSTEMS_PAGE' ? store.SystemsListStore : store.AdvisorySystemsStore);
+    const PatchStore  = store && (currentPage === 'SYSTEMS_PAGE'
+        ? store.SystemsListStore : store.AdvisorySystemsStore);
 
-    switch (action.type) {
+    switch (type) {
         case 'LOAD_ENTITIES_FULFILLED':
             return modifyInventory(columns, PatchStore.rows, state);
 

--- a/src/store/Reducers/InventoryEntitiesReducer.test.js
+++ b/src/store/Reducers/InventoryEntitiesReducer.test.js
@@ -2,7 +2,7 @@ import { inventoryEntitiesReducer, init } from './InventoryEntitiesReducer';
 import { sortable } from '@patternfly/react-table/dist/js';
 
 /* eslint-disable */
-const store = { getState: () => ({ SystemsListStore: { rows: [] } }) };
+const store = { SystemsListStore: { rows: [] } };
 const testColumns = ['col1', 'col2'];
 describe('InventoryEntitiesReducer tests', () => {
     it.each`

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -17,7 +17,7 @@ let registry;
 const persistenceMiddleware = store => next => action => {
     const storeContent = store.getState();
     if (action.type === 'LOAD_ENTITIES_FULFILLED') {
-        action = { ...action, store };
+        action = { ...action, store: storeContent };
     }
 
     next(action);


### PR DESCRIPTION
fixes: 'You may not call store.getState() while the reducer is executing. The reducer has already received the state as an argument. Pass it down from the top reducer instead of reading it from the store.' issue related to fetching an already existing store inside InventoryEntitiesReducer.  The issue occurred after updating frontend-components-utilities to 2.2.9.