### PR TITLE
Without hot refresh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@redhat-cloud-services/frontend-components-utilities": "^3.1.1",
         "axios": "^0.21.1",
         "classnames": "^2.2.6",
+        "package-lock-only": "^0.0.4",
         "query-string": "^6.13.8",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
@@ -4444,7 +4445,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -5664,7 +5664,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -5678,7 +5677,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -6045,7 +6043,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -6053,8 +6050,7 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "node_modules/color-string": {
       "version": "1.6.0",
@@ -10245,7 +10241,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -18402,6 +18397,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/package-lock-only": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/package-lock-only/-/package-lock-only-0.0.4.tgz",
+      "integrity": "sha512-fV1YHeTMWH5LKmdVqfWskm2/SG0iF2IrxJn3ziaPVx9CnpecGJzt8xXtLV+CYINENZwPFMtbxO5qupz0asNz1A==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "chalk": "^2.4.1"
+      }
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -24436,7 +24440,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -31040,7 +31043,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -32076,7 +32078,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -32086,8 +32087,7 @@
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         }
       }
     },
@@ -32394,7 +32394,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -32402,8 +32401,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
       "version": "1.6.0",
@@ -35872,8 +35870,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.2",
@@ -42484,6 +42481,14 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
+    "package-lock-only": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/package-lock-only/-/package-lock-only-0.0.4.tgz",
+      "integrity": "sha512-fV1YHeTMWH5LKmdVqfWskm2/SG0iF2IrxJn3ziaPVx9CnpecGJzt8xXtLV+CYINENZwPFMtbxO5qupz0asNz1A==",
+      "requires": {
+        "chalk": "^2.4.1"
+      }
+    },
     "pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -47543,7 +47548,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@redhat-cloud-services/frontend-components-utilities": "^3.1.1",
     "axios": "^0.21.1",
     "classnames": "^2.2.6",
+    "package-lock-only": "^0.0.4",
     "query-string": "^6.13.8",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/src/PresentationalComponents/Filters/VersionFilter.js
