### PR TITLE
Integrate handle refresh into getEntities.

### DIFF
--- a/src/SmartComponents/AdvisorySystems/AdvisorySystems.js
+++ b/src/SmartComponents/AdvisorySystems/AdvisorySystems.js
@@ -13,9 +13,16 @@ import { inventoryEntitiesReducer } from '../../store/Reducers/InventoryEntities
 import { fetchAdvisorySystems } from '../../Utilities/api';
 import { STATUS_REJECTED, STATUS_RESOLVED, remediationIdentifiers } from '../../Utilities/constants';
 import { createSystemsRows } from '../../Utilities/DataMappers';
-import { arrayFromObj, buildFilterChips, createSortBy, remediationProvider, filterSelectedRowIDs } from '../../Utilities/Helpers';
 import {
-    useDeepCompareEffect, useHandleRefresh, useOnSelect, usePagePerPage, useRemoveFilter,
+    arrayFromObj,
+    buildFilterChips,
+    createSortBy,
+    remediationProvider,
+    filterSelectedRowIDs,
+    handleRefresh
+} from '../../Utilities/Helpers';
+import {
+    useDeepCompareEffect, useOnSelect, usePagePerPage, useRemoveFilter,
     useSortColumn, useBulkSelectConfig
 } from '../../Utilities/Hooks';
 import { intl } from '../../Utilities/IntlProvider';
@@ -54,7 +61,6 @@ const AdvisorySystems = ({ advisoryName }) => {
         ({ entities }) => entities && entities.columns
     );
 
-    const handleRefresh = useHandleRefresh(metadata, apply);
     const { filter, search } = queryParams;
 
     React.useEffect(() => {
@@ -124,10 +130,13 @@ const AdvisorySystems = ({ advisoryName }) => {
             {status === STATUS_REJECTED ? <Unavailable/> : (
                 <InventoryTable
                     disableDefaultColumns
-                    getEntities={() => Promise.resolve({
-                        results: rawAdvisorySystems.map((system) => ({ ...system.attributes, id: system.id })),
-                        total: metadata.total_items
-                    })}
+                    getEntities={(_ids, pagination) => {
+                        handleRefresh(pagination, metadata, apply);
+                        return Promise.resolve({
+                            results: rawAdvisorySystems.map((system) => ({ ...system.attributes, id: system.id })),
+                            total: metadata.total_items
+                        });
+                    }}
                     onLoad={({ mergeWithEntities }) => {
                         const store = getStore();
                         register({
@@ -140,7 +149,6 @@ const AdvisorySystems = ({ advisoryName }) => {
                     page={page}
                     total={metadata.total_items}
                     perPage={perPage}
-                    onRefresh={handleRefresh}
                     isLoaded={status === STATUS_RESOLVED}
                     actions={systemsRowActions(showRemediationModal)}
                     tableProps = {{ canSelectAll: false,

--- a/src/Utilities/Helpers.js
+++ b/src/Utilities/Helpers.js
@@ -399,3 +399,13 @@ export const createOSColumn = ({ osName, rhsm }) => (rhsm === '' || rhsm ===  un
 );
 
 export const filterSelectedRowIDs = (selectedRows) =>  Object.keys(selectedRows).filter(row => selectedRows[row]);
+
+export const handleRefresh = ({ page, per_page: perPage }, metadata, callback) => {
+    const offset = getOffsetFromPageLimit(page, perPage);
+    const limit = getLimitFromPageSize(perPage);
+    (metadata.offset !== offset || metadata.limit !== limit) &&
+        callback({
+            ...(metadata.offset !== offset && { offset }),
+            ...(metadata.limit !== limit && { limit })
+        });
+};

--- a/src/Utilities/Hooks.js
+++ b/src/Utilities/Hooks.js
@@ -2,7 +2,7 @@ import { SortByDirection } from '@patternfly/react-table/dist/js';
 import isDeepEqualReact from 'fast-deep-equal/react';
 import React from 'react';
 import { compoundSortValues } from './constants';
-import { convertLimitOffset, getLimitFromPageSize, getOffsetFromPageLimit } from './Helpers';
+import { convertLimitOffset, getLimitFromPageSize, getOffsetFromPageLimit, handleRefresh } from './Helpers';
 import { intl } from './IntlProvider';
 import messages from '../Messages';
 
@@ -14,16 +14,8 @@ export const useSetPage = (limit, callback) => {
 };
 
 export const useHandleRefresh = (metadata, callback) => {
-    const handleRefresh = React.useCallback(({ page, per_page: perPage }) => {
-        const offset = getOffsetFromPageLimit(page, perPage);
-        const limit = getLimitFromPageSize(perPage);
-        (metadata.offset !== offset || metadata.limit !== limit) &&
-            callback({
-                ...(metadata.offset !== offset && { offset }),
-                ...(metadata.limit !== limit && { limit })
-            });
-    });
-    return handleRefresh;
+    const refresh = React.useCallback((pagination) => handleRefresh(pagination, metadata, callback));
+    return refresh;
 };
 
 export const usePagePerPage = (limit, offset) => {


### PR DESCRIPTION
cc @mkholjuraev 

This PR fixes an issue when the inventory table hangs in a loading state.

The problem was caused by duplicate API calls by the `getEntities` and `onRefresh` callbacks. Where possible, I've integrated the onRefresh into the `getEntities` callback which will prevent double calls and hanging loading state in the entities reducer.

@mkholjuraev Please double-check that nothing broke with this change.