### PR TITLE
fix(PatchSetWizard): separate request to update and create set

### DIFF
--- a/src/SmartComponents/PatchSetWizard/InputFields/SelectExistingSets.js
+++ b/src/SmartComponents/PatchSetWizard/InputFields/SelectExistingSets.js
@@ -20,7 +20,10 @@ const SelectExistingSets = ({ patchSets, setSelectedPatchSet, selectedSets, syst
         setSelectedPatchSet(selected);
 
         const selectedSet = patchSets.filter(set => set.name === selected);
-        formOptions.change('existing_patch_set', { name: selectedSet[0].name, systems });
+        if (selectedSet.length === 1) {
+            formOptions.change('existing_patch_set', { name: selectedSet[0]?.name, systems, id: selectedSet[0]?.id });
+        }
+
     };
 
     return (

--- a/src/Utilities/api.js
+++ b/src/Utilities/api.js
@@ -202,3 +202,7 @@ export const assignSystemPatchSet = (payload, requestConfig) => {
 export const fetchPatchSets = params => {
     return createApiCall(`/baselines`, 'get', params);
 };
+
+export const updatePatchSets = (payload, requestConfig, id) => {
+    return createApiCall(`/baselines/${id}`, 'put', null, payload, requestConfig);
+};


### PR DESCRIPTION
We need to send  distinct requests for updating and creating a patch set according to the changed [API docs](https://console.stage.redhat.com/beta/docs/api/patch#operations-default-createBaseline). The API doc is missing description field on both endpoints:

1. For creating a patch set (**/api/patch/v1/baselines**): 
  `{
    "config": {
      "to_time": "2022-12-31T12:00:00-04:00"
    },
    "inventory_ids": [
      "string"
    ],
    "name": "string"
  }` 
2. For updating a patch set (**/api/patch/v1/baselines/{baseline_id}**):
```
  {
    "config": {
      "to_time": "2022-12-31T12:00:00-04:00"
    },
    "inventory_ids": {
      "additionalProp1": true,
      "additionalProp2": true,
      "additionalProp3": true
    },
    "name": "my-changed-baseline-name"
  }
```