### PR TITLE
fix(SPM-1490, SPM-1493): wizard texts updated

### DIFF
--- a/src/Messages.js
+++ b/src/Messages.js
@@ -391,12 +391,21 @@ export default defineMessages({
         description: 'step name of the patch set wizard',
         defaultMessage: 'Select systems'
     },
-    patchSetTitle: {
+    patchSetTitleAssignSystem: {
+        id: 'patchSetTitle',
+        description: 'title of the patch set wizard',
+        defaultMessage: 'Assign system(s) to patch set'
+    },
+    patchSetTitleCreate: {
         id: 'patchSetTitle',
         description: 'title of the patch set wizard',
         defaultMessage: 'Create patch set'
     },
-
+    patchSetTitleEdit: {
+        id: 'patchSetTitle',
+        description: 'title of the patch set wizard',
+        defaultMessage: 'Edit patch set'
+    },
     statesError: {
         id: 'statesError',
         description: 'Label',

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -394,7 +394,7 @@ export default defineMessages({
     patchSetTitleAssignSystem: {
         id: 'patchSetTitle',
         description: 'title of the patch set wizard',
-        defaultMessage: 'Assign system(s) to patch set'
+        defaultMessage: 'Assign system(s) to a patch set'
     },
     patchSetTitleCreate: {
         id: 'patchSetTitle',
@@ -531,10 +531,10 @@ export default defineMessages({
         description: 'page title with capital letter',
         defaultMessage: 'Patch set'
     },
-    titlesPatchSetAssignMultipleButton: {
-        id: 'titlesPatchSetAssignMultipleButton',
+    titlesPatchSetAssign: {
+        id: 'titlesPatchSetAssign',
         description: 'title with capital letters',
-        defaultMessage: 'Assign to patch sets'
+        defaultMessage: 'Assign to a patch set'
     },
     titlesPatchSystems: {
         id: 'titlesPatchSystems',

--- a/src/SmartComponents/PatchSetWizard/PatchSetWizard.js
+++ b/src/SmartComponents/PatchSetWizard/PatchSetWizard.js
@@ -24,6 +24,8 @@ import messages from '../../Messages';
 import { fetchPatchSetAction, clearPatchSetAction, fetchPatchSetSystemsAction } from '../../store/Actions/Actions';
 
 export const PatchSetWizard = ({ systemsIDs, setBaselineState, patchSetID }) => {
+    //if system ids exist, those are being assigned. Likewise if patchSetID exists, it is being edited
+    const wizardType = systemsIDs ? 'assign' : (patchSetID ? 'edit' : 'create');
     const [wizardState, setWizardState] = useState({
         submitted: false,
         formValues: {},
@@ -81,7 +83,7 @@ export const PatchSetWizard = ({ systemsIDs, setBaselineState, patchSetID }) => 
         <Fragment>
             {!wizardState.submitted &&  (
                 <FormRenderer
-                    schema={schema(patchSetID)}
+                    schema={schema(wizardType)}
                     subscription={{ values: true }}
                     FormTemplate={(props) => (
                         <Pf4FormTemplate {...props} showFormControls={false} />

--- a/src/SmartComponents/PatchSetWizard/WizardAssets.js
+++ b/src/SmartComponents/PatchSetWizard/WizardAssets.js
@@ -60,51 +60,66 @@ export const toDateComponent = [{
     ]
 }];
 
-export const schema = (patchSetID) => ({
-    fields: [
-        {
-            component: componentTypes.WIZARD,
-            name: 'patch-set-wizard',
-            isDynamic: true,
-            inModal: true,
-            showTitles: true,
-            title: intl.formatMessage(messages.patchSetTitle),
-            description: intl.formatMessage(messages.patchSetDescription),
-            fields: [
-                {
-                    name: 'patch-set-config',
-                    title: intl.formatMessage(patchSetID && messages.patchSetEditSet || messages.patchSetNewSet),
-                    fields: configurationFields,
-                    nextStep: 'systems'
-                },
-                {
-                    name: 'systems',
-                    title: intl.formatMessage(messages.patchSetSelectSystems),
-                    fields: [
-                        {
-                            name: 'systems',
-                            component: 'review-systems',
-                            validate: [{ type: 'validate-systems' }]
-                        }
-                    ],
-                    nextStep: 'review'
-                },
-                {
-                    name: 'review',
-                    title: intl.formatMessage(messages.patchSetReviewSet),
-                    fields: [
-                        {
-                            name: 'review',
-                            component: 'review-patch-set'
-                        }
-                    ]
-                }
+export const schema = (wizardType) =>{
+    let wizardTitle = '';
 
-            ]
+    switch (wizardType) {
+        case 'assign':
+            wizardTitle = intl.formatMessage(messages.patchSetTitleAssignSystem);
+            break;
+        case 'edit':
+            wizardTitle = intl.formatMessage(messages.patchSetTitleEdit);
+            break;
+        default:
+            wizardTitle = intl.formatMessage(messages.patchSetTitleCreate);
+    }
 
-        }
-    ]
-});
+    return ({
+        fields: [
+            {
+                component: componentTypes.WIZARD,
+                name: 'patch-set-wizard',
+                isDynamic: true,
+                inModal: true,
+                showTitles: true,
+                title: wizardTitle,
+                description: intl.formatMessage(messages.patchSetDescription),
+                fields: [
+                    {
+                        name: 'patch-set-config',
+                        title: intl.formatMessage(wizardType === 'edit' ? messages.patchSetEditSet : messages.patchSetNewSet),
+                        fields: configurationFields,
+                        nextStep: 'systems'
+                    },
+                    {
+                        name: 'systems',
+                        title: intl.formatMessage(messages.patchSetSelectSystems),
+                        fields: [
+                            {
+                                name: 'systems',
+                                component: 'review-systems',
+                                validate: [{ type: 'validate-systems' }]
+                            }
+                        ],
+                        nextStep: 'review'
+                    },
+                    {
+                        name: 'review',
+                        title: intl.formatMessage(messages.patchSetReviewSet),
+                        fields: [
+                            {
+                                name: 'review',
+                                component: 'review-patch-set'
+                            }
+                        ]
+                    }
+
+                ]
+
+            }
+        ]
+    });
+};
 
 export const validatorMapper = {
     'validate-systems': () => (system) => {

--- a/src/SmartComponents/SystemDetail/InventoryDetail.js
+++ b/src/SmartComponents/SystemDetail/InventoryDetail.js
@@ -75,7 +75,7 @@ const InventoryDetail = ({ match }) => {
                     showTags
                     actions={[
                         {
-                            title: intl.formatMessage(messages.titlesPatchSetAssignMultipleButton),
+                            title: intl.formatMessage(messages.titlesPatchSetAssign),
                             key: 'assign-to-patch-set',
                             onClick: showBaselineModal
                         }]}

--- a/src/SmartComponents/SystemDetail/__snapshots__/InventoryDetail.test.js.snap
+++ b/src/SmartComponents/SystemDetail/__snapshots__/InventoryDetail.test.js.snap
@@ -201,7 +201,7 @@ exports[`InventoryPage.js Should match the snapshots 1`] = `
                           Object {
                             "key": "assign-to-patch-set",
                             "onClick": [Function],
-                            "title": "Assign to patch sets",
+                            "title": "Assign to a patch set",
                           },
                         ]
                       }

--- a/src/SmartComponents/Systems/Systems.js
+++ b/src/SmartComponents/Systems/Systems.js
@@ -231,7 +231,7 @@ const Systems = () => {
                                     <Button onClick={assignMultipleSystems}
                                         key='assign-multiple-systems'
                                         isDisabled={selectedCount === 0}>
-                                        {intl.formatMessage(messages.titlesPatchSetAssignMultipleButton)}
+                                        {intl.formatMessage(messages.titlesPatchSetAssign)}
                                     </Button>]
                             }}
                             filterConfig={filterConfig}

--- a/src/SmartComponents/Systems/SystemsListAssets.js
+++ b/src/SmartComponents/Systems/SystemsListAssets.js
@@ -96,7 +96,7 @@ export const systemsRowActions = (showRemediationModal, showBaselineModal, isPat
             }
         },
         ...(isPatchSetEnabled && showBaselineModal ? [{
-            title: 'Assign to patch set',
+            title: 'Assign to a patch set',
             onClick: (event, rowId, rowData) => {
                 showBaselineModal(rowData);
             }


### PR DESCRIPTION
Resolves: 

1. [Editing a patch set created wizard named 'Create patch set'](https://issues.redhat.com/browse/SPM-1490). Wizard title is renamed to 'Edit patch set'
2. [Assigning system to a patch set created wizard named 'Create patch set'](https://issues.redhat.com/browse/SPM-1493) Wizard title is renamed to 'Assign system(s) to a patch set'.
3. ['Assign to patch sets' action should be 'Assign to a patch set' (singular form).](https://issues.redhat.com/browse/SPM-1489) (all occurrances in Systems page)