### PR TITLE
fix(Systems): SPM-847 remove extra mounted remediation modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,3 @@
-## [1.17.2](https://github.com/RedHatInsights/patchman-ui/compare/v1.17.1...v1.17.2) (2021-04-13)
-
-
-### Bug Fixes
-
-* **Advisories:** SPM-844 wqremove unwanted checkbox ([8ed9317](https://github.com/RedHatInsights/patchman-ui/commit/8ed9317a0b95a5a3282e7fef25f31be56137ccfe))
-
 ## [1.17.1](https://github.com/RedHatInsights/patchman-ui/compare/v1.17.0...v1.17.1) (2021-04-13)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@redhat-cloud-services/frontend-components-inventory-patchman",
-  "version": "1.17.2",
+  "version": "1.17.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redhat-cloud-services/frontend-components-inventory-patchman",
-  "version": "1.17.2",
+  "version": "1.17.1",
   "browser": "dist/index.js",
   "private": false,
   "dependencies": {

--- a/src/SmartComponents/Remediation/RemediationModal.js
+++ b/src/SmartComponents/Remediation/RemediationModal.js
@@ -46,9 +46,12 @@ const RemediationModal = ({ data }) => {
     };
 
     React.useEffect(() => {
-        remediations &&
+        //temporary fix: this code decides if there is already mounted remediation modal
+        const remediationModal = document.getElementsByClassName('ins-c-remediation-modal');
+        if (remediations && remediationModal.length === 0) {
             remediations
             .openWizard({ ...data, onRemediationCreated: handleRemediationSuccess });
+        }
     }, [remediations]);
 
     return (


### PR DESCRIPTION
It looks like the useEffect with empty dependencies is being triggered twice which contradicts its design. I was not able to find the cause of it. I suggest using this temporary fix for now. We can dig it more after the summit. 

What I tried so far:
1. most likely it is triggered due to parent unmount remount events. I have tried tracing which parent, but I could not trace.
2. create a ref to remediation modal and try triggering the effect if the modal already exists
2. create a state [mounted, setMounted] = useState(false);
