### PR TITLE
fix(SPM-1487): let users create patch sets with zero systems assigned

### DIFF
--- a/src/SmartComponents/PatchSetWizard/WizardAssets.js
+++ b/src/SmartComponents/PatchSetWizard/WizardAssets.js
@@ -98,8 +98,9 @@ export const schema = (wizardType) =>{
                         fields: [
                             {
                                 name: 'systems',
-                                component: 'review-systems',
-                                validate: [{ type: 'validate-systems' }]
+                                component: 'review-systems'
+                                //We can use this later in case UX wantes to prevent patch sets without zero systems
+                                //validate: [{ type: 'validate-systems' }]
                             }
                         ],
                         nextStep: 'review'


### PR DESCRIPTION
This resolves: 
https://issues.redhat.com/browse/SPM-1487.

Initially PM asked to prevent users creating patch sets with zero systems. However, during the latest meeting team we agreed to remove the revert this case and remove the validation. Now, wizard lets users go through the step 2 even if no system is selected.


to reproduce: 

1. Go to Patch set page: https://console.stage.redhat.com/beta/insights/patch/patch-set
2. Click 'Create Patch Set' button
3. Fill the name and date, click next.
4. System selection is displayed, 'Next' button is greyed out. There's no way how to complete Patch Set creation.



Similarly, this PR enables patch sets with zero systems assigned to be edited. This bug is tracked: https://issues.redhat.com/browse/SPM-1491. 
To reproduce SPM-1491:

1. Edit a patch set with zero systems
2. Change the e.g. the upto date
3. Go to next page, it's not possible to proceed further if no systems are associated with a patch set.

