### PR TITLE
fix(Inventory): fix clear filters issue after custom inventory fetch

### DIFF
--- a/src/PresentationalComponents/Snippets/AdvisoriesIcon.js
+++ b/src/PresentationalComponents/Snippets/AdvisoriesIcon.js
@@ -9,7 +9,7 @@ const AdvisoriesIcon = ({ count, tooltipText, Icon }) =>(
                 <Icon/>
             </FlexItem>
             <FlexItem spacer={{ default: 'spacerSm' }}>
-                {count.toString()}
+                {count && count.toString() || 0}
             </FlexItem>
         </Flex>
     </Tooltip>

--- a/src/SmartComponents/Systems/Systems.js
+++ b/src/SmartComponents/Systems/Systems.js
@@ -137,9 +137,8 @@ const Systems = () => {
     };
 
     const areActionsDisabled = (rowData) => {
-        // eslint-disable-next-line camelcase
-        const { applicable_advisories } = rowData;
-        return applicable_advisories.every(typeSum => typeSum === 0);
+        const { applicable_advisories: applicableAdvisories } = rowData;
+        return applicableAdvisories && applicableAdvisories.every(typeSum => typeSum === 0);
     };
 
     const prepareRemediationPairs = (systems) => {


### PR DESCRIPTION
Systems, advisory details page breaks after clicking 'Clear filters' button due to initial undefined data 