### PR TITLE
chore(Travis): add custom release scripts

### DIFF
--- a/.travis/custom_release.sh
+++ b/.travis/custom_release.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+set -x
+
+# map master branch to stage-beta environment
+if [[ "${TRAVIS_BRANCH}" = "master" ]]; then
+    echo "PUSHING stage-beta"
+    rm -rf ./dist/.git
+    .travis/release.sh "stage-beta"
+fi
+
+if [[ "${TRAVIS_BRANCH}" = "stage-stable" || "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" ]]; then
+    echo "PUSHING ${TRAVIS_BRANCH}"
+    rm -rf ./build/.git
+    .travis/release.sh "${TRAVIS_BRANCH}"
+fi


### PR DESCRIPTION
After Node.js upgrade to  version 16, Travis CI build is failing. @leSamo had already this situation and suggested writing custom release. The PR is inspired by [Vulnerability](https://github.com/RedHatInsights/vulnerability-ui/blob/master/.travis/custom_release.sh). I am not familiar with Travis, so any improvements are highly welcome.