### PR TITLE
chore(dependabot): extend the update checking period

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -2,9 +2,10 @@ version: 1
 update_configs:
   - package_manager: "javascript"
     directory: "/"
-    update_schedule: "live"
+    update_schedule: "weekly"
     default_reviewers:
-      - "karelhala"
+      - "jiridostal"
+      - "mkholjuraev"
     allowed_updates:
       - match:
           dependency_name: "@redhat-cloud-services/frontend*"


### PR DESCRIPTION
I would suggest extending the update checking period from _live_ to _weekly_ so that we do not have every version updates which ends up with a lot of PRs opened. 