### PR TITLE
fix(PatchSetWizard): Adding missing message

### DIFF
--- a/src/Messages.js
+++ b/src/Messages.js
@@ -394,7 +394,7 @@ export default defineMessages({
     patchSetTitle: {
         id: 'patchSetTitle',
         description: 'title of the patch set wizard',
-        defaultMessage: 'Patch set'
+        defaultMessage: 'Create patch set'
     },
     patchSetTitleAssignSystem: {
         id: 'patchSetTitle',

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -391,6 +391,11 @@ export default defineMessages({
         description: 'step name of the patch set wizard',
         defaultMessage: 'Select systems'
     },
+    patchSetTitle: {
+        id: 'patchSetTitle',
+        description: 'title of the patch set wizard',
+        defaultMessage: 'Patch set'
+    },
     patchSetTitleAssignSystem: {
         id: 'patchSetTitle',
         description: 'title of the patch set wizard',


### PR DESCRIPTION
I am not sure what the title should be, but there was a missing message causing a blank page after assigning a patch set.