### PR TITLE
feat(SPM-1311): enable patch set removal on System details page

### DIFF
--- a/src/Messages.js
+++ b/src/Messages.js
@@ -559,7 +559,7 @@ export default defineMessages({
     titlesPatchSetRemoveMultipleButton: {
         id: 'titlesPatchSetAssignMultipleButton',
         description: 'title with capital letters',
-        defaultMessage: 'Remove from patch sets'
+        defaultMessage: 'Remove from patch set'
     },
     titlesPatchSystems: {
         id: 'titlesPatchSystems',

--- a/src/SmartComponents/Modals/UnassignSystemsModal.js
+++ b/src/SmartComponents/Modals/UnassignSystemsModal.js
@@ -14,19 +14,20 @@ const UnassignSystemsModal = ({ unassignSystemsModalState = {}, setUnassignSyste
 
     const { systemsIDs, isUnassignSystemsModalOpen } = unassignSystemsModalState;
 
-    const handleModalOpen = () => {
+    const handleModalOpen = (shouldRefresh) => {
         setUnassignSystemsModalOpen({
             isUnassignSystemsModalOpen: !isUnassignSystemsModalOpen,
-            systemsIDs: []
+            systemsIDs: [],
+            shouldRefresh
         });
     };
 
     const handleUnassignment = async () => {
-        const result = await removePatchSetApi(systemsIDs);
+        const result = await removePatchSetApi({ inventory_ids: systemsIDs });
 
         //TODO: mockups do not have error notifications designed, add them if UX designes.
         if (result.status === 200) {
-            handleModalOpen();
+            handleModalOpen(true);
             dispatch(addNotification(patchSetUnassignSystemsNotifications(systemsIDs?.length || 0).success));
         }
     };

--- a/src/SmartComponents/Modals/UnassignSystemsModal.test.js
+++ b/src/SmartComponents/Modals/UnassignSystemsModal.test.js
@@ -51,7 +51,8 @@ describe('UnassignSystemsModal', () => {
         expect(addNotification).toHaveBeenCalledWith(
             patchSetUnassignSystemsNotifications(3).success
         );
-        expect(unassignSystemsModalState.isUnassignSystemsModalOpen).toBeFalsy();
+        expect(unassignSystemsModalState).toEqual({ isUnassignSystemsModalOpen: false, shouldRefresh: true, systemsIDs: [] });
+        expect(removePatchSetApi).toHaveBeenCalledWith({ inventory_ids: ['test_1', 'test_2', 'test_3'] });
     });
 
     it('should close the modal', () => {

--- a/src/SmartComponents/SystemDetail/InventoryDetail.js
+++ b/src/SmartComponents/SystemDetail/InventoryDetail.js
@@ -19,7 +19,8 @@ import UnassignSystemsModal from '../Modals/UnassignSystemsModal';
 const InventoryDetail = ({ match }) => {
     const [unassignSystemsModalState, setUnassignSystemsModalState] = React.useState({
         isUnassignSystemsModalOpen: false,
-        systemsIDs: []
+        systemsIDs: [],
+        shouldRefresh: false
     });
     const [patchSetState, setBaselineState] = React.useState({
         isOpen: false,
@@ -41,7 +42,7 @@ const InventoryDetail = ({ match }) => {
         return () => {
             dispatch(clearNotifications());
         };
-    }, [patchSetState.shouldRefresh]);
+    }, [patchSetState.shouldRefresh, unassignSystemsModalState.shouldRefresh]);
 
     const pageTitle = entityDetails && `${entityDetails.display_name} - ${intl.formatMessage(messages.titlesSystems)}`;
     setPageTitle(pageTitle);
@@ -97,8 +98,9 @@ const InventoryDetail = ({ match }) => {
                         },
                         {
                             title: intl.formatMessage(messages.titlesPatchSetRemoveMultipleButton),
-                            key: 'assign-to-patch-set',
-                            onClick: () => openUnassignSystemsModal(entityId)
+                            key: 'remove-from-patch-set',
+                            isDisabled: !patchSetName,
+                            onClick: () => openUnassignSystemsModal([entityId])
                         }]}
                 >
                     <Grid>

--- a/src/SmartComponents/SystemDetail/__snapshots__/InventoryDetail.test.js.snap
+++ b/src/SmartComponents/SystemDetail/__snapshots__/InventoryDetail.test.js.snap
@@ -58,6 +58,7 @@ exports[`InventoryPage.js Should match the snapshots 1`] = `
                 unassignSystemsModalState={
                   Object {
                     "isUnassignSystemsModalOpen": false,
+                    "shouldRefresh": false,
                     "systemsIDs": Array [],
                   }
                 }
@@ -287,9 +288,10 @@ exports[`InventoryPage.js Should match the snapshots 1`] = `
                             "title": "Assign to a patch set",
                           },
                           Object {
-                            "key": "assign-to-patch-set",
+                            "isDisabled": true,
+                            "key": "remove-from-patch-set",
                             "onClick": [Function],
-                            "title": "Remove from patch sets",
+                            "title": "Remove from patch set",
                           },
                         ]
                       }

--- a/src/SmartComponents/Systems/__snapshots__/System.test.js.snap
+++ b/src/SmartComponents/Systems/__snapshots__/System.test.js.snap
@@ -696,7 +696,7 @@ exports[`Systems.js should match the snapshot 1`] = `
                       </Button>,
                       Object {
                         "key": "remove-multiple-systems",
-                        "label": "Remove from patch sets",
+                        "label": "Remove from patch set",
                         "onClick": [Function],
                         "props": Object {
                           "isDisabled": false,

--- a/src/Utilities/api.js
+++ b/src/Utilities/api.js
@@ -220,6 +220,6 @@ export const fetchPatchSetSystems = (id, params) => {
     return createApiCall(`/baselines/${id}/systems`, 'get', params);
 };
 
-export const removePatchSetApi = (systemIDs) => {
-    return createApiCall('/api/patch/v1/baselines/systems/remove', 'post', null, systemIDs);
+export const removePatchSetApi = (payload) => {
+    return createApiCall('/baselines/systems/remove', 'post', null, payload);
 };


### PR DESCRIPTION
Enables system removal from a patch set on system details page (https://issues.redhat.com/browse/SPM-1311).

To verify, visit a system details page

1.  when that system has a set assigned, you should see 'Remove from patch set' action enabled on the right corner dropdown.

- the action should open a modal with confirmation purpose
- system should get unassigned, when user  hits on 'Remove' button on the modal.
- page should refresh after successful removal

2. when that system has no set assigned, you should see  'Remove from patch set' action disabled on the right corner dropdown
 