### PR TITLE
feat(PatchSet): put patch set work under feature flag

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,7 +7,7 @@ import { useHistory, useLocation, withRouter } from 'react-router-dom';
 import './App.scss';
 import { paths, Routes } from './Routes';
 import { changeGlobalTags, changeProfile, globalFilter } from './store/Actions/Actions';
-import { mapGlobalFilters } from './Utilities/Helpers';
+import { mapGlobalFilters, activateFeatureFlags } from './Utilities/Helpers';
 
 const App = () => {
     const dispatch = useDispatch();
@@ -17,6 +17,8 @@ const App = () => {
     });
     const location = useLocation();
     const history = useHistory();
+
+    activateFeatureFlags(location);
 
     const listenNavigation = () => {
         return  insights.chrome.on('APP_NAVIGATION', event => {

--- a/src/PresentationalComponents/TableView/__snapshots__/TableView.test.js.snap
+++ b/src/PresentationalComponents/TableView/__snapshots__/TableView.test.js.snap
@@ -203,6 +203,7 @@ exports[`TableView TableView 2`] = `
     pagination={
       Object {
         "isCompact": true,
+        "isDisabled": false,
         "itemCount": undefined,
         "onPerPageSelect": [MockFunction],
         "onSetPage": [MockFunction],
@@ -327,6 +328,7 @@ exports[`TableView test table props TableView 1`] = `
     pagination={
       Object {
         "isCompact": true,
+        "isDisabled": false,
         "itemCount": 10,
         "onPerPageSelect": [MockFunction],
         "onSetPage": [MockFunction],

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -4,6 +4,7 @@ import React, { Fragment, lazy, Suspense, useState } from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import { fetchSystems } from './Utilities/api';
 import { useHistory } from 'react-router-dom';
+import { checkEnabledFeature } from './Utilities/Helpers';
 
 const Advisories = lazy(() =>
     import(
@@ -116,6 +117,8 @@ export const Routes = (props) => {
 
     const path = props.childProps.location.pathname;
 
+    const isPatchSetEnabled = checkEnabledFeature('patchSet');
+
     return (
         // I recommend discussing with UX some nice loading placeholder
         <Suspense fallback={Fragment}>
@@ -158,15 +161,15 @@ export const Routes = (props) => {
                     path={paths.packageDetail.to}
                     component={PackageDetail}
                 />
-                <Route
+                {isPatchSetEnabled && <Route
                     exact
                     path={paths.patchSet.to}
                     component={PatchSet}
-                />
+                />}
 
                 <Route
                     render={() =>
-                        some(paths, p => p.to === path) || (
+                        (!isPatchSetEnabled || !some(paths, p => p.to === path)) && (
                             <Redirect to={paths.advisories.to} />
                         )
                     }

--- a/src/SmartComponents/AdvisorySystems/__snapshots__/AdvisorySystem.test.js.snap
+++ b/src/SmartComponents/AdvisorySystems/__snapshots__/AdvisorySystem.test.js.snap
@@ -48,14 +48,6 @@ exports[`AdvisorySystems.js Should match the snapshots and dispatch FETCH_AFFECT
                 "onClick": [Function],
                 "title": "Apply all applicable advisories",
               },
-              Object {
-                "onClick": [Function],
-                "title": "Assign to patch set",
-              },
-              Object {
-                "onClick": [Function],
-                "title": "Remove from patch set",
-              },
             ]
           }
           activeFiltersConfig={

--- a/src/SmartComponents/Packages/__snapshots__/Packages.test.js.snap
+++ b/src/SmartComponents/Packages/__snapshots__/Packages.test.js.snap
@@ -283,6 +283,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                   pagination={
                     Object {
                       "isCompact": true,
+                      "isDisabled": true,
                       "itemCount": 0,
                       "onPerPageSelect": [Function],
                       "onSetPage": [Function],
@@ -1295,7 +1296,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                                   defaultToFullPage={false}
                                   firstPage={1}
                                   isCompact={true}
-                                  isDisabled={false}
+                                  isDisabled={true}
                                   isSticky={false}
                                   itemCount={0}
                                   itemsEnd={null}
@@ -1388,7 +1389,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                                       defaultToFullPage={false}
                                       dropDirection="down"
                                       firstIndex={0}
-                                      isDisabled={false}
+                                      isDisabled={true}
                                       itemCount={0}
                                       itemsPerPageTitle="Items per page"
                                       itemsTitle=""
@@ -1477,7 +1478,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                                         toggle={
                                           <OptionsToggle
                                             firstIndex={0}
-                                            isDisabled={false}
+                                            isDisabled={true}
                                             isOpen={false}
                                             itemCount={0}
                                             itemsPerPageTitle="Items per page"
@@ -1503,7 +1504,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                                             firstIndex={0}
                                             getMenuRef={[Function]}
                                             id="pf-dropdown-toggle-id-8"
-                                            isDisabled={false}
+                                            isDisabled={true}
                                             isOpen={false}
                                             isPlain={true}
                                             isText={false}
@@ -1524,7 +1525,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                                                   data-ouia-safe="true"
                                                 >
                                                   <div
-                                                    class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+                                                    class="pf-c-options-menu__toggle pf-m-disabled pf-m-plain pf-m-text"
                                                   >
                                                     <span
                                                       class="pf-c-options-menu__toggle-text"
@@ -1550,6 +1551,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                                                       data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
                                                       data-ouia-component-type="PF4/DropdownToggle"
                                                       data-ouia-safe="true"
+                                                      disabled=""
                                                       id="pagination-options-menu-toggle-2"
                                                       type="button"
                                                     >
@@ -1580,7 +1582,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                                             widgetId="pagination-options-menu"
                                           >
                                             <div
-                                              className="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+                                              className="pf-c-options-menu__toggle pf-m-disabled pf-m-plain pf-m-text"
                                             >
                                               <span
                                                 className="pf-c-options-menu__toggle-text"
@@ -1610,7 +1612,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                                                 aria-label="Items per page"
                                                 className="pf-c-options-menu__toggle-button"
                                                 id="pagination-options-menu-toggle-2"
-                                                isDisabled={0}
+                                                isDisabled={true}
                                                 isOpen={false}
                                                 onEnter={[Function]}
                                                 onToggle={[Function]}
@@ -1622,7 +1624,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                                                       data-ouia-safe="true"
                                                     >
                                                       <div
-                                                        class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+                                                        class="pf-c-options-menu__toggle pf-m-disabled pf-m-plain pf-m-text"
                                                       >
                                                         <span
                                                           class="pf-c-options-menu__toggle-text"
@@ -1648,6 +1650,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                                                           data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
                                                           data-ouia-component-type="PF4/DropdownToggle"
                                                           data-ouia-safe="true"
+                                                          disabled=""
                                                           id="pagination-options-menu-toggle-2"
                                                           type="button"
                                                         >
@@ -1684,7 +1687,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                                                   getMenuRef={null}
                                                   id="pagination-options-menu-toggle-2"
                                                   isActive={false}
-                                                  isDisabled={0}
+                                                  isDisabled={true}
                                                   isOpen={false}
                                                   isPlain={false}
                                                   isPrimary={false}
@@ -1700,7 +1703,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                                                         data-ouia-safe="true"
                                                       >
                                                         <div
-                                                          class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+                                                          class="pf-c-options-menu__toggle pf-m-disabled pf-m-plain pf-m-text"
                                                         >
                                                           <span
                                                             class="pf-c-options-menu__toggle-text"
@@ -1726,6 +1729,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                                                             data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
                                                             data-ouia-component-type="PF4/DropdownToggle"
                                                             data-ouia-safe="true"
+                                                            disabled=""
                                                             id="pagination-options-menu-toggle-2"
                                                             type="button"
                                                           >
@@ -1760,7 +1764,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                                                     data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
                                                     data-ouia-component-type="PF4/DropdownToggle"
                                                     data-ouia-safe={true}
-                                                    disabled={0}
+                                                    disabled={true}
                                                     id="pagination-options-menu-toggle-2"
                                                     onClick={[Function]}
                                                     onKeyDown={[Function]}
@@ -1807,7 +1811,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                                       currPage="Current page"
                                       firstPage={1}
                                       isCompact={true}
-                                      isDisabled={false}
+                                      isDisabled={true}
                                       itemCount={0}
                                       lastPage={0}
                                       ofWord="of"
@@ -4771,7 +4775,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                             defaultToFullPage={false}
                             firstPage={1}
                             isCompact={false}
-                            isDisabled={false}
+                            isDisabled={true}
                             isSticky={false}
                             itemCount={0}
                             itemsEnd={null}
@@ -4840,7 +4844,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                                 defaultToFullPage={false}
                                 dropDirection="up"
                                 firstIndex={0}
-                                isDisabled={false}
+                                isDisabled={true}
                                 itemCount={0}
                                 itemsPerPageTitle="Items per page"
                                 itemsTitle=""
@@ -4929,7 +4933,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                                   toggle={
                                     <OptionsToggle
                                       firstIndex={0}
-                                      isDisabled={false}
+                                      isDisabled={true}
                                       isOpen={false}
                                       itemCount={0}
                                       itemsPerPageTitle="Items per page"
@@ -4955,7 +4959,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                                       firstIndex={0}
                                       getMenuRef={[Function]}
                                       id="pf-dropdown-toggle-id-9"
-                                      isDisabled={false}
+                                      isDisabled={true}
                                       isOpen={false}
                                       isPlain={true}
                                       isText={false}
@@ -4976,7 +4980,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                                             data-ouia-safe="true"
                                           >
                                             <div
-                                              class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+                                              class="pf-c-options-menu__toggle pf-m-disabled pf-m-plain pf-m-text"
                                             >
                                               <span
                                                 class="pf-c-options-menu__toggle-text"
@@ -5002,6 +5006,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                                                 data-ouia-component-id="OUIA-Generated-DropdownToggle-2"
                                                 data-ouia-component-type="PF4/DropdownToggle"
                                                 data-ouia-safe="true"
+                                                disabled=""
                                                 id="pagination-options-menu-bottom-toggle-3"
                                                 type="button"
                                               >
@@ -5032,7 +5037,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                                       widgetId="pagination-options-menu-bottom"
                                     >
                                       <div
-                                        className="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+                                        className="pf-c-options-menu__toggle pf-m-disabled pf-m-plain pf-m-text"
                                       >
                                         <span
                                           className="pf-c-options-menu__toggle-text"
@@ -5062,7 +5067,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                                           aria-label="Items per page"
                                           className="pf-c-options-menu__toggle-button"
                                           id="pagination-options-menu-bottom-toggle-3"
-                                          isDisabled={0}
+                                          isDisabled={true}
                                           isOpen={false}
                                           onEnter={[Function]}
                                           onToggle={[Function]}
@@ -5074,7 +5079,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                                                 data-ouia-safe="true"
                                               >
                                                 <div
-                                                  class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+                                                  class="pf-c-options-menu__toggle pf-m-disabled pf-m-plain pf-m-text"
                                                 >
                                                   <span
                                                     class="pf-c-options-menu__toggle-text"
@@ -5100,6 +5105,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                                                     data-ouia-component-id="OUIA-Generated-DropdownToggle-2"
                                                     data-ouia-component-type="PF4/DropdownToggle"
                                                     data-ouia-safe="true"
+                                                    disabled=""
                                                     id="pagination-options-menu-bottom-toggle-3"
                                                     type="button"
                                                   >
@@ -5136,7 +5142,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                                             getMenuRef={null}
                                             id="pagination-options-menu-bottom-toggle-3"
                                             isActive={false}
-                                            isDisabled={0}
+                                            isDisabled={true}
                                             isOpen={false}
                                             isPlain={false}
                                             isPrimary={false}
@@ -5152,7 +5158,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                                                   data-ouia-safe="true"
                                                 >
                                                   <div
-                                                    class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+                                                    class="pf-c-options-menu__toggle pf-m-disabled pf-m-plain pf-m-text"
                                                   >
                                                     <span
                                                       class="pf-c-options-menu__toggle-text"
@@ -5178,6 +5184,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                                                       data-ouia-component-id="OUIA-Generated-DropdownToggle-2"
                                                       data-ouia-component-type="PF4/DropdownToggle"
                                                       data-ouia-safe="true"
+                                                      disabled=""
                                                       id="pagination-options-menu-bottom-toggle-3"
                                                       type="button"
                                                     >
@@ -5212,7 +5219,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                                               data-ouia-component-id="OUIA-Generated-DropdownToggle-2"
                                               data-ouia-component-type="PF4/DropdownToggle"
                                               data-ouia-safe={true}
-                                              disabled={0}
+                                              disabled={true}
                                               id="pagination-options-menu-bottom-toggle-3"
                                               onClick={[Function]}
                                               onKeyDown={[Function]}
@@ -5259,7 +5266,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                                 currPage="Current page"
                                 firstPage={1}
                                 isCompact={false}
-                                isDisabled={false}
+                                isDisabled={true}
                                 itemCount={0}
                                 lastPage={0}
                                 ofWord="of"

--- a/src/SmartComponents/Systems/Systems.js
+++ b/src/SmartComponents/Systems/Systems.js
@@ -22,7 +22,7 @@ import { remediationIdentifiers, systemsListDefaultFilters } from '../../Utiliti
 import {
     arrayFromObj, buildFilterChips,
     decodeQueryparams, filterRemediatableSystems, persistantParams, remediationProviderWithPairs, removeUndefinedObjectKeys,
-    transformPairs, systemsColumnsMerger
+    transformPairs, systemsColumnsMerger, checkEnabledFeature
 } from '../../Utilities/Helpers';
 import {
     setPageTitle, useBulkSelectConfig, useGetEntities, useOnExport,
@@ -51,6 +51,8 @@ const Systems = () => {
         isOpen: false,
         systemsIDs: []
     });
+
+    const isPatchSetEnabled = checkEnabledFeature('patchSet');
 
     const decodedParams = decodeQueryparams(history.location.search);
     const systems = useSelector(({ entities }) => entities?.rows || [], shallowEqual);
@@ -159,7 +161,7 @@ const Systems = () => {
             <Header title={intl.formatMessage(messages.titlesPatchSystems)} headerOUIA={'systems'} />
             <RemediationModalCmp />
             <SystemsStatusReport apply={apply} queryParams={queryParams}/>
-            {patchSetState.isOpen &&
+            {(patchSetState.isOpen && isPatchSetEnabled) &&
                 <PatchSetWizard systemsIDs={patchSetState.systemsIDs} setBaselineState={setBaselineState}/>}
             <Main>
                 {status.hasError && <ErrorHandler code={status.code} /> ||
@@ -192,7 +194,7 @@ const Systems = () => {
                                 });
                             }}
                             getEntities={getEntities}
-                            actions={systemsRowActions(showRemediationModal, showBaselineModal)}
+                            actions={systemsRowActions(showRemediationModal, showBaselineModal, isPatchSetEnabled)}
                             tableProps={{
                                 areActionsDisabled,
                                 canSelectAll: false,

--- a/src/SmartComponents/Systems/SystemsListAssets.js
+++ b/src/SmartComponents/Systems/SystemsListAssets.js
@@ -69,7 +69,7 @@ export const packageSystemsColumns = [
     }
 ];
 
-export const systemsRowActions = (showRemediationModal, showBaselineModal) => {
+export const systemsRowActions = (showRemediationModal, showBaselineModal, isPatchSetEnabled) => {
     return [
         {
             title: 'Apply all applicable advisories',
@@ -88,7 +88,7 @@ export const systemsRowActions = (showRemediationModal, showBaselineModal) => {
                 );
             }
         },
-        {
+        ...(isPatchSetEnabled && [{
             title: 'Assign to patch set',
             onClick: (event, rowId, rowData) => {
                 showBaselineModal(rowData);
@@ -99,6 +99,6 @@ export const systemsRowActions = (showRemediationModal, showBaselineModal) => {
             onClick: (event, rowId, rowData) => {
                 console.log(event, rowId, rowData);
             }
-        }
+        }] || [])
     ];
 };

--- a/src/SmartComponents/Systems/__snapshots__/System.test.js.snap
+++ b/src/SmartComponents/Systems/__snapshots__/System.test.js.snap
@@ -596,14 +596,6 @@ exports[`Systems.js should match the snapshot 1`] = `
                       "onClick": [Function],
                       "title": "Apply all applicable advisories",
                     },
-                    Object {
-                      "onClick": [Function],
-                      "title": "Assign to patch set",
-                    },
-                    Object {
-                      "onClick": [Function],
-                      "title": "Remove from patch set",
-                    },
                   ]
                 }
                 activeFiltersConfig={
@@ -996,6 +988,11 @@ exports[`Systems.js should match the snapshot 1`] = `
                 initialLoading={true}
                 isFullView={true}
                 onLoad={[Function]}
+                paginationProps={
+                  Object {
+                    "isDisabled": true,
+                  }
+                }
                 showTags={true}
                 tableProps={
                   Object {

--- a/src/Utilities/Helpers.js
+++ b/src/Utilities/Helpers.js
@@ -6,8 +6,7 @@ import {
     SecurityIcon
 } from '@patternfly/react-icons';
 import { SortByDirection } from '@patternfly/react-table/dist/js';
-import findIndex from 'lodash/findIndex';
-import flatten from 'lodash/findIndex';
+import { findIndex, flatten } from 'lodash';
 import qs from 'query-string';
 import React from 'react';
 import LinesEllipsis from 'react-lines-ellipsis';
@@ -19,7 +18,9 @@ import {
     advisorySeverities,
     compoundSortValues,
     filterCategories,
-    multiValueFilters
+    multiValueFilters,
+    featureFlags,
+    environments
 } from './constants';
 import { intl } from './IntlProvider';
 
@@ -562,4 +563,30 @@ export const systemsColumnsMerger = defaultColumns => {
     let nameAndTag = defaultColumns.filter(({ key }) => key === 'display_name' || key === 'tags');
 
     return [...nameAndTag, ...systemsListColumns, lastSeen[0]];
+};
+
+export const activateFeatureFlags = (location) => {
+    let environment = {};
+
+    environments.forEach(env => {
+        if (window.location.href.includes(env.key)) {
+            environment.name = env.name;
+        }
+    });
+
+    const enabledFeatures = featureFlags.filter(flag => {
+        return location.search.includes(flag.urlKey) || environment.name === 'dev' || 'stage';
+    });
+
+    localStorage.setItem('enabledFeatures', JSON.stringify(enabledFeatures));
+};
+
+export const checkEnabledFeature = (featureName) => {
+    const enabledFeatures = localStorage.getItem('enabledFeatures') ;
+
+    if (enabledFeatures && JSON.parse(enabledFeatures).find(feat => feat.name === featureName)) {
+        return true;
+    }
+
+    return false;
 };

--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -372,3 +372,25 @@ export const exportNotifications = (format) => ({
 });
 
 export const multiValueFilters = ['installed_evra', 'os'];
+
+export const environments = [
+    {
+        name: 'dev',
+        key: 'foo.redhat.com'
+    },
+    {
+        name: 'stage',
+        key: 'console.stage.redhat.com'
+    },
+    {
+        name: 'prod',
+        key: 'console.redhat.com'
+    }
+];
+
+export const featureFlags = [
+    {
+        name: 'patchSet',
+        urlKey: 'patch_set=enabled'
+    }
+];


### PR DESCRIPTION
This PR is intended to put patch set work under a feature flag. This feature is inteded to be released into prod in Q2. 

**activateFeatureFlag** is used in App.js once to enable flags using URL search params and environment substring. The function calculates what features are enabled and stores them in localStorage. Later **checkEnabledFeature** can be used in any component down in the DOM to check a single feature. 

 All features are by default enabled in development and stage environments. So that we do not have to enter url search param everytime if we want a certain feature. I do not see any reason to hide a feature in these environments.