+++ b/src/PresentationalComponents/Filters/VersionFilter.js
@@ -7,7 +7,9 @@ const VersionFilter = (apply, filter, packageVersions) => {
     const [numOptions, setNumOptions] = React.useState(10);
 
     const isSet = filter && filter.installed_evra;
-    const installedEvra = isSet && filter.installed_evra.split(',');
+    const installedEvra = isSet &&
+        (typeof(filter.installed_evra) === 'string' && filter.installed_evra.split(',')
+        || filter.installed_evra);
     const versionList = packageVersions.data && packageVersions.data.sort().map(version => ({ value: version.evra }))
         || [{ value: 'No version is available', disabled: true }];
 

--- a/src/SmartComponents/SystemAdvisories/SystemAdvisories.js
+++ b/src/SmartComponents/SystemAdvisories/SystemAdvisories.js
@@ -8,7 +8,7 @@ import typeFilter from '../../PresentationalComponents/Filters/TypeFilter';
 import { Unavailable } from '@redhat-cloud-services/frontend-components/Unavailable';
 import TableView from '../../PresentationalComponents/TableView/TableView';
 import { systemAdvisoriesColumns } from '../../PresentationalComponents/TableView/TableViewAssets';
-import { changeSystemAdvisoryListParams, clearSystemAdvisoriesStore, expandSystemAdvisoryRow,
+import { changeSystemAdvisoryListParams, expandSystemAdvisoryRow,
     fetchApplicableSystemAdvisories, selectSystemAdvisoryRow } from '../../store/Actions/Actions';
 import { fetchApplicableSystemAdvisoriesApi,
     exportSystemAdvisoriesCSV, exportSystemAdvisoriesJSON
@@ -50,10 +50,6 @@ const SystemAdvisories = ({ history, handleNoSystemData }) => {
             createSystemAdvisoriesRows(advisories, expandedRows, selectedRows, metadata),
         [advisories, expandedRows, selectedRows]
     );
-
-    React.useEffect(() => {
-        return () => dispatch(clearSystemAdvisoriesStore());
-    }, []);
 
     React.useEffect(() => {
         if (firstMount) {

--- a/src/SmartComponents/SystemPackages/SystemPackages.js
+++ b/src/SmartComponents/SystemPackages/SystemPackages.js
@@ -9,7 +9,7 @@ import { SystemUpToDate } from '../../PresentationalComponents/Snippets/SystemUp
 import TableView from '../../PresentationalComponents/TableView/TableView';
 import { systemPackagesColumns } from '../../PresentationalComponents/TableView/TableViewAssets';
 import {
-    changeSystemPackagesParams, clearSystemPackagesStore,
+    changeSystemPackagesParams,
     fetchApplicableSystemPackages, selectSystemPackagesRow
 } from '../../store/Actions/Actions';
 import { fetchApplicablePackagesApi, exportSystemPackagesCSV, exportSystemPackagesJSON } from '../../Utilities/api';
@@ -45,10 +45,6 @@ const SystemPackages = ({ handleNoSystemData }) => {
             createSystemPackagesRows(packages, selectedRows),
         [packages,  selectedRows]
     );
-
-    React.useEffect(() => {
-        return () => dispatch(clearSystemPackagesStore());
-    }, []);
 
     React.useEffect(()=> {
         dispatch(fetchApplicableSystemPackages({ id: entity.id, ...queryParams }));

--- a/src/Utilities/Helpers.js
+++ b/src/Utilities/Helpers.js
@@ -313,7 +313,8 @@ export const buildFilterChips = (filters, search) => {
     let filterConfig = [];
     const buildChips = (filters, category) =>{
         if (category === 'installed_evra') {
-            const versions = filters[category] && filters[category].split(',') || [];
+            const versions = filters[category] && (typeof(filters[category]) === 'string' && filters[category].split(',')
+                || filters[category]) || [];
             return versions.map(version => ({
                 name: version,
                 id: category,

--- a/src/Utilities/Hooks.js
+++ b/src/Utilities/Hooks.js
@@ -78,7 +78,10 @@ export const useRemoveFilter = (filters, callback, defaultFilters = { filter: {}
                     newParams.filter[categoryId] = undefined;
                 }
             } else if (categoryId === 'installed_evra') {
-                const versions = filters[categoryId].split(',');
+                const versions = filters[categoryId] &&
+                    (typeof(filters[categoryId]) === 'string' && filters[categoryId].split(',')
+                        || filters[categoryId]) || [];
+
                 newParams.filter[categoryId] = (versions.length !== 1) && versions
                 .filter(version => !chips.find(chip => chip.value === version)).join(',') || undefined;
             }

--- a/src/store/Reducers/SystemAdvisoryListStore.js
+++ b/src/store/Reducers/SystemAdvisoryListStore.js
@@ -30,9 +30,6 @@ export const SystemAdvisoryListStore = (state = storeListDefaults, action) => {
         case ActionTypes.SELECT_SYSTEM_ADVISORY_ROW:
             return selectRows(newState, action);
 
-        case ActionTypes.CLEAR_SYSTEM_ADVISORIES:
-            return storeListDefaults;
-
         case ActionTypes.TRIGGER_GLOBAL_FILTER:
             return changeFilters(newState, action);
 

--- a/src/store/Reducers/SystemPackageListStore.js
+++ b/src/store/Reducers/SystemPackageListStore.js
@@ -22,9 +22,6 @@ export const SystemPackageListStore = (state = { ...storeListDefaults, ...initia
         case ActionTypes.SELECT_SYSTEM_PACKAGES_ROW:
             return selectRows(newState, action);
 
-        case ActionTypes.CLEAR_SYSTEM_PACKAGES:
-            return { ...storeListDefaults, ...initializeState };
-
         case ActionTypes.TRIGGER_GLOBAL_FILTER:
             return changeFilters(newState, action);
 


### PR DESCRIPTION
The PR includes 2 fixes for the release: 
1. Broken page after reload because of difference between how installed_evra is decoded from URL params. installed_evra gets decoded as an array, while version filter handles installed_evra as a string. Now I have put a condition to handle the type accordingly.
2. System advisories and System packages were not persisting parameters as we were clearing the store on unmount. I have removed clearing the store.