### PR TITLE
fix(SPM-1488): remove systems from patch sets

### DIFF
--- a/src/Messages.js
+++ b/src/Messages.js
@@ -41,6 +41,11 @@ export default defineMessages({
         description: 'button label',
         defaultMessage: 'Edit patch set'
     },
+    labelsCancel: {
+        id: 'labelsCancel',
+        description: 'Button label',
+        defaultMessage: 'Cancel'
+    },
     labelsColumnsApplicableSystems: {
         id: 'labelsColumnsApplicableSystems',
         description: 'shared label',
@@ -306,6 +311,11 @@ export default defineMessages({
         description: 'Button label',
         defaultMessage: 'Remediate'
     },
+    labelsRemove: {
+        id: 'labelsRemove',
+        description: 'Button label',
+        defaultMessage: 'Remove'
+    },
     labelsReturnToLandingPage: {
         id: 'returnToLandingPage',
         description: 'Return to landing page label for general usage',
@@ -491,6 +501,11 @@ export default defineMessages({
         description: 'text about the third paty managed hosts',
         defaultMessage: 'This system has content that is managed by repositories other than the Red Hat CDN'
     },
+    textUnassignSystemsStatement: {
+        id: 'textUnassignSystemsStatement',
+        description: 'text about systems being removed',
+        defaultMessage: 'Do you want to remove the {systemIDs} selected systems from this Patch set'
+    },
     titlesAdvisories: {
         id: 'titlesAdvisories',
         description: 'page title with capital letter',
@@ -535,6 +550,11 @@ export default defineMessages({
         id: 'titlesPatchSetAssign',
         description: 'title with capital letters',
         defaultMessage: 'Assign to a patch set'
+    },
+    titlesPatchSetRemoveMultipleButton: {
+        id: 'titlesPatchSetAssignMultipleButton',
+        description: 'title with capital letters',
+        defaultMessage: 'Remove from patch sets'
     },
     titlesPatchSystems: {
         id: 'titlesPatchSystems',

--- a/src/SmartComponents/Modals/UnassignSystemsModal.js
+++ b/src/SmartComponents/Modals/UnassignSystemsModal.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import propTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { Modal, Button } from '@patternfly/react-core';
+
+import { intl } from '../../Utilities/IntlProvider';
+import messages from '../../Messages';
+import { removePatchSetApi } from '../../Utilities/api';
+import { patchSetUnassignSystemsNotifications } from '../../Utilities/constants';
+import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
+
+const UnassignSystemsModal = ({ unassignSystemsModalState = {}, setUnassignSystemsModalOpen }) => {
+    const dispatch = useDispatch();
+
+    const { systemsIDs, isUnassignSystemsModalOpen } = unassignSystemsModalState;
+
+    const handleModalOpen = () => {
+        setUnassignSystemsModalOpen({
+            isUnassignSystemsModalOpen: !isUnassignSystemsModalOpen,
+            systemsIDs: []
+        });
+    };
+
+    const handleUnassignment = async () => {
+        const result = await removePatchSetApi(systemsIDs);
+
+        //TODO: mockups do not have error notifications designed, add them if UX designes.
+        if (result.status === 200) {
+            handleModalOpen();
+            dispatch(addNotification(patchSetUnassignSystemsNotifications(systemsIDs?.length || 0).success));
+        }
+    };
+
+    return (
+        <Modal
+            variant={'small'}
+            isOpen={unassignSystemsModalState.isUnassignSystemsModalOpen}
+            title="Remove systems"
+            onClose={handleModalOpen}
+            titleIconVariant="warning"
+            actions={[
+                <Button key="confirm" variant="danger" onClick={handleUnassignment}>
+                    {intl.formatMessage(messages.labelsRemove)}
+                </Button>,
+                <Button key="cancel" variant="link" onClick={handleModalOpen}>
+                    {intl.formatMessage(messages.labelsCancel)}
+                </Button>
+            ]}
+        >
+            {intl.formatMessage(
+                messages.textUnassignSystemsStatement,
+                { systemIDs: <b>{systemsIDs ? systemsIDs.length : 0}</b> }
+            )}
+        </Modal>
+    );
+};
+
+UnassignSystemsModal.propTypes = {
+    setUnassignSystemsModalOpen: propTypes.func,
+    unassignSystemsModalState: propTypes.object
+};
+export default UnassignSystemsModal;

--- a/src/SmartComponents/Modals/UnassignSystemsModal.test.js
+++ b/src/SmartComponents/Modals/UnassignSystemsModal.test.js
@@ -1,0 +1,77 @@
+import toJson from 'enzyme-to-json';
+import { act } from 'react-dom/test-utils';
+import { Modal } from '@patternfly/react-core';
+import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
+
+import UnassignSystemsModal from './UnassignSystemsModal';
+import { removePatchSetApi } from '../../Utilities/api';
+import { patchSetUnassignSystemsNotifications } from '../../Utilities/constants';
+
+jest.mock('../../Utilities/api', () => ({
+    ...jest.requireActual('../../Utilities/api'),
+    removePatchSetApi: jest.fn()
+}));
+
+jest.mock('react-redux', () => ({
+    useDispatch: jest.fn(() => () => {})
+}));
+
+jest.mock('@redhat-cloud-services/frontend-components-notifications/redux', () => ({
+    addNotification: jest.fn(() => {})
+}));
+
+describe('UnassignSystemsModal', () => {
+    let unassignSystemsModalState = {
+        isUnassignSystemsModalOpen: true,
+        systemsIDs: ['test_1', 'test_2', 'test_3']
+    };
+    const setUnassignSystemsModalOpen = (modalState) => {
+        unassignSystemsModalState = modalState;
+    };
+
+    const wrapper = mount(<UnassignSystemsModal
+        unassignSystemsModalState={unassignSystemsModalState}
+        setUnassignSystemsModalOpen={setUnassignSystemsModalOpen}
+    />
+    );
+
+    it('should match the snapshots', () => {
+        expect(toJson(wrapper)).toMatchSnapshot();
+    });
+
+    it('Should remove systems from a patch set and handle success notification', async ()  => {
+        unassignSystemsModalState.isUnassignSystemsModalOpen = true;
+        removePatchSetApi.mockReturnValueOnce(
+            new Promise((resolve) => {
+                resolve({ status: 200 });
+            }
+            )
+        );
+        await wrapper.find(Modal).props().actions[0].props.onClick();
+        expect(addNotification).toHaveBeenCalledWith(
+            patchSetUnassignSystemsNotifications(3).success
+        );
+        expect(unassignSystemsModalState.isUnassignSystemsModalOpen).toBeFalsy();
+    });
+
+    it('should close the modal', () => {
+        unassignSystemsModalState.isUnassignSystemsModalOpen = true;
+        act(() => {
+            wrapper.props().setUnassignSystemsModalOpen(false);
+        });
+
+        wrapper.update();
+        expect(unassignSystemsModalState.isUnassignSystemsModalOpen).toBeFalsy();
+    });
+
+    it('should hide the modal when isUnassignSystemsModalOpen=false', () => {
+        const wrapper = mount(<UnassignSystemsModal
+            systemsIDs={unassignSystemsModalState.systemsIDs}
+            isUnassignSystemsModalOpen={false}
+            setUnassignSystemsModalOpen={setUnassignSystemsModalOpen}
+        />
+        );
+
+        expect(wrapper.find(Modal).props().isOpen).toBeFalsy();
+    });
+});

--- a/src/SmartComponents/Modals/__snapshots__/UnassignSystemsModal.test.js.snap
+++ b/src/SmartComponents/Modals/__snapshots__/UnassignSystemsModal.test.js.snap
@@ -1,0 +1,447 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UnassignSystemsModal should match the snapshots 1`] = `
+<UnassignSystemsModal
+  setUnassignSystemsModalOpen={[Function]}
+  unassignSystemsModalState={
+    Object {
+      "isUnassignSystemsModalOpen": true,
+      "systemsIDs": Array [
+        "test_1",
+        "test_2",
+        "test_3",
+      ],
+    }
+  }
+>
+  <Modal
+    actions={
+      Array [
+        <Button
+          onClick={[Function]}
+          variant="danger"
+        >
+          Remove
+        </Button>,
+        <Button
+          onClick={[Function]}
+          variant="link"
+        >
+          Cancel
+        </Button>,
+      ]
+    }
+    appendTo={[Function]}
+    aria-describedby=""
+    aria-label=""
+    aria-labelledby=""
+    className=""
+    hasNoBodyWrapper={false}
+    isOpen={true}
+    onClose={[Function]}
+    ouiaSafe={true}
+    showClose={true}
+    title="Remove systems"
+    titleIconVariant="warning"
+    titleLabel=""
+    variant="small"
+  >
+    <Portal
+      containerInfo={
+        <div>
+          <div
+            class="pf-c-backdrop"
+          >
+            <div
+              class="pf-l-bullseye"
+            >
+              <div
+                aria-describedby="pf-modal-part-2"
+                aria-labelledby="pf-modal-part-1"
+                aria-modal="true"
+                class="pf-c-modal-box pf-m-warning pf-m-sm"
+                data-ouia-component-id="OUIA-Generated-Modal-small-1"
+                data-ouia-component-type="PF4/ModalContent"
+                data-ouia-safe="true"
+                id="pf-modal-part-0"
+                role="dialog"
+              >
+                <button
+                  aria-disabled="false"
+                  aria-label="Close"
+                  class="pf-c-button pf-m-plain"
+                  data-ouia-component-id="OUIA-Generated-Modal-small-1-ModalBoxCloseButton"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    style="vertical-align: -0.125em;"
+                    viewBox="0 0 352 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                    />
+                  </svg>
+                </button>
+                <header
+                  class="pf-c-modal-box__header"
+                >
+                  <h1
+                    class="pf-c-modal-box__title pf-m-icon"
+                    id="pf-modal-part-1"
+                  >
+                    <span
+                      class="pf-c-modal-box__title-icon"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        style="vertical-align: -0.125em;"
+                        viewBox="0 0 576 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="pf-u-screen-reader"
+                    >
+                      Warning alert:
+                    </span>
+                    <span
+                      class="pf-c-modal-box__title-text"
+                    >
+                      Remove systems
+                    </span>
+                  </h1>
+                </header>
+                <div
+                  class="pf-c-modal-box__body"
+                  id="pf-modal-part-2"
+                >
+                  Do you want to remove the 
+                  <b>
+                    3
+                  </b>
+                   selected systems from this Patch set
+                </div>
+                <footer
+                  class="pf-c-modal-box__footer"
+                >
+                  <button
+                    aria-disabled="false"
+                    class="pf-c-button pf-m-danger"
+                    data-ouia-component-id="OUIA-Generated-Button-danger-1"
+                    data-ouia-component-type="PF4/Button"
+                    data-ouia-safe="true"
+                    type="button"
+                  >
+                    Remove
+                  </button>
+                  <button
+                    aria-disabled="false"
+                    class="pf-c-button pf-m-link"
+                    data-ouia-component-id="OUIA-Generated-Button-link-1"
+                    data-ouia-component-type="PF4/Button"
+                    data-ouia-safe="true"
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                </footer>
+              </div>
+            </div>
+          </div>
+        </div>
+      }
+    >
+      <ModalContent
+        actions={
+          Array [
+            <Button
+              onClick={[Function]}
+              variant="danger"
+            >
+              Remove
+            </Button>,
+            <Button
+              onClick={[Function]}
+              variant="link"
+            >
+              Cancel
+            </Button>,
+          ]
+        }
+        aria-describedby=""
+        aria-label=""
+        aria-labelledby=""
+        boxId="pf-modal-part-0"
+        className=""
+        descriptorId="pf-modal-part-2"
+        hasNoBodyWrapper={false}
+        isOpen={true}
+        labelId="pf-modal-part-1"
+        onClose={[Function]}
+        ouiaId="OUIA-Generated-Modal-small-1"
+        ouiaSafe={true}
+        showClose={true}
+        title="Remove systems"
+        titleIconVariant="warning"
+        titleLabel=""
+        variant="small"
+      >
+        <Backdrop>
+          <div
+            className="pf-c-backdrop"
+          >
+            <FocusTrap
+              active={true}
+              className="pf-l-bullseye"
+              focusTrapOptions={
+                Object {
+                  "clickOutsideDeactivates": true,
+                }
+              }
+              paused={false}
+              preventScrollOnDeactivate={false}
+            >
+              <div
+                className="pf-l-bullseye"
+              >
+                <ModalBox
+                  aria-describedby="pf-modal-part-2"
+                  aria-label=""
+                  aria-labelledby="pf-modal-part-1"
+                  className="pf-m-warning"
+                  data-ouia-component-id="OUIA-Generated-Modal-small-1"
+                  data-ouia-component-type="PF4/ModalContent"
+                  data-ouia-safe={true}
+                  id="pf-modal-part-0"
+                  style={Object {}}
+                  variant="small"
+                >
+                  <div
+                    aria-describedby="pf-modal-part-2"
+                    aria-label={null}
+                    aria-labelledby="pf-modal-part-1"
+                    aria-modal="true"
+                    className="pf-c-modal-box pf-m-warning pf-m-sm"
+                    data-ouia-component-id="OUIA-Generated-Modal-small-1"
+                    data-ouia-component-type="PF4/ModalContent"
+                    data-ouia-safe={true}
+                    id="pf-modal-part-0"
+                    role="dialog"
+                    style={Object {}}
+                  >
+                    <ModalBoxCloseButton
+                      onClose={[Function]}
+                      ouiaId="OUIA-Generated-Modal-small-1"
+                    >
+                      <Button
+                        aria-label="Close"
+                        className=""
+                        onClick={[Function]}
+                        ouiaId="OUIA-Generated-Modal-small-1-ModalBoxCloseButton"
+                        variant="plain"
+                      >
+                        <ButtonBase
+                          aria-label="Close"
+                          className=""
+                          innerRef={null}
+                          onClick={[Function]}
+                          ouiaId="OUIA-Generated-Modal-small-1-ModalBoxCloseButton"
+                          variant="plain"
+                        >
+                          <button
+                            aria-disabled={false}
+                            aria-label="Close"
+                            className="pf-c-button pf-m-plain"
+                            data-ouia-component-id="OUIA-Generated-Modal-small-1-ModalBoxCloseButton"
+                            data-ouia-component-type="PF4/Button"
+                            data-ouia-safe={true}
+                            disabled={false}
+                            onClick={[Function]}
+                            role={null}
+                            type="button"
+                          >
+                            <TimesIcon
+                              color="currentColor"
+                              noVerticalAlign={false}
+                              size="sm"
+                            >
+                              <svg
+                                aria-hidden={true}
+                                aria-labelledby={null}
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                style={
+                                  Object {
+                                    "verticalAlign": "-0.125em",
+                                  }
+                                }
+                                viewBox="0 0 352 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                                />
+                              </svg>
+                            </TimesIcon>
+                          </button>
+                        </ButtonBase>
+                      </Button>
+                    </ModalBoxCloseButton>
+                    <ModalBoxHeader
+                      help={null}
+                    >
+                      <header
+                        className="pf-c-modal-box__header"
+                      >
+                        <ModalBoxTitle
+                          id="pf-modal-part-1"
+                          title="Remove systems"
+                          titleIconVariant="warning"
+                          titleLabel=""
+                        >
+                          <h1
+                            className="pf-c-modal-box__title pf-m-icon"
+                            id="pf-modal-part-1"
+                          >
+                            <span
+                              className="pf-c-modal-box__title-icon"
+                            >
+                              <ExclamationTriangleIcon
+                                color="currentColor"
+                                noVerticalAlign={false}
+                                size="sm"
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  aria-labelledby={null}
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  style={
+                                    Object {
+                                      "verticalAlign": "-0.125em",
+                                    }
+                                  }
+                                  viewBox="0 0 576 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+                                  />
+                                </svg>
+                              </ExclamationTriangleIcon>
+                            </span>
+                            <span
+                              className="pf-u-screen-reader"
+                            >
+                              Warning alert:
+                            </span>
+                            <span
+                              className="pf-c-modal-box__title-text"
+                            >
+                              Remove systems
+                            </span>
+                          </h1>
+                        </ModalBoxTitle>
+                      </header>
+                    </ModalBoxHeader>
+                    <ModalBoxBody
+                      id="pf-modal-part-2"
+                    >
+                      <div
+                        className="pf-c-modal-box__body"
+                        id="pf-modal-part-2"
+                      >
+                        Do you want to remove the 
+                        <b
+                          key=".1"
+                        >
+                          3
+                        </b>
+                         selected systems from this Patch set
+                      </div>
+                    </ModalBoxBody>
+                    <ModalBoxFooter>
+                      <footer
+                        className="pf-c-modal-box__footer"
+                      >
+                        <Button
+                          key="confirm"
+                          onClick={[Function]}
+                          variant="danger"
+                        >
+                          <ButtonBase
+                            innerRef={null}
+                            onClick={[Function]}
+                            variant="danger"
+                          >
+                            <button
+                              aria-disabled={false}
+                              aria-label={null}
+                              className="pf-c-button pf-m-danger"
+                              data-ouia-component-id="OUIA-Generated-Button-danger-1"
+                              data-ouia-component-type="PF4/Button"
+                              data-ouia-safe={true}
+                              disabled={false}
+                              onClick={[Function]}
+                              role={null}
+                              type="button"
+                            >
+                              Remove
+                            </button>
+                          </ButtonBase>
+                        </Button>
+                        <Button
+                          key="cancel"
+                          onClick={[Function]}
+                          variant="link"
+                        >
+                          <ButtonBase
+                            innerRef={null}
+                            onClick={[Function]}
+                            variant="link"
+                          >
+                            <button
+                              aria-disabled={false}
+                              aria-label={null}
+                              className="pf-c-button pf-m-link"
+                              data-ouia-component-id="OUIA-Generated-Button-link-1"
+                              data-ouia-component-type="PF4/Button"
+                              data-ouia-safe={true}
+                              disabled={false}
+                              onClick={[Function]}
+                              role={null}
+                              type="button"
+                            >
+                              Cancel
+                            </button>
+                          </ButtonBase>
+                        </Button>
+                      </footer>
+                    </ModalBoxFooter>
+                  </div>
+                </ModalBox>
+              </div>
+            </FocusTrap>
+          </div>
+        </Backdrop>
+      </ModalContent>
+    </Portal>
+  </Modal>
+</UnassignSystemsModal>
+`;

--- a/src/SmartComponents/SystemDetail/InventoryDetail.js
+++ b/src/SmartComponents/SystemDetail/InventoryDetail.js
@@ -14,9 +14,13 @@ import { fetchSystemDetailsAction } from '../../store/Actions/Actions';
 import propTypes from 'prop-types';
 import { clearNotifications } from '@redhat-cloud-services/frontend-components-notifications/redux';;
 import PatchSetWizard from '../PatchSetWizard/PatchSetWizard';
+import UnassignSystemsModal from '../Modals/UnassignSystemsModal';
 
 const InventoryDetail = ({ match }) => {
-
+    const [unassignSystemsModalState, setUnassignSystemsModalState] = React.useState({
+        isUnassignSystemsModalOpen: false,
+        systemsIDs: []
+    });
     const [patchSetState, setBaselineState] = React.useState({
         isOpen: false,
         shouldRefresh: false,
@@ -46,6 +50,13 @@ const InventoryDetail = ({ match }) => {
         setBaselineState({ isOpen: true, systemsIDs: [entityId] });
     };
 
+    const openUnassignSystemsModal = (systemsIDs) => {
+        setUnassignSystemsModalState({
+            isUnassignSystemsModalOpen: true,
+            systemsIDs
+        });
+    };
+
     return (
         <DetailWrapper
             onLoad={({ mergeWithDetail }) => {
@@ -54,6 +65,11 @@ const InventoryDetail = ({ match }) => {
                 });
             }}
         >
+            <UnassignSystemsModal
+                unassignSystemsModalState={unassignSystemsModalState}
+                setUnassignSystemsModalOpen={setUnassignSystemsModalState}
+                systemsIDs={unassignSystemsModalState.systemsIDs}
+            />
             {(patchSetState.isOpen) &&
                 <PatchSetWizard systemsIDs={patchSetState.systemsIDs} setBaselineState={setBaselineState} />}
             <Header
@@ -78,6 +94,11 @@ const InventoryDetail = ({ match }) => {
                             title: intl.formatMessage(messages.titlesPatchSetAssign),
                             key: 'assign-to-patch-set',
                             onClick: showBaselineModal
+                        },
+                        {
+                            title: intl.formatMessage(messages.titlesPatchSetRemoveMultipleButton),
+                            key: 'assign-to-patch-set',
+                            onClick: () => openUnassignSystemsModal(entityId)
                         }]}
                 >
                     <Grid>

--- a/src/SmartComponents/SystemDetail/__snapshots__/InventoryDetail.test.js.snap
+++ b/src/SmartComponents/SystemDetail/__snapshots__/InventoryDetail.test.js.snap
@@ -52,6 +52,89 @@ exports[`InventoryPage.js Should match the snapshots 1`] = `
             className="testDetailWrapper"
           >
             <div>
+              <UnassignSystemsModal
+                setUnassignSystemsModalOpen={[Function]}
+                systemsIDs={Array []}
+                unassignSystemsModalState={
+                  Object {
+                    "isUnassignSystemsModalOpen": false,
+                    "systemsIDs": Array [],
+                  }
+                }
+              >
+                <Modal
+                  actions={
+                    Array [
+                      <Button
+                        onClick={[Function]}
+                        variant="danger"
+                      >
+                        Remove
+                      </Button>,
+                      <Button
+                        onClick={[Function]}
+                        variant="link"
+                      >
+                        Cancel
+                      </Button>,
+                    ]
+                  }
+                  appendTo={[Function]}
+                  aria-describedby=""
+                  aria-label=""
+                  aria-labelledby=""
+                  className=""
+                  hasNoBodyWrapper={false}
+                  isOpen={false}
+                  onClose={[Function]}
+                  ouiaSafe={true}
+                  showClose={true}
+                  title="Remove systems"
+                  titleIconVariant="warning"
+                  titleLabel=""
+                  variant="small"
+                >
+                  <Portal
+                    containerInfo={<div />}
+                  >
+                    <ModalContent
+                      actions={
+                        Array [
+                          <Button
+                            onClick={[Function]}
+                            variant="danger"
+                          >
+                            Remove
+                          </Button>,
+                          <Button
+                            onClick={[Function]}
+                            variant="link"
+                          >
+                            Cancel
+                          </Button>,
+                        ]
+                      }
+                      aria-describedby=""
+                      aria-label=""
+                      aria-labelledby=""
+                      boxId="pf-modal-part-0"
+                      className=""
+                      descriptorId="pf-modal-part-2"
+                      hasNoBodyWrapper={false}
+                      isOpen={false}
+                      labelId="pf-modal-part-1"
+                      onClose={[Function]}
+                      ouiaId="OUIA-Generated-Modal-small-1"
+                      ouiaSafe={true}
+                      showClose={true}
+                      title="Remove systems"
+                      titleIconVariant="warning"
+                      titleLabel=""
+                      variant="small"
+                    />
+                  </Portal>
+                </Modal>
+              </UnassignSystemsModal>
               <Header
                 breadcrumbs={
                   Array [
@@ -202,6 +285,11 @@ exports[`InventoryPage.js Should match the snapshots 1`] = `
                             "key": "assign-to-patch-set",
                             "onClick": [Function],
                             "title": "Assign to a patch set",
+                          },
+                          Object {
+                            "key": "assign-to-patch-set",
+                            "onClick": [Function],
+                            "title": "Remove from patch sets",
                           },
                         ]
                       }

--- a/src/SmartComponents/Systems/System.test.js
+++ b/src/SmartComponents/Systems/System.test.js
@@ -1,4 +1,5 @@
 import { Provider, useSelector } from 'react-redux';
+import { act } from 'react-dom/test-utils';
 import { BrowserRouter as Router } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 import { exportSystemsCSV, exportSystemsJSON, fetchSystems } from '../../Utilities/api';
@@ -8,6 +9,7 @@ import Systems from './Systems';
 import toJson from 'enzyme-to-json';
 import { useFeatureFlag } from '../../Utilities/Hooks';
 
+import UnassignSystemsModal from '../Modals/UnassignSystemsModal';
 initMocks();
 
 jest.mock('react-redux', () => ({
@@ -168,7 +170,7 @@ describe('Systems.js', () => {
             </Provider>);
 
             const { actions } = tempWrapper.find('.testInventroyComponentChild').parent().props();
-            expect(actions.length).toEqual(2);
+            expect(actions.length).toEqual(3);
         });
 
         it('Should hide table row actions for patch-set when flag is disabled', () => {
@@ -181,6 +183,45 @@ describe('Systems.js', () => {
             const { actions } = tempWrapper.find('.testInventroyComponentChild').parent().props();
             expect(actions.length).toEqual(1);
         });
+
+        describe('Unassign systems from patch sets', () => {
+
+            it('should table row actions open UnassignSystemsModal with row id', () => {
+                useFeatureFlag.mockReturnValue(true);
+
+                const tempWrapper = mount(<Provider store={store}>
+                    <Router><Systems /></Router>
+                </Provider>);
+
+                const { actions } = tempWrapper.find('.testInventroyComponentChild').parent().props();
+
+                act(() => actions[2].onClick(undefined, undefined, { testRow: { id: 'test-id' } }));
+
+                tempWrapper.update();
+
+                expect(
+                    tempWrapper.find(UnassignSystemsModal).props().unassignSystemsModalState.isUnassignSystemsModalOpen
+                ).toBeTruthy();
+            });
+
+            it('should table toolbar button open UnassignSystemsModal', () => {
+                useFeatureFlag.mockReturnValue(true);
+
+                const tempWrapper = mount(<Provider store={store}>
+                    <Router><Systems /></Router>
+                </Provider>);
+
+                const { actionsConfig } = tempWrapper.find('.testInventroyComponentChild').parent().props();
+                act(() => actionsConfig.actions[1].onClick());
+
+                tempWrapper.update();
+
+                expect(
+                    tempWrapper.find(UnassignSystemsModal).props().unassignSystemsModalState.isUnassignSystemsModalOpen
+                ).toBeTruthy();
+            });
+        });
+
     });
 
     describe('test entity selecting', () => {
@@ -244,4 +285,5 @@ describe('Systems.js', () => {
             expect(bulkSelect.items[2].title).toEqual('Select all (1)');
         });
     });
+
 });

--- a/src/SmartComponents/Systems/SystemsListAssets.js
+++ b/src/SmartComponents/Systems/SystemsListAssets.js
@@ -76,7 +76,7 @@ export const packageSystemsColumns = [
     }
 ];
 
-export const systemsRowActions = (showRemediationModal, showBaselineModal, isPatchSetEnabled) => {
+export const systemsRowActions = (showRemediationModal, showBaselineModal, isPatchSetEnabled, openUnassignSystemsModal) => {
     return [
         {
             title: 'Apply all applicable advisories',
@@ -100,6 +100,13 @@ export const systemsRowActions = (showRemediationModal, showBaselineModal, isPat
             onClick: (event, rowId, rowData) => {
                 showBaselineModal(rowData);
             }
-        }] : [])
+        },
+        {
+            title: 'Remove from patch set',
+            onClick: (event, rowId, rowData) => {
+                openUnassignSystemsModal([rowData.id]);
+            }
+        }
+        ] : [])
     ];
 };

--- a/src/SmartComponents/Systems/__snapshots__/System.test.js.snap
+++ b/src/SmartComponents/Systems/__snapshots__/System.test.js.snap
@@ -587,6 +587,89 @@ exports[`Systems.js should match the snapshot 1`] = `
             </InternalMain>
           </Connect(InternalMain)>
         </SystemsStatusreport>
+        <UnassignSystemsModal
+          setUnassignSystemsModalOpen={[Function]}
+          systemsIDs={Array []}
+          unassignSystemsModalState={
+            Object {
+              "isUnassignSystemsModalOpen": false,
+              "systemsIDs": Array [],
+            }
+          }
+        >
+          <Modal
+            actions={
+              Array [
+                <Button
+                  onClick={[Function]}
+                  variant="danger"
+                >
+                  Remove
+                </Button>,
+                <Button
+                  onClick={[Function]}
+                  variant="link"
+                >
+                  Cancel
+                </Button>,
+              ]
+            }
+            appendTo={[Function]}
+            aria-describedby=""
+            aria-label=""
+            aria-labelledby=""
+            className=""
+            hasNoBodyWrapper={false}
+            isOpen={false}
+            onClose={[Function]}
+            ouiaSafe={true}
+            showClose={true}
+            title="Remove systems"
+            titleIconVariant="warning"
+            titleLabel=""
+            variant="small"
+          >
+            <Portal
+              containerInfo={<div />}
+            >
+              <ModalContent
+                actions={
+                  Array [
+                    <Button
+                      onClick={[Function]}
+                      variant="danger"
+                    >
+                      Remove
+                    </Button>,
+                    <Button
+                      onClick={[Function]}
+                      variant="link"
+                    >
+                      Cancel
+                    </Button>,
+                  ]
+                }
+                aria-describedby=""
+                aria-label=""
+                aria-labelledby=""
+                boxId="pf-modal-part-0"
+                className=""
+                descriptorId="pf-modal-part-2"
+                hasNoBodyWrapper={false}
+                isOpen={false}
+                labelId="pf-modal-part-1"
+                onClose={[Function]}
+                ouiaId="OUIA-Generated-Modal-small-1"
+                ouiaSafe={true}
+                showClose={true}
+                title="Remove systems"
+                titleIconVariant="warning"
+                titleLabel=""
+                variant="small"
+              />
+            </Portal>
+          </Modal>
+        </UnassignSystemsModal>
         <Connect(InternalMain)>
           <InternalMain>
             <section
@@ -601,6 +684,26 @@ exports[`Systems.js should match the snapshot 1`] = `
                       "title": "Apply all applicable advisories",
                     },
                   ]
+                }
+                actionsConfig={
+                  Object {
+                    "actions": Array [
+                      <Button
+                        isDisabled={false}
+                        onClick={[Function]}
+                      >
+                        Assign to a patch set
+                      </Button>,
+                      Object {
+                        "key": "remove-multiple-systems",
+                        "label": "Remove from patch sets",
+                        "onClick": [Function],
+                        "props": Object {
+                          "isDisabled": false,
+                        },
+                      },
+                    ],
+                  }
                 }
                 activeFiltersConfig={
                   Object {

--- a/src/Utilities/api.js
+++ b/src/Utilities/api.js
@@ -219,3 +219,7 @@ export const fetchPatchSet = id => {
 export const fetchPatchSetSystems = (id, params) => {
     return createApiCall(`/baselines/${id}/systems`, 'get', params);
 };
+
+export const removePatchSetApi = (systemIDs) => {
+    return createApiCall('/api/patch/v1/baselines/systems/remove', 'post', null, systemIDs);
+};

--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -388,3 +388,10 @@ export const featureFlags = {
     patch_set: 'patch.patch_set'
 };
 
+export const patchSetUnassignSystemsNotifications = (systemsCount) => ({
+    success: {
+        title: `Systems succesfully removed from this Patch set.`,
+        description: `${systemsCount} ${systemsCount > 1 ? 'systems' : 'system'} removed from Patch set(s)`,
+        variant: 'success'
+    }
+});


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/SPM-1488. I am not able to make any other API requests except GET. Thus please make sure that API handles request nicely.

There are 2 use cases where users can remove system(s) from patch sets.

To reproduce from table row actions:
1. Go to Systems page
2. Click on 'Remove from patch set' row action of a system which has a set assigned.
3. The confirmation with the system number should appear
4. When users clicks on Remove button on the modal, system should be unassigned from the patch set

 To reproduce from table toolbar dropdown:
 1. Go to Systems page
 2. Select as many systems as you want
3. Click on 'Remove from patch set' button from the tabletoolbars dropdown.
4. The confirmation with the system number should appear
5. When users clicks on Remove button on the modal, system should be unassigned from the patch set