### PR TITLE
feat(AdvisoriesReport): SPM-1167 add most impactfull advisory info

### DIFF
--- a/src/Messages.js
+++ b/src/Messages.js
@@ -11,6 +11,11 @@ export default defineMessages({
         description: 'regsiter page title',
         defaultMessage: 'Patch'
     },
+    labelsApplicableSystemsCount: {
+        id: 'labelsApplicableSystemsCount',
+        description: 'applicable systems number label',
+        defaultMessage: '{systemsCount} applicable systems'
+    },
     labelsBulkSelectAll: {
         id: 'labelsBulkSelectAll',
         description: 'bulk select option',
@@ -351,6 +356,11 @@ export default defineMessages({
         description: 'text to notify there is not available version',
         defaultMessage: 'No version is available'
     },
+    textRebootIsRequired: {
+        id: 'textRebootIsRequired',
+        description: 'Advisories table cell text',
+        defaultMessage: 'Reboot is required'
+    },
     textThirdPartyInfo: {
         id: 'textThirdPartyInfo',
         description: 'text about the third paty managed hosts',
@@ -365,6 +375,11 @@ export default defineMessages({
         id: 'affectedSystems',
         description: 'page title with capital letter',
         defaultMessage: 'Affected systems'
+    },
+    titlesMostImpactfulAdvisories: {
+        id: 'titlesMostImpactfulAdvisories',
+        description: 'page title with capital letter',
+        defaultMessage: 'Most impactful advisories'
     },
     titlesPackages: {
         id: 'titlesPackages',

--- a/src/PresentationalComponents/StatusReports/AdvisoriesStatusReport.js
+++ b/src/PresentationalComponents/StatusReports/AdvisoriesStatusReport.js
@@ -1,0 +1,107 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { PowerOffIcon, SecurityIcon } from '@patternfly/react-icons';
+import { intl } from '../../Utilities/IntlProvider';
+import { fetchApplicableAdvisoriesApi } from '../../Utilities/api';
+import messages from '../../Messages';
+import {
+    CardTitle, Card, Grid, GridItem, CardBody, Flex, FlexItem, Title
+} from '@patternfly/react-core';
+import { Main } from '@redhat-cloud-services/frontend-components/Main';
+import { handlePatchLink, handleLongSynopsis } from '../../Utilities/Helpers';
+import { entityTypes, advisorySeverities } from '../../Utilities/constants';
+import AdvisoryType from '../AdvisoryType/AdvisoryType';
+import { processDate } from '@redhat-cloud-services/frontend-components-utilities/helpers';
+
+const StatusCard = ({ advisory: { attributes, id } }) =>
+    (
+        <Card>
+            <CardTitle>
+                {handlePatchLink(entityTypes.advisories, id)}
+            </CardTitle>
+            <CardBody className='fonst-size-sm'>
+                <Grid>
+                    <GridItem span={6}>
+                        <Grid>
+                            <GridItem>
+                                <AdvisoryType
+                                    type={attributes.advisory_type}
+                                />
+                            </GridItem>
+                            <GridItem>
+                                {processDate(attributes.public_date)}
+                            </GridItem>
+                            {attributes.os_name && (<GridItem>
+                                {attributes.os_name}
+                            </GridItem>)}
+                        </Grid>
+                    </GridItem>
+                    <GridItem span={6}>
+                        <Grid>
+                            {attributes.severity && (<GridItem>
+                                <Flex flex={{ default: 'inlineFlex' }} style={{ flexWrap: 'nowrap' }}>
+                                    <FlexItem>
+                                        <SecurityIcon size="sm" color={advisorySeverities[attributes.severity].color} />
+                                    </FlexItem>
+                                    <FlexItem isFilled>{advisorySeverities[attributes.severity].label}</FlexItem>
+                                </Flex>
+                            </GridItem>)}
+                            {attributes.reboot_required && (<GridItem>
+                                <Flex flex={{ default: 'inlineFlex' }} style={{ flexWrap: 'nowrap' }}>
+                                    <FlexItem><PowerOffIcon color='var(--pf-global--palette--red-100)' /></FlexItem>
+                                    <FlexItem isFilled>{intl.formatMessage(messages.textRebootIsRequired)}</FlexItem>
+                                </Flex>
+                            </GridItem>)}
+                        </Grid>
+                    </GridItem>
+                    <GridItem>
+                        {handlePatchLink(
+                            entityTypes.advisories,
+                            id,
+                            intl.formatMessage(
+                                messages.labelsApplicableSystemsCount,
+                                { systemsCount: attributes.applicable_systems }
+                            )
+                        )}
+                    </GridItem>
+                    <GridItem>
+                        {handleLongSynopsis(attributes.synopsis)}
+                    </GridItem>
+                </Grid>
+            </CardBody>
+        </Card>
+    );
+
+const AdvisoriesStatusBar = () => {
+    const [advisories, setAdvisories] = React.useState([]);
+    React.useEffect(async () => {
+        setAdvisories(
+            await fetchApplicableAdvisoriesApi({ limit: 4, sort: '-advisory_type,-applicable_systems' })
+        );
+    }, []);
+
+    return advisories.data && advisories.data.length  && (
+        <Main style={{ paddingBottom: 0, paddingTop: 0 }}>
+
+            <Title headingLevel="h3" className='pf-u-my-md'>
+                {intl.formatMessage(messages.titlesMostImpactfulAdvisories)}
+            </Title>
+
+            <Grid hasGutter span={3}>
+                {advisories.data.map(advisory =>
+                    (<GridItem key={advisory.id}>
+                        <StatusCard
+                            advisory={advisory}
+                        />
+                    </GridItem>)
+                )
+                }
+            </Grid>
+        </Main>
+    ) || null;
+};
+
+StatusCard.propTypes = {
+    advisory: propTypes.object
+};
+export default AdvisoriesStatusBar;

--- a/src/SmartComponents/Advisories/Advisories.js
+++ b/src/SmartComponents/Advisories/Advisories.js
@@ -30,6 +30,7 @@ import {
 } from '../../Utilities/Hooks';
 import { intl } from '../../Utilities/IntlProvider';
 import { clearNotifications } from '@redhat-cloud-services/frontend-components-notifications/redux';
+import AdvisoriesStatusReport from '../../PresentationalComponents/StatusReports/AdvisoriesStatusReport';
 
 const Advisories = ({ history }) => {
     const pageTitle = intl.formatMessage(messages.titlesAdvisories);
@@ -130,6 +131,7 @@ const Advisories = ({ history }) => {
     return (
         <React.Fragment>
             <Header title={intl.formatMessage(messages.titlesPatchAdvisories)} headerOUIA={'advisories'} />
+            <AdvisoriesStatusReport/>
             <Main>
                 <TableView
                     columns={advisoriesColumns}


### PR DESCRIPTION
I have a few suggestions already added into the UI design: 
1. Move advisory name into the title position of the Patternfly card
2. move the number of applicable systems into a separate block GridItem  so that it is not split into 2 lines
3. Move os name to first column Grid item elements so that we have a balanced number of info labels into 2 sides.

![image](https://user-images.githubusercontent.com/59481011/133993936-3708f7e2-529e-4348-823b-03948ec8a01e.png)


I have not put a loader, because I am not sure if we have always more than 4 advisories in the database. If we always have and we know what will be shown, the loader can be put always