### PR TITLE
fix(OSLock): change rhsm_version object key name to rhsm

### DIFF
--- a/src/Utilities/DataMappers.js
+++ b/src/Utilities/DataMappers.js
@@ -133,7 +133,7 @@ export const createSystemsRows = (rows, selectedRows = {}) => {
                 operating_system: {
                     osName: attributes.os_name && `${attributes.os_name} ${attributes.os_major}.${attributes.os_minor}`
                         || 'No data',
-                    rhsmVersion: attributes.rhsm_version
+                    rhsm: attributes.rhsm
                 },
                 selected: selectedRows[id] !== undefined
             };

--- a/src/Utilities/Helpers.js
+++ b/src/Utilities/Helpers.js
@@ -347,10 +347,10 @@ export function sortCves(cves, index, direction) {
 
 }
 
-export const createOSColumn = ({ osName, rhsmVersion }) => rhsmVersion === '' &&  osName || (
+export const createOSColumn = ({ osName, rhsm }) => rhsm === '' &&  osName || (
     <Tooltip
         content={
-            intl.formatMessage(messages.textLockVersionTooltip, { lockedVersion: rhsmVersion })
+            intl.formatMessage(messages.textLockVersionTooltip, { lockedVersion: rhsm })
         }
     >
         <Flex flex={{ default: 'inlineFlex' }}>


### PR DESCRIPTION
Patch engine has changed API response object key name from rhsm_version to rhsm. We also need to make some changes