### PR TITLE
Integrate patch set

### DIFF
--- a/src/Messages.js
+++ b/src/Messages.js
@@ -71,6 +71,11 @@ export default defineMessages({
         description: 'shared label',
         defaultMessage: 'Name'
     },
+    labelsColumnsPatchSet: {
+        id: 'labelsColumnsPatchSet',
+        description: 'Label for patch set column',
+        defaultMessage: 'Patch set'
+    },
     labelsColumnsPublishDate: {
         id: 'labelsColumnsPublishDate',
         description: 'shared label',

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -4,8 +4,6 @@ import React, { Fragment, lazy, Suspense, useState } from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import { fetchSystems } from './Utilities/api';
 import { useHistory } from 'react-router-dom';
-import { useFeatureFlag } from './Utilities/Hooks';
-import { featureFlags } from './Utilities/constants';
 
 const Advisories = lazy(() =>
     import(
@@ -118,8 +116,6 @@ export const Routes = (props) => {
 
     const path = props.childProps.location.pathname;
 
-    const isPatchSetEnabled = useFeatureFlag(featureFlags.patch_set);
-
     return (
         // I recommend discussing with UX some nice loading placeholder
         <Suspense fallback={Fragment}>
@@ -162,15 +158,15 @@ export const Routes = (props) => {
                     path={paths.packageDetail.to}
                     component={PackageDetail}
                 />
-                {isPatchSetEnabled && <Route
+                <Route
                     exact
                     path={paths.patchSet.to}
                     component={PatchSet}
-                />}
+                />
 
                 <Route
                     render={() =>
-                        (!isPatchSetEnabled || !some(paths, p => p.to === path)) && (
+                        !some(paths, p => p.to === path) && (
                             <Redirect to={paths.advisories.to} />
                         )
                     }

--- a/src/SmartComponents/PatchSetWizard/WizardAssets.js
+++ b/src/SmartComponents/PatchSetWizard/WizardAssets.js
@@ -7,14 +7,21 @@ export const reviewSystemColumns = [{
     key: 'display_name',
     title: 'Name',
     props: {
-        width: 40
+        width: 50
     }
 },
 {
     title: 'OS',
     key: 'os',
     props: {
-        width: 60
+        width: 25
+    }
+},
+{
+    key: 'baseline_name',
+    title: 'Patch set',
+    props: {
+        width: 25
     }
 }
 ];

--- a/src/SmartComponents/PatchSetWizard/steps/ReviewSystems.js
+++ b/src/SmartComponents/PatchSetWizard/steps/ReviewSystems.js
@@ -11,10 +11,13 @@ import { createSortBy, buildSelectedSystemsObj } from '../../../Utilities/Helper
 import { createSystemsRowsReview } from '../../../Utilities/DataMappers';
 import { useOnSelect, usePerPageSelect, useSetPage, useSortColumn } from '../../../Utilities/Hooks';
 import TableView from '../../../PresentationalComponents/TableView/TableView';
+import staleFilter from '../../../PresentationalComponents/Filters/SystemStaleFilter';
+import systemsUpdatableFilter from '../../../PresentationalComponents/Filters/SystemsUpdatableFilter';
 import { fetchSystems } from '../../../Utilities/api';
 import { reviewSystemColumns } from '../WizardAssets';
 import messages from '../../../Messages';
 import { intl } from '../../../Utilities/IntlProvider';
+import { systemsListDefaultFilters } from '../../../Utilities/constants';
 
 export const ReviewSystems = ({ systemsIDs = [], ...props }) => {
     const { input } = useFieldApi(props);
@@ -35,7 +38,9 @@ export const ReviewSystems = ({ systemsIDs = [], ...props }) => {
     const [queryParams, setQueryParams] = useState({
         page: 1,
         perPage: 20,
-        filter: {}
+        filter: {
+            stale: [true, false]
+        }
     });
 
     const { assignedSystems } = useSelector(({ SpecificPatchSetReducer }) => SpecificPatchSetReducer, shallowEqual);
@@ -71,7 +76,7 @@ export const ReviewSystems = ({ systemsIDs = [], ...props }) => {
 
     const apply = (params) => {
         setLoading(true);
-        setQueryParams({ ...queryParams, ...params });
+        setQueryParams((prevQueryParams) => ({ ...prevQueryParams, ...params }));
     };
 
     const onSort = useSortColumn(reviewSystemColumns, apply, 1);
@@ -129,10 +134,13 @@ export const ReviewSystems = ({ systemsIDs = [], ...props }) => {
                                 intl.formatMessage(messages.labelsFiltersSystemsSearchTitle),
                                 intl.formatMessage(messages.labelsFiltersSearch)
                             ),
+                            staleFilter(apply, queryParams.filter),
+                            systemsUpdatableFilter(apply, queryParams.filter),
                             osVersionFilter(queryParams.filter, apply)
                         ]
                     }}
                     searchChipLabel={intl.formatMessage(messages.labelsFiltersSystemsSearchTitle)}
+                    defaultFilters={systemsListDefaultFilters}
                 />
             </StackItem>
         </Stack>

--- a/src/SmartComponents/SystemDetail/InventoryDetail.js
+++ b/src/SmartComponents/SystemDetail/InventoryDetail.js
@@ -9,7 +9,7 @@ import { intl } from '../../Utilities/IntlProvider';
 import messages from '../../Messages';
 import { setPageTitle, useFeatureFlag } from '../../Utilities/Hooks';
 import { InventoryDetailHead, AppInfo, DetailWrapper } from '@redhat-cloud-services/frontend-components/Inventory';
-import { Alert } from '@patternfly/react-core';
+import { Alert, Grid, GridItem, TextContent, Text } from '@patternfly/react-core';
 import { fetchSystemDetailsAction } from '../../store/Actions/Actions';
 import propTypes from 'prop-types';
 import { clearNotifications } from '@redhat-cloud-services/frontend-components-notifications/redux';
@@ -30,8 +30,8 @@ const InventoryDetail = ({ match }) => {
         ({ entityDetails }) => entityDetails && entityDetails.entity
     );
 
-    const hasThirdPartyRepo = useSelector(
-        ({ entityDetails }) => entityDetails && entityDetails.hasThirdPartyRepo
+    const { hasThirdPartyRepo, patchSetName } = useSelector(
+        ({ entityDetails }) => entityDetails ?? {}
     );
     const entityId = match.params?.inventoryId;
     useEffect(() => {
@@ -73,18 +73,31 @@ const InventoryDetail = ({ match }) => {
                     }
                 ]}
             >
-                <InventoryDetailHead hideBack actions={isPatchSetEnabled && [
-                    {
-                        title: intl.formatMessage(messages.titlesPatchSetAssignMultipleButton),
-                        key: 'assign-to-patch-set',
-                        onClick: showBaselineModal
-                    }]}
+                <InventoryDetailHead hideBack
+                    showTags
+                    actions={isPatchSetEnabled && [
+                        {
+                            title: intl.formatMessage(messages.titlesPatchSetAssignMultipleButton),
+                            key: 'assign-to-patch-set',
+                            onClick: showBaselineModal
+                        }]}
                 >
-                    { hasThirdPartyRepo &&
-                        (<Alert className='pf-u-mt-md' isInline variant="info"
-                            title={intl.formatMessage(messages.textThirdPartyInfo)}>
-                        </Alert>)
-                    }
+                    <Grid>
+                        <GridItem>
+                            <TextContent>
+                                <Text>
+                                    {`${intl.formatMessage(messages.labelsColumnsPatchSet)}: ${patchSetName}`}
+                                </Text>
+                            </TextContent>
+                        </GridItem>
+                        <GridItem>
+                            {hasThirdPartyRepo &&
+                                (<Alert className='pf-u-mt-md' isInline variant="info"
+                                    title={intl.formatMessage(messages.textThirdPartyInfo)}>
+                                </Alert>)
+                            }
+                        </GridItem>
+                    </Grid>
                 </InventoryDetailHead>
             </Header>
             <Main>

--- a/src/SmartComponents/SystemDetail/__snapshots__/InventoryDetail.test.js.snap
+++ b/src/SmartComponents/SystemDetail/__snapshots__/InventoryDetail.test.js.snap
@@ -197,6 +197,7 @@ exports[`InventoryPage.js Should match the snapshots 1`] = `
                     </PageHeaderTitle>
                     <mockConstructor
                       hideBack={true}
+                      showTags={true}
                     >
                       <div
                         className="testInventoryDetailHead"

--- a/src/SmartComponents/Systems/Systems.js
+++ b/src/SmartComponents/Systems/Systems.js
@@ -192,7 +192,7 @@ const Systems = () => {
                             autoRefresh
                             initialLoading
                             hideFilters={{ all: true, tags: false }}
-                            columns={(defaultColumns) => systemsColumnsMerger(defaultColumns, isPatchSetEnabled)}
+                            columns={(defaultColumns) => systemsColumnsMerger(defaultColumns, true)}
                             showTags
                             customFilters={{
                                 patchParams: {

--- a/src/SmartComponents/Systems/SystemsListAssets.js
+++ b/src/SmartComponents/Systems/SystemsListAssets.js
@@ -1,14 +1,13 @@
 import { fetchApplicableSystemAdvisoriesApi } from '../../Utilities/api';
 import { remediationIdentifiers } from '../../Utilities/constants';
 import { createAdvisoriesIcons, createUpgradableColumn,
-    remediationProvider, createOSColumn, createPatchSetColumn } from '../../Utilities/Helpers';
+    remediationProvider, createOSColumn } from '../../Utilities/Helpers';
 import './SystemsListAssets.scss';
 
 export const systemsListColumns = (isPatchSetEnabled = false) => [
     ...(isPatchSetEnabled ? [{
         key: 'baseline_name',
         title: 'Patch set',
-        renderFunc: value => createPatchSetColumn(value),
         props: {
             width: 5
         }

--- a/src/Utilities/DataMappers.js
+++ b/src/Utilities/DataMappers.js
@@ -10,7 +10,7 @@ import { EmptyAdvisoryList, EmptyCvesList, EmptyPackagesList,
     EmptyPatchSetList, NoPatchSetList, EmptySystemsList } from '../PresentationalComponents/Snippets/EmptyStates';
 import { SystemUpToDate } from '../PresentationalComponents/Snippets/SystemUpToDate';
 import { advisorySeverities, entityTypes } from './constants';
-import { createUpgradableColumn, handleLongSynopsis, handlePatchLink } from './Helpers';
+import { createUpgradableColumn, handleLongSynopsis, handlePatchLink, createPatchSetColumnWizard } from './Helpers';
 import { intl } from './IntlProvider';
 
 export const createAdvisoriesRows = (rows, expandedRows, selectedRows) => {
@@ -316,6 +316,9 @@ export const createSystemsRowsReview = (rows, selectedRows) => {
                     },
                     {
                         title: attributes.os
+                    },
+                    {
+                        title: createPatchSetColumnWizard(attributes.baseline_name)
                     }
                 ]
             };

--- a/src/Utilities/DataMappers.js
+++ b/src/Utilities/DataMappers.js
@@ -10,7 +10,7 @@ import { EmptyAdvisoryList, EmptyCvesList, EmptyPackagesList,
     EmptyPatchSetList, NoPatchSetList, EmptySystemsList } from '../PresentationalComponents/Snippets/EmptyStates';
 import { SystemUpToDate } from '../PresentationalComponents/Snippets/SystemUpToDate';
 import { advisorySeverities, entityTypes } from './constants';
-import { createUpgradableColumn, handleLongSynopsis, handlePatchLink, createPatchSetColumnWizard } from './Helpers';
+import { createUpgradableColumn, handleLongSynopsis, handlePatchLink } from './Helpers';
 import { intl } from './IntlProvider';
 
 export const createAdvisoriesRows = (rows, expandedRows, selectedRows) => {
@@ -318,7 +318,7 @@ export const createSystemsRowsReview = (rows, selectedRows) => {
                         title: attributes.os
                     },
                     {
-                        title: createPatchSetColumnWizard(attributes.baseline_name)
+                        title: attributes.baseline_name
                     }
                 ]
             };

--- a/src/Utilities/Helpers.js
+++ b/src/Utilities/Helpers.js
@@ -632,3 +632,15 @@ export const createPatchSetColumn = (value) => value && (
         <PficonTemplateIcon size="sm" color={'var(--pf-global--info-color--100)'} />
     </Tooltip>
 );
+
+export const createPatchSetColumnWizard = (value) => value && (
+    <Flex flex={{ default: 'inlineFlex' }} style={{ flexWrap: 'nowrap' }}>
+        <FlexItem spacer={{ default: 'spacerSm' }}>
+            <PficonTemplateIcon size="sm" color={'var(--pf-global--info-color--100)'} />
+        </FlexItem>
+        <FlexItem spacer={{ default: 'spacerSm' }}>
+            {value}
+        </FlexItem>
+    </Flex>
+
+);

--- a/src/Utilities/Helpers.js
+++ b/src/Utilities/Helpers.js
@@ -3,7 +3,7 @@ import { Flex, FlexItem, Tooltip } from '@patternfly/react-core';
 import {
     BugIcon, CheckIcon, FlagIcon,
     EnhancementIcon, InfoCircleIcon, LongArrowAltUpIcon,
-    SecurityIcon, PficonTemplateIcon
+    SecurityIcon
 } from '@patternfly/react-icons';
 import { SortByDirection } from '@patternfly/react-table/dist/js';
 import { findIndex, flatten } from 'lodash';
@@ -627,20 +627,3 @@ export const objUndefinedToFalse = (object) =>
         return modifiedObject;
     }, {});
 
-export const createPatchSetColumn = (value) => value && (
-    <Tooltip content={value} position='right'>
-        <PficonTemplateIcon size="sm" color={'var(--pf-global--info-color--100)'} />
-    </Tooltip>
-);
-
-export const createPatchSetColumnWizard = (value) => value && (
-    <Flex flex={{ default: 'inlineFlex' }} style={{ flexWrap: 'nowrap' }}>
-        <FlexItem spacer={{ default: 'spacerSm' }}>
-            <PficonTemplateIcon size="sm" color={'var(--pf-global--info-color--100)'} />
-        </FlexItem>
-        <FlexItem spacer={{ default: 'spacerSm' }}>
-            {value}
-        </FlexItem>
-    </Flex>
-
-);

--- a/src/store/Reducers/SystemDetailStore.js
+++ b/src/store/Reducers/SystemDetailStore.js
@@ -10,6 +10,7 @@ export const SystemDetailStore = (state = initialState, { type, payload }) => {
     switch (type) {
         case 'FETCH_SYSTEM_DETAIL_FULFILLED':
             state.hasThirdPartyRepo = payload.data?.attributes.third_party;
+            state.patchSetName = payload.data?.attributes.baseline_name;
             return state;
         case 'LOAD_ENTITY_FULFILLED':
             return {


### PR DESCRIPTION
This PR will add:

-  patch set info on Inventory detail header.
-  status and patch status filters into Review systems table in the patch set wizard.
-  default filters into Review systems table  in the patch set wizard.
-  patch set column into Review systems table  in the patch set wizard.
- remove feature flags for the Patch set table.