### PR TITLE
feat(Packages): change remediation identifier to patch-package

### DIFF
--- a/src/SmartComponents/AdvisorySystems/AdvisorySystems.js
+++ b/src/SmartComponents/AdvisorySystems/AdvisorySystems.js
@@ -12,7 +12,7 @@ import { getStore, register } from '../../store';
 import { changeAdvisorySystemsParams, clearAdvisorySystemsStore, fetchAdvisorySystemsAction } from '../../store/Actions/Actions';
 import { inventoryEntitiesReducer } from '../../store/Reducers/InventoryEntitiesReducer';
 import { fetchAdvisorySystems } from '../../Utilities/api';
-import { STATUS_REJECTED, STATUS_RESOLVED } from '../../Utilities/constants';
+import { STATUS_REJECTED, STATUS_RESOLVED, remediationIdentifiers } from '../../Utilities/constants';
 import { createSystemsRows } from '../../Utilities/DataMappers';
 import { arrayFromObj, buildFilterChips, createSortBy, remediationProvider } from '../../Utilities/Helpers';
 import {
@@ -178,7 +178,8 @@ const AdvisorySystems = ({ advisoryName }) => {
                                     showRemediationModal(
                                         remediationProvider(
                                             advisoryName,
-                                            Object.keys(selectedRows)
+                                            Object.keys(selectedRows),
+                                            remediationIdentifiers.advisory
                                         )
                                     )
                                 }

--- a/src/SmartComponents/PackageSystems/PackageSystems.js
+++ b/src/SmartComponents/PackageSystems/PackageSystems.js
@@ -13,7 +13,7 @@ import { getStore, register } from '../../store';
 import { changePackageSystemsParams, clearPackageSystemsStore, fetchPackageSystemsAction } from '../../store/Actions/Actions';
 import { packagesSystemsInventoryReducer } from '../../store/Reducers/InventoryEntitiesReducer';
 import { fetchPackageSystems } from '../../Utilities/api';
-import { STATUS_REJECTED, STATUS_RESOLVED } from '../../Utilities/constants';
+import { STATUS_REJECTED, STATUS_RESOLVED, remediationIdentifiers } from '../../Utilities/constants';
 import { createPackageSystemsRows } from '../../Utilities/DataMappers';
 import { arrayFromObj, buildFilterChips, createSortBy, remediationProvider } from '../../Utilities/Helpers';
 import {
@@ -184,7 +184,8 @@ const PackageSystems = ({ packageName }) => {
                                     showRemediationModal(
                                         remediationProvider(
                                             packageName,
-                                            Object.keys(selectedRows)
+                                            Object.keys(selectedRows),
+                                            remediationIdentifiers.package
                                         )
                                     )
                                 }

--- a/src/SmartComponents/Packages/Packages.js
+++ b/src/SmartComponents/Packages/Packages.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 import { Main } from '@redhat-cloud-services/frontend-components';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/cjs/actions';
 import React from 'react';
@@ -13,8 +12,8 @@ import { packagesColumns } from '../../PresentationalComponents/TableView/TableV
 import { changePackagesListParams, fetchPackagesAction } from '../../store/Actions/Actions';
 import { STATUS_REJECTED } from '../../Utilities/constants';
 import { createPackagesRows } from '../../Utilities/DataMappers';
-import { buildFilterChips, createSortBy } from '../../Utilities/Helpers';
-import { usePerPageSelect, useRemoveFilter, useSetPage, useSortColumn, setPageTitle } from '../../Utilities/Hooks';
+import { createSortBy } from '../../Utilities/Helpers';
+import { usePerPageSelect, useSetPage, useSortColumn, setPageTitle } from '../../Utilities/Hooks';
 import { intl } from '../../Utilities/IntlProvider';
 import messages from '../../Messages';
 import { downloadFile } from '@redhat-cloud-services/frontend-components-utilities/files/cjs/helpers';
@@ -42,8 +41,6 @@ const Packages = () => {
         ({ PackagesListStore }) => PackagesListStore.queryParams
     );
 
-    const { filter, search } = queryParams;
-
     React.useEffect(() => {
         dispatch(fetchPackagesAction(queryParams));
     }, [queryParams]);
@@ -51,13 +48,6 @@ const Packages = () => {
     function apply(params) {
         dispatch(changePackagesListParams(params));
     }
-
-    const removeFilter = useRemoveFilter(filter, apply);
-
-    const activeFiltersConfig = {
-        filters: buildFilterChips(filter, search),
-        onDelete: removeFilter
-    };
 
     const onExport = (_, format) => {
         const date = new Date().toISOString().replace(/[T:]/g, '-').split('.')[0] + '-utc';

--- a/src/SmartComponents/SystemAdvisories/SystemAdvisories.js
+++ b/src/SmartComponents/SystemAdvisories/SystemAdvisories.js
@@ -12,7 +12,7 @@ import { systemAdvisoriesColumns } from '../../PresentationalComponents/TableVie
 import { changeSystemAdvisoryListParams, clearSystemAdvisoriesStore, expandSystemAdvisoryRow,
     fetchApplicableSystemAdvisories, selectSystemAdvisoryRow } from '../../store/Actions/Actions';
 import { fetchApplicableSystemAdvisoriesApi } from '../../Utilities/api';
-import { STATUS_REJECTED } from '../../Utilities/constants';
+import { STATUS_REJECTED, remediationIdentifiers } from '../../Utilities/constants';
 import { createSystemAdvisoriesRows } from '../../Utilities/DataMappers';
 import { arrayFromObj, createSortBy, decodeQueryparams, encodeURLParams,
     getRowIdByIndexExpandable, remediationProvider } from '../../Utilities/Helpers';
@@ -120,7 +120,11 @@ const SystemAdvisories = ({ history, handleNoSystemData }) => {
                 onSort={onSort}
                 sortBy={sortBy}
                 remediationProvider={() =>
-                    remediationProvider(arrayFromObj(selectedRows), entity.id)
+                    remediationProvider(
+                        arrayFromObj(selectedRows),
+                        entity.id,
+                        remediationIdentifiers.advisory
+                    )
                 }
                 selectedRows={selectedRows}
                 systemId={entity.id}

--- a/src/SmartComponents/SystemAdvisories/SystemAdvisories.test.js
+++ b/src/SmartComponents/SystemAdvisories/SystemAdvisories.test.js
@@ -7,7 +7,7 @@ import { fetchApplicableSystemAdvisoriesApi } from '../../Utilities/api';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { remediationProvider } from '../../Utilities/Helpers';
-
+import { remediationIdentifiers } from '../../Utilities/constants';
 /* eslint-disable */
 initMocks()
 
@@ -101,7 +101,7 @@ describe('SystemAdvisories.js', () => {
     it('Should provide correct remediation data', () => {
         const remediation = wrapper.find('TableView').props().remediationProvider;
         remediation();
-        expect(remediationProvider).toHaveBeenCalledWith([true], 'test');
+        expect(remediationProvider).toHaveBeenCalledWith([true], 'test', remediationIdentifiers.advisory);
     });
 
     describe('test entity selecting', () => {

--- a/src/SmartComponents/SystemPackages/SystemPackages.js
+++ b/src/SmartComponents/SystemPackages/SystemPackages.js
@@ -14,7 +14,7 @@ import {
     fetchApplicableSystemPackages, selectSystemPackagesRow
 } from '../../store/Actions/Actions';
 import { fetchApplicablePackagesApi } from '../../Utilities/api';
-import { STATUS_REJECTED, STATUS_RESOLVED } from '../../Utilities/constants';
+import { STATUS_REJECTED, STATUS_RESOLVED, remediationIdentifiers } from '../../Utilities/constants';
 import { createSystemPackagesRows } from '../../Utilities/DataMappers';
 import { arrayFromObj, createSortBy, remediationProvider } from '../../Utilities/Helpers';
 import { useOnSelect, usePerPageSelect, useSetPage, useSortColumn } from '../../Utilities/Hooks';
@@ -110,7 +110,11 @@ const SystemPackages = ({ handleNoSystemData }) => {
                 onSetPage={onSetPage}
                 onPerPageSelect={onPerPageSelect}
                 remediationProvider={() =>
-                    remediationProvider(arrayFromObj(selectedRows), entity.id)
+                    remediationProvider(
+                        arrayFromObj(selectedRows),
+                        entity.id,
+                        remediationIdentifiers.package
+                    )
                 }
                 apply={apply}
                 filterConfig={{

--- a/src/SmartComponents/SystemPackages/SystemPackages.test.js
+++ b/src/SmartComponents/SystemPackages/SystemPackages.test.js
@@ -4,7 +4,7 @@ import { Provider } from 'react-redux';
 import { systemPackages } from '../../Utilities/RawDataForTesting';
 import configureStore from 'redux-mock-store';
 import { initMocks } from '../../Utilities/unitTestingUtilities.js';
-import { storeListDefaults } from '../../Utilities/constants';
+import { storeListDefaults, remediationIdentifiers } from '../../Utilities/constants';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { fetchApplicablePackagesApi } from '../../Utilities/api';
@@ -116,7 +116,7 @@ describe('SystemPackages.js', () => {
     it('Should provide correct remediation data', () => {
         const remediation = wrapper.find('TableView').props().remediationProvider;
         remediation();
-        expect(remediationProvider).toHaveBeenCalledWith([], 'entity');
+        expect(remediationProvider).toHaveBeenCalledWith([], 'entity', remediationIdentifiers.package);
     });
 
     it('Should display SystemUpToDate when status is resolved, but there is no items', () => {

--- a/src/SmartComponents/Systems/SystemListAssets.test.js
+++ b/src/SmartComponents/Systems/SystemListAssets.test.js
@@ -1,6 +1,7 @@
 import { systemsListColumns, packageSystemsColumns, systemsRowActions } from './SystemsListAssets';
 import { createAdvisoriesIcons, createUpgradableColumn, remediationProvider } from '../../Utilities/Helpers';
 import { fetchApplicableSystemAdvisoriesApi } from '../../Utilities/api';
+import { remediationIdentifiers } from '../../Utilities/constants';
 /* eslint-disable */
 jest.mock('../../Utilities/Helpers', () => ({
     ...jest.requireActual('../../Utilities/Helpers'),
@@ -40,6 +41,7 @@ describe('SystemListAssets.js', () => {
             expect(remediationProvider).toHaveBeenCalledWith(
                 ['testDataID'],
                 'testId',
+                remediationIdentifiers.advisory
             )
         });
     });

--- a/src/SmartComponents/Systems/SystemsListAssets.js
+++ b/src/SmartComponents/Systems/SystemsListAssets.js
@@ -1,5 +1,6 @@
 import { sortable } from '@patternfly/react-table/dist/js';
 import { fetchApplicableSystemAdvisoriesApi } from '../../Utilities/api';
+import { remediationIdentifiers } from '../../Utilities/constants';
 import { createAdvisoriesIcons, createUpgradableColumn, remediationProvider } from '../../Utilities/Helpers';
 import './SystemsListAssets.scss';
 
@@ -87,7 +88,8 @@ export const systemsRowActions = showRemediationModal => {
                     showRemediationModal(
                         remediationProvider(
                             res.data.map(item => item.id),
-                            rowData.id
+                            rowData.id,
+                            remediationIdentifiers.advisory
                         )
                     )
                 );

--- a/src/Utilities/Helpers.js
+++ b/src/Utilities/Helpers.js
@@ -141,13 +141,13 @@ export function handlePatchLink(type, name, body) {
 export const arrayFromObj = items =>
     Object.values(items).filter(value => value);
 
-export const remediationProvider = (issues, systems) => {
+export const remediationProvider = (issues, systems, remediationIdentifier) => {
     issues = [].concat(issues);
     systems = [].concat(systems);
     return issues.length && systems.length
         ? {
             issues: issues.map(item => ({
-                id: `patch-advisory:${item}`,
+                id: `${remediationIdentifier}:${item}`,
                 description: item
             })),
             systems

--- a/src/Utilities/Helpers.test.js
+++ b/src/Utilities/Helpers.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 import { SortByDirection } from '@patternfly/react-table/dist/js';
 import toJson from 'enzyme-to-json';
-import { publicDateOptions } from '../Utilities/constants';
+import { publicDateOptions, remediationIdentifiers } from '../Utilities/constants';
 import { addOrRemoveItemFromSet, arrayFromObj, buildFilterChips, changeListParams, convertLimitOffset, createAdvisoriesIcons, createSortBy, decodeQueryparams, encodeApiParams, encodeParams, encodeURLParams, getFilterValue, getLimitFromPageSize, getNewSelectedItems, getOffsetFromPageLimit, getRowIdByIndexExpandable, getSeverityById, handlePatchLink, remediationProvider } from './Helpers';
 
 const TestHook = ({ callback }) => {
@@ -207,12 +207,12 @@ describe('Helpers tests', () => {
     });
 
     it.each`
-    issues         | systems            | result
-    ${["issue-1"]} | ${["system-1"]}    | ${{issues: [{id: "patch-advisory:issue-1", description: "issue-1"}],systems: ["system-1"]}}
-    ${"issue-1"}   | ${"system-1"}      | ${{issues: [{id: "patch-advisory:issue-1", description: "issue-1"}],systems: ["system-1"]}}
-    ${[]}          | ${["system-1"]}    | ${false}
-    `('remediationProvider: Should create correct remediation object for $issues $systems', ({issues, systems, result}) => {
-        expect(remediationProvider(issues,systems)).toEqual(result);
+    issues         | systems            |  identifier                        | result
+    ${["issue-1"]} | ${["system-1"]}    | ${remediationIdentifiers.advisory} | ${{issues: [{id: "patch-advisory:issue-1", description: "issue-1"}],systems: ["system-1"]}}
+    ${"issue-1"}   | ${"system-1"}      | ${remediationIdentifiers.package}  | ${{issues: [{id: "patch-package:issue-1", description: "issue-1"}],systems: ["system-1"]}}
+    ${[]}          | ${["system-1"]}    | ${remediationIdentifiers.package}  | ${false}
+    `('remediationProvider: Should create correct remediation object for $issues $systems', ({issues, systems, identifier, result}) => {
+        expect(remediationProvider(issues,systems, identifier)).toEqual(result);
     });
 
     it.each`

--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -180,3 +180,8 @@ export const ReadOnlyNotification = {
     title: 'title',
     detail: 'message'
 };
+
+export const remediationIdentifiers = {
+    package: 'patch-package',
+    advisory: 'patch-advisory'
+};


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/SPM-737

- I think we have only 2 usages of remediation (remediation advisories, and remediation packages). Thus I did want to touch on existing, already working code. Instead created a special case for remediating packages.
- some unused code is removed from Packages component