### PR TITLE
fix(Advisories): SPM-1100 make advisory description font consistent

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -10,7 +10,13 @@ table.patchCompactInventory {
 }
 
 .patch-root {
-    overflow: inherit !important;
+    overflow: inherit !important;    
+
+    .pf-c-table__expandable-row-content {
+        .patch-advisory-description {
+            font-size: var(--pf-global--FontSize--sm);
+        }
+    }
 }
 
 .patch-root

--- a/src/PresentationalComponents/Snippets/DescriptionWithLink.js
+++ b/src/PresentationalComponents/Snippets/DescriptionWithLink.js
@@ -13,7 +13,7 @@ import { SecurityIcon } from '@patternfly/react-icons';
 export const DescriptionWithLink = ({ row }) =>  {
     const severityObject = getSeverityById(row.attributes.severity);
     return (
-        <TextContent>
+        <TextContent className='patch-advisory-description'>
             {
                 row.attributes.cve_count > 0 &&
                 (<TextList component={TextListVariants.dl} style ={{ '--pf-c-content--dl--RowGap': '0.5rem' }}>


### PR DESCRIPTION
Before: 

![image](https://user-images.githubusercontent.com/59481011/129869064-7d1a4cf5-4640-486f-99ad-ac3f1245f47e.png)


After:

![image](https://user-images.githubusercontent.com/59481011/129869008-714f1009-b608-4841-bf6e-a02b90f9efb0.png)

