### PR TITLE
fix(SPM-1381): Pagination dropdown disabled when table empty

### DIFF
--- a/src/PresentationalComponents/TableView/TableFooter.js
+++ b/src/PresentationalComponents/TableView/TableFooter.js
@@ -15,6 +15,7 @@ const TableFooter = ({ page, perPage, onSetPage, totalItems, onPerPageSelect, pa
                 widgetId={`pagination-options-menu-bottom`}
                 variant={PaginationVariant.bottom}
                 ouiaId={paginationOUIA}
+                isDisabled={totalItems === 0}
             />
         </TableToolbar>
     );

--- a/src/PresentationalComponents/TableView/TableView.js
+++ b/src/PresentationalComponents/TableView/TableView.js
@@ -78,7 +78,8 @@ const TableView = ({
                             isCompact: true,
                             onSetPage,
                             onPerPageSelect,
-                            ouiaId: `top-${paginationOUIA}`
+                            ouiaId: `top-${paginationOUIA}`,
+                            isDisabled: metadata.total_items === 0
                         }}
                         filterConfig={filterConfig}
                         activeFiltersConfig={{

--- a/src/PresentationalComponents/TableView/__snapshots__/TableView.test.js.snap
+++ b/src/PresentationalComponents/TableView/__snapshots__/TableView.test.js.snap
@@ -78,6 +78,7 @@ exports[`TableView TableView 1`] = `
     pagination={
       Object {
         "isCompact": true,
+        "isDisabled": false,
         "itemCount": undefined,
         "onPerPageSelect": [MockFunction],
         "onSetPage": [MockFunction],

--- a/src/SmartComponents/AdvisoryDetail/__snapshots__/CveModal.test.js.snap
+++ b/src/SmartComponents/AdvisoryDetail/__snapshots__/CveModal.test.js.snap
@@ -1457,6 +1457,7 @@ exports[`CveModal.js Should match the snapshots 1`] = `
                                   pagination={
                                     Object {
                                       "isCompact": true,
+                                      "isDisabled": false,
                                       "itemCount": 12,
                                       "onPerPageSelect": [Function],
                                       "onSetPage": [Function],

--- a/src/SmartComponents/AdvisorySystems/AdvisorySystems.js
+++ b/src/SmartComponents/AdvisorySystems/AdvisorySystems.js
@@ -125,6 +125,9 @@ const AdvisorySystems = ({ advisoryName }) => {
                             selectedTags
                         }
                     }}
+                    paginationProps={{
+                        isDisabled: totalItems === 0
+                    }}
                     onLoad={({ mergeWithEntities }) => {
                         register({
                             ...mergeWithEntities(

--- a/src/SmartComponents/AdvisorySystems/__snapshots__/AdvisorySystem.test.js.snap
+++ b/src/SmartComponents/AdvisorySystems/__snapshots__/AdvisorySystem.test.js.snap
@@ -418,6 +418,11 @@ exports[`AdvisorySystems.js Should match the snapshots and dispatch FETCH_AFFECT
           initialLoading={true}
           isFullView={true}
           onLoad={[Function]}
+          paginationProps={
+            Object {
+              "isDisabled": true,
+            }
+          }
           showTags={true}
           tableProps={
             Object {

--- a/src/SmartComponents/PackageSystems/PackageSystems.js
+++ b/src/SmartComponents/PackageSystems/PackageSystems.js
@@ -165,6 +165,9 @@ const PackageSystems = ({ packageName }) => {
                             selectedTags
                         }
                     }}
+                    paginationProps={{
+                        isDisabled: totalItems === 0
+                    }}
                     onLoad={({ mergeWithEntities }) => {
                         register({
                             ...mergeWithEntities(

--- a/src/SmartComponents/SystemPackages/__snapshots__/SystemPackages.test.js.snap
+++ b/src/SmartComponents/SystemPackages/__snapshots__/SystemPackages.test.js.snap
@@ -303,6 +303,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
             pagination={
               Object {
                 "isCompact": true,
+                "isDisabled": true,
                 "itemCount": 0,
                 "onPerPageSelect": [Function],
                 "onSetPage": [Function],
@@ -1824,7 +1825,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                             defaultToFullPage={false}
                             firstPage={1}
                             isCompact={true}
-                            isDisabled={false}
+                            isDisabled={true}
                             isSticky={false}
                             itemCount={0}
                             itemsEnd={null}
@@ -1917,7 +1918,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                 defaultToFullPage={false}
                                 dropDirection="down"
                                 firstIndex={0}
-                                isDisabled={false}
+                                isDisabled={true}
                                 itemCount={0}
                                 itemsPerPageTitle="Items per page"
                                 itemsTitle=""
@@ -2006,7 +2007,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                   toggle={
                                     <OptionsToggle
                                       firstIndex={0}
-                                      isDisabled={false}
+                                      isDisabled={true}
                                       isOpen={false}
                                       itemCount={0}
                                       itemsPerPageTitle="Items per page"
@@ -2032,7 +2033,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                       firstIndex={0}
                                       getMenuRef={[Function]}
                                       id="pf-dropdown-toggle-id-4"
-                                      isDisabled={false}
+                                      isDisabled={true}
                                       isOpen={false}
                                       isPlain={true}
                                       isText={false}
@@ -2053,7 +2054,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                             data-ouia-safe="true"
                                           >
                                             <div
-                                              class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+                                              class="pf-c-options-menu__toggle pf-m-disabled pf-m-plain pf-m-text"
                                             >
                                               <span
                                                 class="pf-c-options-menu__toggle-text"
@@ -2079,6 +2080,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                                 data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
                                                 data-ouia-component-type="PF4/DropdownToggle"
                                                 data-ouia-safe="true"
+                                                disabled=""
                                                 id="pagination-options-menu-toggle-0"
                                                 type="button"
                                               >
@@ -2109,7 +2111,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                       widgetId="pagination-options-menu"
                                     >
                                       <div
-                                        className="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+                                        className="pf-c-options-menu__toggle pf-m-disabled pf-m-plain pf-m-text"
                                       >
                                         <span
                                           className="pf-c-options-menu__toggle-text"
@@ -2139,7 +2141,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                           aria-label="Items per page"
                                           className="pf-c-options-menu__toggle-button"
                                           id="pagination-options-menu-toggle-0"
-                                          isDisabled={0}
+                                          isDisabled={true}
                                           isOpen={false}
                                           onEnter={[Function]}
                                           onToggle={[Function]}
@@ -2151,7 +2153,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                                 data-ouia-safe="true"
                                               >
                                                 <div
-                                                  class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+                                                  class="pf-c-options-menu__toggle pf-m-disabled pf-m-plain pf-m-text"
                                                 >
                                                   <span
                                                     class="pf-c-options-menu__toggle-text"
@@ -2177,6 +2179,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                                     data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
                                                     data-ouia-component-type="PF4/DropdownToggle"
                                                     data-ouia-safe="true"
+                                                    disabled=""
                                                     id="pagination-options-menu-toggle-0"
                                                     type="button"
                                                   >
@@ -2213,7 +2216,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                             getMenuRef={null}
                                             id="pagination-options-menu-toggle-0"
                                             isActive={false}
-                                            isDisabled={0}
+                                            isDisabled={true}
                                             isOpen={false}
                                             isPlain={false}
                                             isPrimary={false}
@@ -2229,7 +2232,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                                   data-ouia-safe="true"
                                                 >
                                                   <div
-                                                    class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+                                                    class="pf-c-options-menu__toggle pf-m-disabled pf-m-plain pf-m-text"
                                                   >
                                                     <span
                                                       class="pf-c-options-menu__toggle-text"
@@ -2255,6 +2258,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                                       data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
                                                       data-ouia-component-type="PF4/DropdownToggle"
                                                       data-ouia-safe="true"
+                                                      disabled=""
                                                       id="pagination-options-menu-toggle-0"
                                                       type="button"
                                                     >
@@ -2289,7 +2293,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                               data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
                                               data-ouia-component-type="PF4/DropdownToggle"
                                               data-ouia-safe={true}
-                                              disabled={0}
+                                              disabled={true}
                                               id="pagination-options-menu-toggle-0"
                                               onClick={[Function]}
                                               onKeyDown={[Function]}
@@ -2336,7 +2340,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                 currPage="Current page"
                                 firstPage={1}
                                 isCompact={true}
-                                isDisabled={false}
+                                isDisabled={true}
                                 itemCount={0}
                                 lastPage={0}
                                 ofWord="of"
@@ -6162,7 +6166,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                       defaultToFullPage={false}
                       firstPage={1}
                       isCompact={false}
-                      isDisabled={false}
+                      isDisabled={true}
                       isSticky={false}
                       itemCount={0}
                       itemsEnd={null}
@@ -6231,7 +6235,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                           defaultToFullPage={false}
                           dropDirection="up"
                           firstIndex={0}
-                          isDisabled={false}
+                          isDisabled={true}
                           itemCount={0}
                           itemsPerPageTitle="Items per page"
                           itemsTitle=""
@@ -6320,7 +6324,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                             toggle={
                               <OptionsToggle
                                 firstIndex={0}
-                                isDisabled={false}
+                                isDisabled={true}
                                 isOpen={false}
                                 itemCount={0}
                                 itemsPerPageTitle="Items per page"
@@ -6346,7 +6350,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                 firstIndex={0}
                                 getMenuRef={[Function]}
                                 id="pf-dropdown-toggle-id-5"
-                                isDisabled={false}
+                                isDisabled={true}
                                 isOpen={false}
                                 isPlain={true}
                                 isText={false}
@@ -6367,7 +6371,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                       data-ouia-safe="true"
                                     >
                                       <div
-                                        class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+                                        class="pf-c-options-menu__toggle pf-m-disabled pf-m-plain pf-m-text"
                                       >
                                         <span
                                           class="pf-c-options-menu__toggle-text"
@@ -6393,6 +6397,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                           data-ouia-component-id="OUIA-Generated-DropdownToggle-2"
                                           data-ouia-component-type="PF4/DropdownToggle"
                                           data-ouia-safe="true"
+                                          disabled=""
                                           id="pagination-options-menu-bottom-toggle-1"
                                           type="button"
                                         >
@@ -6423,7 +6428,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                 widgetId="pagination-options-menu-bottom"
                               >
                                 <div
-                                  className="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+                                  className="pf-c-options-menu__toggle pf-m-disabled pf-m-plain pf-m-text"
                                 >
                                   <span
                                     className="pf-c-options-menu__toggle-text"
@@ -6453,7 +6458,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                     aria-label="Items per page"
                                     className="pf-c-options-menu__toggle-button"
                                     id="pagination-options-menu-bottom-toggle-1"
-                                    isDisabled={0}
+                                    isDisabled={true}
                                     isOpen={false}
                                     onEnter={[Function]}
                                     onToggle={[Function]}
@@ -6465,7 +6470,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                           data-ouia-safe="true"
                                         >
                                           <div
-                                            class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+                                            class="pf-c-options-menu__toggle pf-m-disabled pf-m-plain pf-m-text"
                                           >
                                             <span
                                               class="pf-c-options-menu__toggle-text"
@@ -6491,6 +6496,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                               data-ouia-component-id="OUIA-Generated-DropdownToggle-2"
                                               data-ouia-component-type="PF4/DropdownToggle"
                                               data-ouia-safe="true"
+                                              disabled=""
                                               id="pagination-options-menu-bottom-toggle-1"
                                               type="button"
                                             >
@@ -6527,7 +6533,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                       getMenuRef={null}
                                       id="pagination-options-menu-bottom-toggle-1"
                                       isActive={false}
-                                      isDisabled={0}
+                                      isDisabled={true}
                                       isOpen={false}
                                       isPlain={false}
                                       isPrimary={false}
@@ -6543,7 +6549,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                             data-ouia-safe="true"
                                           >
                                             <div
-                                              class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+                                              class="pf-c-options-menu__toggle pf-m-disabled pf-m-plain pf-m-text"
                                             >
                                               <span
                                                 class="pf-c-options-menu__toggle-text"
@@ -6569,6 +6575,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                                 data-ouia-component-id="OUIA-Generated-DropdownToggle-2"
                                                 data-ouia-component-type="PF4/DropdownToggle"
                                                 data-ouia-safe="true"
+                                                disabled=""
                                                 id="pagination-options-menu-bottom-toggle-1"
                                                 type="button"
                                               >
@@ -6603,7 +6610,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                                         data-ouia-component-id="OUIA-Generated-DropdownToggle-2"
                                         data-ouia-component-type="PF4/DropdownToggle"
                                         data-ouia-safe={true}
-                                        disabled={0}
+                                        disabled={true}
                                         id="pagination-options-menu-bottom-toggle-1"
                                         onClick={[Function]}
                                         onKeyDown={[Function]}
@@ -6650,7 +6657,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                           currPage="Current page"
                           firstPage={1}
                           isCompact={false}
-                          isDisabled={false}
+                          isDisabled={true}
                           itemCount={0}
                           lastPage={0}
                           ofWord="of"

--- a/src/SmartComponents/Systems/Systems.js
+++ b/src/SmartComponents/Systems/Systems.js
@@ -180,6 +180,9 @@ const Systems = () => {
                                     selectedTags
                                 }
                             }}
+                            paginationProps={{
+                                isDisabled: totalItems === 0
+                            }}
                             onLoad={({ mergeWithEntities }) => {
                                 register({
                                     ...mergeWithEntities(


### PR DESCRIPTION
Should be working in all parts of Patchman
![image](https://user-images.githubusercontent.com/20592948/156792837-b0189894-c7a3-4a68-9ca0-0abdaa4f2371.png)
