### PR TITLE
fix(1494): fix selected systems across steps

### DIFF
--- a/src/SmartComponents/PatchSetWizard/WizardAssets.js
+++ b/src/SmartComponents/PatchSetWizard/WizardAssets.js
@@ -2,6 +2,7 @@ import componentTypes from '@data-driven-forms/react-form-renderer/component-typ
 import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
 import { intl } from '../../Utilities/IntlProvider';
 import messages from '../../Messages';
+import { filterSelectedActiveSystemIDs } from '../../Utilities/Helpers';
 
 export const reviewSystemColumns = [{
     key: 'display_name',
@@ -107,11 +108,13 @@ export const schema = (patchSetID) => ({
 });
 
 export const validatorMapper = {
-    'validate-systems': () => (system) => {
-        if (system === undefined) {
+    'validate-systems': () => (formValueSystems) => {
+        const systems = filterSelectedActiveSystemIDs(formValueSystems);
+
+        if (systems === undefined) {
             return;
         }
-        else if (Object.keys(system).length > 0) {
+        else if (systems.length > 0) {
             return;
         } else {
             return intl.formatMessage(messages.patchSetNoSystemSelected);

--- a/src/SmartComponents/PatchSetWizard/steps/ReviewSystems.js
+++ b/src/SmartComponents/PatchSetWizard/steps/ReviewSystems.js
@@ -23,7 +23,7 @@ export const ReviewSystems = ({ systemsIDs = [], ...props }) => {
     const { input } = useFieldApi(props);
     const formOptions = useFormApi();
     const { values } = formOptions.getState();
-    const defaultSelectedSystems = buildSelectedSystemsObj([...systemsIDs, ...Object.keys(values?.systems || {})]);
+    const defaultSelectedSystems = buildSelectedSystemsObj(systemsIDs, values?.systems);
 
     const [isLoading, setLoading] = useState(true);
     const [rawData, setRawData] = useState([]);

--- a/src/Utilities/Helpers.js
+++ b/src/Utilities/Helpers.js
@@ -617,8 +617,24 @@ export const convertIsoToDate = (isoDate) => {
         `-${dateObject.getDate().toString().padStart(2, '0')}`;
 };
 
-export const buildSelectedSystemsObj = (systemsIDs) => {
-    const assignedSystemsObject = systemsIDs?.reduce((object, system) => {
+export const filterSelectedActiveSystemIDs = (selectedSystemsObject) => {
+    const formValueSystemIDs = [];
+    if (typeof selectedSystemsObject === 'object') {
+        Object.keys(selectedSystemsObject).forEach((key) => {
+            if (selectedSystemsObject[key]) {
+                formValueSystemIDs.push(key);
+            }
+        });
+    }
+
+    return formValueSystemIDs;
+};
+
+export const buildSelectedSystemsObj = (systemsIDs, formValueSystems) => {
+
+    const mergedSystems = [...systemsIDs, ...filterSelectedActiveSystemIDs(formValueSystems)];
+
+    const assignedSystemsObject = mergedSystems?.reduce((object, system) => {
         object[system] = true;
         return object;
     }, {});
@@ -631,4 +647,3 @@ export const objUndefinedToFalse = (object) =>
         modifiedObject[key] =  object[key] === undefined ? false : object[key];
         return modifiedObject;
     }, {});
-


### PR DESCRIPTION
This resolves the ticket: https://issues.redhat.com/browse/SPM-1494

To reproduce:

1. Create new patch set using wizard
2. On 2nd page select e.g. 3 systems, deselect 2 of them so 1 is selected.
3. Go to Final page of the wizard, the wizard shows 1 system in patch set
4. Go back to system selection, 3 systems are selected although no action was taken.
5. Go next to final page of the wizard, it shows 3 systems now although only actions taken were going to previous (2nd page) and immediately to 3rd page.