### PR TITLE
chore(InventoryDetail) remove feature flag, show patch set only when it is present

### DIFF
--- a/src/SmartComponents/SystemDetail/InventoryDetail.js
+++ b/src/SmartComponents/SystemDetail/InventoryDetail.js
@@ -7,17 +7,15 @@ import { register } from '../../store';
 import { SystemDetailStore } from '../../store/Reducers/SystemDetailStore';
 import { intl } from '../../Utilities/IntlProvider';
 import messages from '../../Messages';
-import { setPageTitle, useFeatureFlag } from '../../Utilities/Hooks';
+import { setPageTitle } from '../../Utilities/Hooks';
 import { InventoryDetailHead, AppInfo, DetailWrapper } from '@redhat-cloud-services/frontend-components/Inventory';
 import { Alert, Grid, GridItem, TextContent, Text } from '@patternfly/react-core';
 import { fetchSystemDetailsAction } from '../../store/Actions/Actions';
 import propTypes from 'prop-types';
-import { clearNotifications } from '@redhat-cloud-services/frontend-components-notifications/redux';
-import { featureFlags } from '../../Utilities/constants';
+import { clearNotifications } from '@redhat-cloud-services/frontend-components-notifications/redux';;
 import PatchSetWizard from '../PatchSetWizard/PatchSetWizard';
 
 const InventoryDetail = ({ match }) => {
-    const isPatchSetEnabled = useFeatureFlag(featureFlags.patch_set);
 
     const [patchSetState, setBaselineState] = React.useState({
         isOpen: false,
@@ -56,7 +54,7 @@ const InventoryDetail = ({ match }) => {
                 });
             }}
         >
-            {(patchSetState.isOpen && isPatchSetEnabled) &&
+            {(patchSetState.isOpen) &&
                 <PatchSetWizard systemsIDs={patchSetState.systemsIDs} setBaselineState={setBaselineState} />}
             <Header
                 title=""
@@ -75,7 +73,7 @@ const InventoryDetail = ({ match }) => {
             >
                 <InventoryDetailHead hideBack
                     showTags
-                    actions={isPatchSetEnabled && [
+                    actions={[
                         {
                             title: intl.formatMessage(messages.titlesPatchSetAssignMultipleButton),
                             key: 'assign-to-patch-set',
@@ -84,11 +82,12 @@ const InventoryDetail = ({ match }) => {
                 >
                     <Grid>
                         <GridItem>
-                            <TextContent>
+                            {patchSetName && <TextContent>
                                 <Text>
                                     {`${intl.formatMessage(messages.labelsColumnsPatchSet)}: ${patchSetName}`}
                                 </Text>
                             </TextContent>
+                            }
                         </GridItem>
                         <GridItem>
                             {hasThirdPartyRepo &&

--- a/src/SmartComponents/SystemDetail/InventoryDetail.test.js
+++ b/src/SmartComponents/SystemDetail/InventoryDetail.test.js
@@ -65,34 +65,5 @@ describe('InventoryPage.js', () => {
     it('Should match the snapshots', () => {
         expect(toJson(wrapper.update())).toMatchSnapshot();
     });
-
-    describe('test patch-set: ', () => {
-        it('Should hide actions dropdown for patch-set when flag is disabled', () => {
-            useFeatureFlag.mockReturnValue(false);
-
-            const tempWrapper = mount(<Provider store={store}>
-                <Router><InventoryDetail match={{ params: { inventoryId: 'test' } }} /></Router>
-            </Provider>);
-
-            const { actions } = tempWrapper.find('.testInventoryDetailHead').parent().props();
-
-            expect(actions).toBeFalsy();
-            expect(tempWrapper.update().find('.patch-set').length).toBe(0);
-        });
-
-        it('Should show actions dropdown for patch-set when flag is enabled', () => {
-            useFeatureFlag.mockReturnValue(true);
-
-            const tempWrapper = mount(<Provider store={store}>
-                <Router><InventoryDetail match={{ params: { inventoryId: 'test' } }} /></Router>
-            </Provider>);
-
-            const { actions } = tempWrapper.find('.testInventoryDetailHead').parent().props();
-            actions[0].onClick();
-
-            expect(actions.length).toEqual(1);
-            expect(tempWrapper.update().find('.patch-set').length).toBe(2);
-        });
-    });
 });
 

--- a/src/SmartComponents/SystemDetail/__snapshots__/InventoryDetail.test.js.snap
+++ b/src/SmartComponents/SystemDetail/__snapshots__/InventoryDetail.test.js.snap
@@ -196,6 +196,15 @@ exports[`InventoryPage.js Should match the snapshots 1`] = `
                       </Title>
                     </PageHeaderTitle>
                     <mockConstructor
+                      actions={
+                        Array [
+                          Object {
+                            "key": "assign-to-patch-set",
+                            "onClick": [Function],
+                            "title": "Assign to patch sets",
+                          },
+                        ]
+                      }
                       hideBack={true}
                       showTags={true}
                     >

--- a/src/Utilities/DataMappers.js
+++ b/src/Utilities/DataMappers.js
@@ -194,7 +194,7 @@ export const createPackageSystemsRows = (rows, selectedRows = {}) => {
 };
 
 export const createSystemPackagesRows = (rows, selectedRows = {}) => {
-    if (rows.length !== 0) {
+    if (rows && rows.length !== 0) {
         return rows.map(pkg => {
             const pkgNEVRA = `${pkg.name}-${pkg.evra}`;
             const pkgUpdates = pkg.updates || [];


### PR DESCRIPTION
I had discussion with UX and they agreed to remove completely patch set info on System detail header when it is not present.

Also this PR removes patch set flag **Assign to patch set** on system detail actions. 