### PR TITLE
fix(Inventory): problems after rebase are solved

### DIFF
--- a/src/SmartComponents/AdvisorySystems/AdvisorySystems.js
+++ b/src/SmartComponents/AdvisorySystems/AdvisorySystems.js
@@ -46,7 +46,7 @@ const AdvisorySystems = ({ advisoryName }) => {
         ({ AdvisorySystemsStore }) => AdvisorySystemsStore?.queryParams || {}
     );
     const selectedRows = useSelector(
-        ({ AdvisorySystemsStore }) => AdvisorySystemsStore?.selectedRows || []
+        ({ entities }) => entities?.selectedRows || []
     );
 
     const { systemProfile, selectedTags,

--- a/src/SmartComponents/Systems/Systems.js
+++ b/src/SmartComponents/Systems/Systems.js
@@ -17,7 +17,7 @@ import {
 import { remediationIdentifiers } from '../../Utilities/constants';
 import {
     arrayFromObj, buildFilterChips,
-    filterSelectedRowIDs, remediationProviderWithPairs,
+    removeUndefinedObjectKeys, remediationProviderWithPairs,
     transformPairs, persistantParams, filterRemediatableSystems, decodeQueryparams
 } from '../../Utilities/Helpers';
 import {
@@ -50,7 +50,7 @@ const Systems = () => {
     );
 
     const selectedRows = useSelector(
-        ({ SystemsStore }) => SystemsStore?.selectedRows || []
+        ({ entities }) => entities?.selectedRows || []
     );
     const status = useSelector(
         ({ entities }) => entities?.status || {}
@@ -176,7 +176,7 @@ const Systems = () => {
                                     onClick={() =>
                                         showRemediationModal(
                                             remediationProviderWithPairs(
-                                                filterSelectedRowIDs(selectedRows),
+                                                removeUndefinedObjectKeys(selectedRows),
                                                 prepareRemediationPairs,
                                                 transformPairs,
                                                 remediationIdentifiers.advisory)

--- a/src/Utilities/Helpers.js
+++ b/src/Utilities/Helpers.js
@@ -470,6 +470,8 @@ export const filterRemediatableSystems = result => ({ data: result?.data.filter(
 })
 });
 
+export const filterRemediatablePackageSystems = result => ({ data: result.data.filter(system => system.updatable) });
+
 export const persistantParams = (patchParams, decodedParams) => {
     const persistantParams = { ...patchParams, ...decodedParams };
     return (

--- a/src/store/Reducers/InventoryEntitiesReducer.js
+++ b/src/store/Reducers/InventoryEntitiesReducer.js
@@ -54,8 +54,10 @@ export const inventoryEntitiesReducer = (columns, inventoryModifier) => (state =
         case 'LOAD_ENTITIES_FULFILLED':
             return inventoryModifier(columns, newState);
 
-        case 'SELECT_ENTITY':
-            return selectRows(newState, action);
+        case 'SELECT_ENTITY': {
+            const stateAfterSelection = selectRows(newState, action);
+            return inventoryModifier(columns, stateAfterSelection);
+        }
 
         case ActionTypes.CLEAR_INVENTORY_REDUCER:
             return initialState;


### PR DESCRIPTION
The issues after rebase:
1. `filterSelectedRowIDs` function in Helpers.js was renamed to `removeUndefinedObjectKeys`. But this change was got lost during rebase and it was not reflected in Inventory Components.
2. `useEffect` in PackageSystems page was changed to async function and it broke the implementation of `clearInventoryReducer`. Thus if you select a system on the Package Systems page it was present also in Systems Page. 
3. If you select All systems, all of the systems on the first page is selected even if it was selected. It was because we did not call the `inventoryModifier` reducer to remap with updated systems selected.
4. The last problem that occurred was the incorrect `useSelector` for selected rows in all Inventory pages. Previously `selectedRows` was a part of the relevant reducer for the component. But after rebase, it is now stored in `entities` reducer