### PR TITLE
chore(SIDs): change SIDs filter from comma separated values to single…

### DIFF
--- a/src/Utilities/Helpers.js
+++ b/src/Utilities/Helpers.js
@@ -245,14 +245,16 @@ export const getFilterValue = (category, key) => {
 };
 
 export const encodeParams = (parameters, shouldTranslateKeys) => {
-    const calculateWorkloads = (systemProfile) => {
+    const calculateWorkloads = ({ sap_sids, ...restOfProfile }) => {
         let result = '';
-        Object.entries(generateFilter({ system_profile: systemProfile })).forEach(entry => {
+        Object.entries(generateFilter({ system_profile: restOfProfile })).forEach(entry => {
             const [key, value] = entry;
             result = `${result}&${key}=${value}`;
         });
 
-        return result;
+        const SIDsFilter = sap_sids?.map(sid => `filter[system_profile][sap_sids][in]=${sid}`).join('&');
+
+        return result.concat(sap_sids ? `&${SIDsFilter}#SIDs=${sap_sids.join(',') }` : '');
     };
 
     const flattenFilters = filter => {
@@ -560,7 +562,7 @@ export const mapGlobalFilters = (tags, SIDs, workloads = {}) => {
         && { ansible: { controller_version: 'not_nil' } },
         ...workloads?.['Microsoft SQL']?.isSelected
         && { mssql: { version: 'not_nil' } },
-        ...SIDs?.length > 0 && { sap_sids: `in:${SIDs.join(',')}` }
+        ...SIDs?.length > 0 && { sap_sids: SIDs }
     };
 
     tagsInUrlFormat && (globalFilterConfig.selectedTags = tagsInUrlFormat);

--- a/src/Utilities/Helpers.test.js
+++ b/src/Utilities/Helpers.test.js
@@ -295,9 +295,9 @@ describe('Test global filters', () => {
     ${[]}                              | ${[]}              | ${{ 'Ansible Automation Platform': { isSelected: true } }}                | ${{ selectedTags: [], systemProfile: { ansible: { controller_version: 'not_nil' } } }}
     ${[]}                              | ${[]}              | ${{ 'Microsoft SQL': { isSelected: true } }}                              | ${{ selectedTags: [], systemProfile: { mssql: { version: 'not_nil' } }  }}
     ${[]}                              | ${[]}              | ${{ SAP: { isSelected: true } }}                                          | ${{ selectedTags: [], systemProfile: { sap_system: true } }}
-    ${[]}                              | ${['abc']}         | ${{ SAP: { isSelected: true } }}                                          | ${{ selectedTags: [], systemProfile: { sap_sids: 'in:abc', sap_system: true } }}
-    ${[]}                              | ${['abc', 'bca']}  | ${{ SAP: { isSelected: true }, 'Microsoft SQL': { isSelected: true } }}   | ${{ selectedTags: [], systemProfile: { sap_sids: 'in:abc,bca', sap_system: true, mssql: { version: 'not_nil' } } }}
-    ${['null/key.BnZPeP=tag.MNGmxQ']}  | ${['abc', 'bca']}  | ${{ SAP: { isSelected: true } }}                                              | ${{ selectedTags: ["tags=null%2Fkey.BnZPeP%3Dtag.MNGmxQ"], systemProfile: { sap_sids: 'in:abc,bca', sap_system: true } }}
+    ${[]}                              | ${['abc']}         | ${{ SAP: { isSelected: true } }}                                          | ${{ selectedTags: [], systemProfile: { sap_sids: ['abc'], sap_system: true } }}
+    ${[]}                              | ${['abc', 'bca']}  | ${{ SAP: { isSelected: true }, 'Microsoft SQL': { isSelected: true } }}   | ${{ selectedTags: [], systemProfile: { sap_sids: ['abc', 'bca'], sap_system: true, mssql: { version: 'not_nil' } } }}
+    ${['null/key.BnZPeP=tag.MNGmxQ']}  | ${['abc', 'bca']}  | ${{ SAP: { isSelected: true } }}                                              | ${{ selectedTags: ["tags=null%2Fkey.BnZPeP%3Dtag.MNGmxQ"], systemProfile: { sap_sids: ['abc', 'bca'], sap_system: true } }}
      `('mapGlobalFilters: Should build correct global filters, $tags, $SIDs, $workloads ', ({ tags, SIDs, workloads, result }) => {
          expect(mapGlobalFilters(tags, SIDs, workloads,)).toEqual(result);
     });


### PR DESCRIPTION
Using the shared [generateFilter](https://github.com/RedHatInsights/patchman-ui/commit/efa5df4cbaf8caac2805f417f526b2d53c36617d#diff-4966f4e1c143ce9542deb4f826c300c57035c4fc796c615b9dd65aad9c3ce09bR250) caused SIDs filter to change to comma separated multivalue filter (`filter[system_profile][sid_filter][in]=a,v`). The engine team asked to avoid this pattern due to perfomance issues. This PR brings back original single value filters pattern: `filter[system_profile][sap_sids][in]=AV1&filter[system_profile][sap_sids][in]=AV2&limit=1&offset=0`