### PR TITLE
feat(PatchSet): put patch set work under feature flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@redhat-cloud-services/frontend-components-remediations": "^3.2.7",
         "@redhat-cloud-services/frontend-components-translations": "^3.2.4",
         "@redhat-cloud-services/frontend-components-utilities": "^3.1.1",
+        "@unleash/proxy-client-react": "^1.0.4",
         "axios": "^0.21.4",
         "classnames": "^2.2.6",
         "package-lock-only": "^0.0.4",
@@ -4481,6 +4482,11 @@
       "version": "21.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@unleash/proxy-client-react": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@unleash/proxy-client-react/-/proxy-client-react-1.0.4.tgz",
+      "integrity": "sha512-YDAiFHmZmb2Frk3UNi8AMdIAMwZGcm9VEhdJYi3ru5rsAYKbrN1BeJ6K3+PKOdOczg/leZH356djxVCc7sPyGA=="
     },
     "node_modules/@vue/compiler-core": {
       "version": "3.2.31",
@@ -28641,6 +28647,11 @@
     "@types/yargs-parser": {
       "version": "21.0.0",
       "dev": true
+    },
+    "@unleash/proxy-client-react": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@unleash/proxy-client-react/-/proxy-client-react-1.0.4.tgz",
+      "integrity": "sha512-YDAiFHmZmb2Frk3UNi8AMdIAMwZGcm9VEhdJYi3ru5rsAYKbrN1BeJ6K3+PKOdOczg/leZH356djxVCc7sPyGA=="
     },
     "@vue/compiler-core": {
       "version": "3.2.31",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@redhat-cloud-services/frontend-components-remediations": "^3.2.7",
     "@redhat-cloud-services/frontend-components-translations": "^3.2.4",
     "@redhat-cloud-services/frontend-components-utilities": "^3.1.1",
+    "@unleash/proxy-client-react": "^1.0.4",
     "axios": "^0.21.4",
     "classnames": "^2.2.6",
     "package-lock-only": "^0.0.4",

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -4,6 +4,8 @@ import React, { Fragment, lazy, Suspense, useState } from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import { fetchSystems } from './Utilities/api';
 import { useHistory } from 'react-router-dom';
+import { useFeatureFlag } from './Utilities/Hooks';
+import { featureFlags } from './Utilities/constants';
 
 const Advisories = lazy(() =>
     import(
@@ -116,6 +118,8 @@ export const Routes = (props) => {
 
     const path = props.childProps.location.pathname;
 
+    const isPatchSetEnabled = useFeatureFlag(featureFlags.patch_set);
+
     return (
         // I recommend discussing with UX some nice loading placeholder
         <Suspense fallback={Fragment}>
@@ -158,15 +162,15 @@ export const Routes = (props) => {
                     path={paths.packageDetail.to}
                     component={PackageDetail}
                 />
-                <Route
+                {isPatchSetEnabled && <Route
                     exact
                     path={paths.patchSet.to}
                     component={PatchSet}
-                />
+                />}
 
                 <Route
                     render={() =>
-                        some(paths, p => p.to === path) || (
+                        (!isPatchSetEnabled || !some(paths, p => p.to === path)) && (
                             <Redirect to={paths.advisories.to} />
                         )
                     }

--- a/src/SmartComponents/AdvisorySystems/AdvisorySystems.js
+++ b/src/SmartComponents/AdvisorySystems/AdvisorySystems.js
@@ -127,7 +127,7 @@ const AdvisorySystems = ({ advisoryName }) => {
                     initialLoading
                     ignoreRefresh
                     hideFilters={{ all: true, tags: false }}
-                    columns={systemsColumnsMerger}
+                    columns={(defaultColumns) => systemsColumnsMerger(defaultColumns, false)}
                     showTags
                     customFilters={{
                         patchParams: {
@@ -143,7 +143,7 @@ const AdvisorySystems = ({ advisoryName }) => {
                     onLoad={({ mergeWithEntities }) => {
                         register({
                             ...mergeWithEntities(
-                                inventoryEntitiesReducer(systemsListColumns, modifyInventory),
+                                inventoryEntitiesReducer(systemsListColumns(false), modifyInventory),
                                 persistantParams({ page, perPage, sort, search }, decodedParams)
                             )
                         });

--- a/src/SmartComponents/Systems/System.test.js
+++ b/src/SmartComponents/Systems/System.test.js
@@ -6,6 +6,7 @@ import { systemRows } from '../../Utilities/RawDataForTesting';
 import { initMocks } from '../../Utilities/unitTestingUtilities.js';
 import Systems from './Systems';
 import toJson from 'enzyme-to-json';
+import { useFeatureFlag } from '../../Utilities/Hooks';
 
 initMocks();
 
@@ -50,6 +51,11 @@ jest.mock('../../Utilities/api', () => ({
             type: 'advisory'
         }]
     }).catch((err) => console.log(err)))
+}));
+
+jest.mock('../../Utilities/Hooks', () => ({
+    ...jest.requireActual('../../Utilities/Hooks'),
+    useFeatureFlag: jest.fn()
 }));
 
 const mockState = {
@@ -158,5 +164,29 @@ describe('Systems.js', () => {
         </Provider>);
 
         expect(tempWrapper.find('EmptyState')).toBeTruthy();
+    });
+
+    describe('test patch-set: ', () => {
+        it('Should show table row actions for patch-set when flag is enabled', () => {
+            useFeatureFlag.mockReturnValue(true);
+
+            const tempWrapper = mount(<Provider store={store}>
+                <Router><Systems /></Router>
+            </Provider>);
+
+            const { actions } = tempWrapper.find('.testInventroyComponentChild').parent().props();
+            expect(actions.length).toEqual(2);
+        });
+
+        it('Should hide table row actions for patch-set when flag is disabled', () => {
+            useFeatureFlag.mockReturnValue(false);
+
+            const tempWrapper = mount(<Provider store={store}>
+                <Router><Systems /></Router>
+            </Provider>);
+
+            const { actions } = tempWrapper.find('.testInventroyComponentChild').parent().props();
+            expect(actions.length).toEqual(1);
+        });
     });
 });

--- a/src/SmartComponents/Systems/SystemListAssets.test.js
+++ b/src/SmartComponents/Systems/SystemListAssets.test.js
@@ -17,7 +17,7 @@ jest.mock('../../Utilities/api', () => ({
 describe('SystemListAssets.js', () => {
 
     it('Should call systemsListColumns on Applicable advisories renderFunc with correct params', () => {
-        systemsListColumns[3].renderFunc('testValue');
+        systemsListColumns(false)[2].renderFunc('testValue');
         expect(createAdvisoriesIcons).toHaveBeenCalledWith('testValue');
     });
 

--- a/src/SmartComponents/Systems/SystemsListAssets.js
+++ b/src/SmartComponents/Systems/SystemsListAssets.js
@@ -4,15 +4,15 @@ import { createAdvisoriesIcons, createUpgradableColumn,
     remediationProvider, createOSColumn, createPatchSetColumn } from '../../Utilities/Helpers';
 import './SystemsListAssets.scss';
 
-export const systemsListColumns = [
-    {
+export const systemsListColumns = (isPatchSetEnabled = false) => [
+    ...(isPatchSetEnabled ? [{
         key: 'baseline_name',
         title: 'Patch set',
         renderFunc: value => createPatchSetColumn(value),
         props: {
             width: 5
         }
-    },
+    }] : []),
     {
         key: 'operating_system',
         title: 'OS',
@@ -77,7 +77,7 @@ export const packageSystemsColumns = [
     }
 ];
 
-export const systemsRowActions = (showRemediationModal, showBaselineModal) => {
+export const systemsRowActions = (showRemediationModal, showBaselineModal, isPatchSetEnabled) => {
     return [
         {
             title: 'Apply all applicable advisories',
@@ -96,11 +96,11 @@ export const systemsRowActions = (showRemediationModal, showBaselineModal) => {
                 );
             }
         },
-        ...showBaselineModal ? [{
+        ...(isPatchSetEnabled && showBaselineModal ? [{
             title: 'Assign to patch set',
             onClick: (event, rowId, rowData) => {
                 showBaselineModal(rowData);
             }
-        }] : []
+        }] : [])
     ];
 };

--- a/src/SmartComponents/Systems/__snapshots__/System.test.js.snap
+++ b/src/SmartComponents/Systems/__snapshots__/System.test.js.snap
@@ -602,23 +602,7 @@ exports[`Systems.js should match the snapshot 1`] = `
                       "onClick": [Function],
                       "title": "Apply all applicable advisories",
                     },
-                    Object {
-                      "onClick": [Function],
-                      "title": "Assign to patch set",
-                    },
                   ]
-                }
-                actionsConfig={
-                  Object {
-                    "actions": Array [
-                      <Button
-                        isDisabled={false}
-                        onClick={[Function]}
-                      >
-                        Assign to patch sets
-                      </Button>,
-                    ],
-                  }
                 }
                 activeFiltersConfig={
                   Object {

--- a/src/Utilities/Helpers.js
+++ b/src/Utilities/Helpers.js
@@ -6,8 +6,7 @@ import {
     SecurityIcon, PficonTemplateIcon
 } from '@patternfly/react-icons';
 import { SortByDirection } from '@patternfly/react-table/dist/js';
-import findIndex from 'lodash/findIndex';
-import flatten from 'lodash/findIndex';
+import { findIndex, flatten } from 'lodash';
 import qs from 'query-string';
 import React from 'react';
 import LinesEllipsis from 'react-lines-ellipsis';
@@ -569,13 +568,13 @@ export const mapGlobalFilters = (tags, SIDs, workloads = {}) => {
 
 };
 
-export const systemsColumnsMerger = defaultColumns => {
+export const systemsColumnsMerger = (defaultColumns, isPatchSetEnabled) => {
     let lastSeen = defaultColumns.filter(({ key }) => key === 'updated');
     lastSeen = [{ ...lastSeen[0], key: 'last_upload' }];
 
     let nameAndTag = defaultColumns.filter(({ key }) => key === 'display_name' || key === 'tags');
 
-    return [...nameAndTag, ...systemsListColumns, lastSeen[0]];
+    return [...nameAndTag, ...systemsListColumns(isPatchSetEnabled), lastSeen[0]];
 };
 
 export const convertDateToISO = (dateString)  => {

--- a/src/Utilities/Hooks.js
+++ b/src/Utilities/Hooks.js
@@ -12,6 +12,7 @@ import {
 import { intl } from './IntlProvider';
 import { multiValueFilters } from '../Utilities/constants';
 import { assignSystemPatchSet, updatePatchSets } from './api';
+import { useFlag, useFlagsStatus } from '@unleash/proxy-client-react';
 
 export const useSetPage = (limit, callback) => {
     const onSetPage = React.useCallback((_, page) =>
@@ -334,4 +335,10 @@ export const usePatchSetApi = (wizardState, setWizardState, patchSetID) => {
         handleApiResponse(response);
     });
     return onSubmit;
+};
+
+export const useFeatureFlag = (flag) => {
+    const { flagsReady } = useFlagsStatus();
+    const flagStatus = useFlag(flag);
+    return flagsReady ? flagStatus : false;
 };

--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -383,3 +383,8 @@ export const patchSetDeleteNotifications = ({
 });
 
 export const multiValueFilters = ['installed_evra', 'os'];
+
+export const featureFlags = {
+    patch_set: 'patch.patch_set'
+};
+


### PR DESCRIPTION
The PR enables using Unleash feature flags provided by the platform to manage path-sets feature. Current version of the Unleash is old, thus we are using only default enablement strategy. It only enables or disables the flag for now. There is a [ticket](https://issues.redhat.com/browse/APPSRE-3449) to upgrade its version. 

In order to enable/disable the flag you would need access to [Unleash instance](https://insights-stage.unleash.devshift.net/#/features/strategies/patch.patch_set) provided by app-sre. You will need to add these lines to your app-sre profile.

- $ref: /teams/insights/roles/insights-stage-unleash-admin.yml
- $ref: /teams/insights/roles/insights-unleash-admin.yml
- $ref: /teams/insights/roles/unleash-proxy.yml

For the sake of simplicity, you can test the PR by simply hard coding the flag value in the code. 