### PR TITLE
chore(ReviewSystems): fix filters breaking the page

### DIFF
--- a/src/SmartComponents/PatchSetWizard/steps/ReviewSystems.js
+++ b/src/SmartComponents/PatchSetWizard/steps/ReviewSystems.js
@@ -76,7 +76,11 @@ export const ReviewSystems = ({ systemsIDs = [], ...props }) => {
 
     const apply = (params) => {
         setLoading(true);
-        setQueryParams((prevQueryParams) => ({ ...prevQueryParams, ...params }));
+        setQueryParams((prevQueryParams) => ({
+            ...prevQueryParams,
+            ...params,
+            filter: { ...prevQueryParams.filter, ...params.filter }
+        }));
     };
 
     const onSort = useSortColumn(reviewSystemColumns, apply, 1);

--- a/src/Utilities/Helpers.js
+++ b/src/Utilities/Helpers.js
@@ -351,6 +351,11 @@ export const buildFilterChips = (filters, search, searchChipLabel = 'Search') =>
             }));
         } else {
             const { values } = filterCategories[category];
+
+            if (!filters[category]) {
+                return [];
+            }
+
             return [].concat(filters[category]).map(filterValue => {
                 const match = values.find(
                     item =>


### PR DESCRIPTION
This resolves: https://issues.redhat.com/browse/SPM-1461.

To repoduce the issue: 

1. Open the patch set wizard
2. Proceed to Review Systems step
3. Active multiple filter with a light speed
4. Hit on the 'Reser filters' button. At this step, the wizard should break and close.
