### PR TITLE
fix(Export button): fix misalignment

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -21,3 +21,6 @@ table.patchCompactInventory {
     overflow: inherit !important;
 }
 
+.patch-root .ins-c-inventory__table--toolbar:not(.ins-c-inventory__table--toolbar-has-items) .pf-c-toolbar__content .pf-c-toolbar__item:last-child {
+    min-width: unset !important;
+}


### PR DESCRIPTION
The problem is related to how FEC sets min-width to the button provided by dedicatedActions. This is a temporary fix. 

![image](https://user-images.githubusercontent.com/59481011/123422470-8a8e0d80-d5be-11eb-91e7-529c8c3eed2f.png)
