### PR TITLE
fix(SPM-1492): system details page refreshs after patch-set change

### DIFF
--- a/src/SmartComponents/SystemDetail/InventoryDetail.js
+++ b/src/SmartComponents/SystemDetail/InventoryDetail.js
@@ -37,7 +37,7 @@ const InventoryDetail = ({ match }) => {
         return () => {
             dispatch(clearNotifications());
         };
-    }, []);
+    }, [patchSetState.shouldRefresh]);
 
     const pageTitle = entityDetails && `${entityDetails.display_name} - ${intl.formatMessage(messages.titlesSystems)}`;
     setPageTitle(pageTitle);


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/SPM-1492. I am not able to do API request other than the type GET, theoratically just adding `patchSetState.shouldRefresh` to the the hook dependency should do the trick, most probably. Thus, please run this PR locally to make sure it does the fix.

To reproduce:
1. Assign system to a patch set via action on system detail page
2. The page continues to display old patch set name a needs to be refreshed to display new patch set name