### PR TITLE
fix(SystemtatusBar): regressions are resolved

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -35,4 +35,6 @@ table.patchCompactInventory {
 .patch-status-report-text {
     color: var(--pf-global--primary-color--100);
     font-weight: bold;
+    margin: 0px;
+    padding: 0px
 }

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -174,12 +174,12 @@ export default defineMessages({
     labelsFiltersStale: {
         id: 'labelsFiltersStale',
         description: 'Label for stale fitler title',
-        defaultMessage: 'System status'
+        defaultMessage: 'Status'
     },
     labelsFiltersStalePlaceholder: {
         id: 'labelsFiltersStalePlaceholder',
         description: 'Label for stale fitler placeholder',
-        defaultMessage: 'Filter by system status'
+        defaultMessage: 'Filter by status'
     },
     labelsFiltersStatus: {
         id: 'labelsFiltersStatus',
@@ -199,12 +199,12 @@ export default defineMessages({
     labelsFiltersSystemsUpdatable: {
         id: 'labelsFiltersSystemsUpdatable',
         description: 'search filter placeholder for systems pages',
-        defaultMessage: 'Updatable packages'
+        defaultMessage: 'Patch status'
     },
     labelsFiltersSystemsUpdatablePlaceholder: {
         id: 'labelsFiltersSystemsUpdatablePlaceholder',
         description: 'search filter placeholder for systems updatable pages',
-        defaultMessage: 'Filter by systems with updatable packages'
+        defaultMessage: 'Filter by patch status'
     },
     labelsFiltersType: {
         id: 'labelsFiltersType',

--- a/src/PresentationalComponents/Filters/SystemStaleFilter.js
+++ b/src/PresentationalComponents/Filters/SystemStaleFilter.js
@@ -16,6 +16,16 @@ const systemsStaleFilter = (apply, currentFilter = {}) => {
             })),
         []
     );
+
+    const currentValueStringType = (
+        currentValue
+            && (
+                Array.isArray(currentValue)
+                    && currentValue.map(value => value.toString())
+                    || [currentValue.toString()]
+            )
+    );
+
     const filterByStale = value => {
         apply({ filter: { stale: value } });
     };
@@ -28,7 +38,7 @@ const systemsStaleFilter = (apply, currentFilter = {}) => {
                 filterByStale(value);
             },
             items: staleMap,
-            value: currentValue,
+            value: currentValueStringType,
             placeholder: intl.formatMessage(messages.labelsFiltersStalePlaceholder)
         }
     };

--- a/src/PresentationalComponents/StatusReports/SystemsStatusReport.js
+++ b/src/PresentationalComponents/StatusReports/SystemsStatusReport.js
@@ -4,28 +4,33 @@ import React from 'react';
 import { intl } from '../../Utilities/IntlProvider';
 import messages from '../../Messages';
 import {
-    CardTitle, Spinner, Button,
+    CardTitle, Button, Skeleton,
     Card, Grid, GridItem, CardBody, Flex, FlexItem
 } from '@patternfly/react-core';
 import { Main } from '@redhat-cloud-services/frontend-components/Main';
 
 const StatusCard = ({ title, color, Icon, value, filter, apply }) => {
     return (
-        <Card isCompact>
+        <Card isCompact style={{ marginRight: 'var(--pf-global--spacer--sm)' }}>
             <CardTitle style={{ marginTop: '0px' }}>{title}</CardTitle>
             <CardBody className='fonst-size-sm'>
                 <Flex flex={{ default: 'inlineFlex' }} style={{ flexWrap: 'nowrap' }}>
-                    <FlexItem spacer={{ default: 'spacerNone' }}><Icon color={color} /></FlexItem>
+                    <FlexItem
+                        spacer={{ default: 'spacerMd' }}
+                        alignSelf={{ default: 'alignSelfCenter' }}
+                    >
+                        <Icon color={color} size='md'/>
+                    </FlexItem>
                     <FlexItem isFilled spacer={{ default: 'spacerNone' }}>
                         {
                             typeof(value) === 'undefined'
-                                &&  <Spinner isSVG size="md" />
-                                ||  <Button
-                                    variant="link"
-                                    onClick={() => {  apply(filter); } }
-                                    className='patch-status-report-text'>
-                                    {value}
-                                </Button>
+                            &&  <Skeleton width="24px" />
+                                    ||  <Button
+                                        variant="link"
+                                        onClick={() => apply(filter)}
+                                        className='patch-status-report-text'>
+                                        {value}
+                                    </Button>
                         }
                     </FlexItem>
                 </Flex>

--- a/src/Utilities/Helpers.js
+++ b/src/Utilities/Helpers.js
@@ -324,7 +324,6 @@ export const buildFilterChips = (filters, search, searchChipLabel = 'Search') =>
             }));
         } else {
             const { values } = filterCategories[category];
-            console.log(values, filters[category], filters);
             return [].concat(filters[category]).map(filterValue => {
                 const match = values.find(
                     item =>
@@ -395,7 +394,6 @@ export const changeListParams = (oldParams, newParams) => {
         newState && delete newState.tags;
     }
 
-    // console.log(newState, 'state after changeparams');
     return newState;
 };
 

--- a/src/Utilities/api.js
+++ b/src/Utilities/api.js
@@ -36,7 +36,6 @@ export const fetchApplicableSystemAdvisoriesApi = params => {
 };
 
 export const fetchSystems = params => {
-    console.log(params);
     return createApiCall('/systems', 'get', prepareEntitiesParams(params));
 };
 

--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -160,11 +160,11 @@ export const updatableTypes = [
 export const packagesListUpdatableTypes = [
     {
         value: 'eq:0',
-        label: 'Up-to-date '
+        label: 'Systems up to date'
     },
     {
         value: 'gt:0',
-        label: 'Upgradable'
+        label: 'Systems with patches available'
     }
 ];
 
@@ -197,11 +197,11 @@ export const filterCategories = {
         values: packagesListUpdatableTypes
     },
     packages_updatable: {
-        label: 'Systems status',
+        label: 'Patch status',
         values: packagesListUpdatableTypes
     },
     stale: {
-        label: 'Stale systems',
+        label: 'Status',
         values: staleSystems
     }
 };

--- a/src/store/Reducers/SystemsStore.js
+++ b/src/store/Reducers/SystemsStore.js
@@ -20,8 +20,6 @@ export const SystemsStore = (state = initialState, action) => {
     switch (action.type) {
 
         case ActionTypes.CHANGE_SYSTEMS_PARAMS:
-            // delete action.payload?.filter;
-            // console.log(action.payload, 'action');
             newState.queryParams = changeListParams(newState.queryParams, action.payload);
             return newState;
 


### PR DESCRIPTION
Regressions are resolved:
1. Spinner is changed to Skeleton on load
2. the space between status cards are made 24 px
3. Icons are made 'md' size
4. status filter wording are made consistent with the mockups
5. double filters chips are fixed. now stale filter chips are only one fresh and one stale
6. status filters are sharable using URL params

https://user-images.githubusercontent.com/59481011/130784860-014d48d2-53cc-4b17-a604-35a795b7f587.mp4

