### PR TITLE
fix(api): errors from api response are passed down to components

### DIFF
--- a/src/Utilities/api.js
+++ b/src/Utilities/api.js
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-/* eslint-disable no-unused-vars */
 import axios from './axiosInterceptors';
 import { encodeApiParams, prepareEntitiesParams } from './Helpers';
 
@@ -14,17 +12,13 @@ export function createApiCall(
         endpoint = endpoint.concat(encodeApiParams(parameters));
     }
 
-    let result = window.insights.chrome.auth
-    .getUser()
-    .then(() =>
-        axios({
-            method,
-            url: '/api/patch/v1' + endpoint,
-            withCredentials: true,
-            data,
-            ...requestConfig
-        })
-    ).catch(err => err);
+    let result = axios({
+        method,
+        url: '/api/patch/v1' + endpoint,
+        withCredentials: true,
+        data,
+        ...requestConfig
+    });
 
     return result;
 }
@@ -65,20 +59,20 @@ export const fetchAdvisorySystems = params => {
 };
 
 export const fetchPackageSystems = params => {
-    const { package_name, ...args } = params;
-    return createApiCall(`/packages/${package_name}/systems`, 'get', prepareEntitiesParams(args));
+    const { package_name: packageName, ...args } = params;
+    return createApiCall(`/packages/${packageName}/systems`, 'get', prepareEntitiesParams(args));
 };
 
 export const fetchPackageVersions = params => {
-    const { package_name, ...args } = params;
-    return createApiCall(`/packages/${package_name}/versions`, 'get', args);
+    const { package_name: packageName, ...args } = params;
+    return createApiCall(`/packages/${packageName}/versions`, 'get', args);
 };
 
 export const fetchPackagesList = params => {
-    const { systems_updatable } = params.filter;
+    const { systems_updatable: systemsUpdatable } = params.filter;
 
     // we have to reset systems_updatable filter to include all filters when we want to show all the data
-    if (Array.isArray(systems_updatable) && systems_updatable.length === 2) {
+    if (Array.isArray(systemsUpdatable) && systemsUpdatable.length === 2) {
         const paramsWithoutSystemsUpdatable = JSON.parse(JSON.stringify(params));
         delete paramsWithoutSystemsUpdatable.filter.systems_updatable;
 

--- a/src/Utilities/api.test.js
+++ b/src/Utilities/api.test.js
@@ -5,36 +5,28 @@ import {
     exportSystemsCSV,
     exportSystemsJSON
 } from './api';
+import { initMocks } from '../Utilities/unitTestingUtilities';
 
-/* eslint-disable */
-window.insights = { chrome: { auth: { getUser: jest.fn(() => Promise.resolve({})) } } };
+initMocks();
 
 describe('api', () => {
     describe('test createApiCall function: ', () => {
-        it('Should "get" method in  createApiCall return response as json', () => {
-            global.fetch = jest.fn(() => Promise.resolve({
-                ok: true,
-                json: () => Promise.resolve({ success: true }),
-            })
-            );
-            const response = createApiCall('testEndpoint', 'get', { testParam: 1 }, { data: 'testData' });
-            response.then((res) => expect(res.success).toBeTruthy()).catch((err) => console.log(err));
-        });
-
         it('Should "get" method in  createApiCall return error from backend', () => {
             global.fetch = jest.fn(() => Promise.resolve({
                 ok: false,
                 status: 400,
                 statusText: 'testStatusText',
-                headers: { get: (type) => [] }
+                headers: { get: () => [] }
             })
             );
             const response = createApiCall('testEndpoint', 'get', { testParam: 1 }, { data: 'testData' });
-            response.then((res) => console.log(res)).catch((err) => expect(res).toEqual({
-                title: 'There was an error getting data',
-                detail: 'testStatusTextsssss',
-                status: 400
-            }));
+            response.catch((err) => {
+                expect(err).toEqual({
+                    title: 'There was an error getting data',
+                    detail: 'testStatusTextsssss',
+                    status: 400
+                });
+            });
         });
 
         it('Should "get" method in  createApiCall return network error', () => {
@@ -42,15 +34,15 @@ describe('api', () => {
                 ok: false,
                 status: 400,
                 statusText: 'testStatusText',
-                headers: { get: (type) => ['json'] }
+                headers: { get: () => ['json'] }
             })
             );
             const response = createApiCall('testEndpoint', 'get', { testParam: 1 }, { data: 'testData' });
-            response.then((res) => expect(res).toEqual({
+            response.catch((res) => expect(res).toEqual({
                 title: 'There was an error getting data',
                 detail: 'testStatusTextsssss',
                 status: 400
-            })).catch(err => { });
+            }));
         });
     });
 
@@ -99,7 +91,6 @@ describe('api', () => {
             );
             global.fetch.mockClear();
         });
-    })
+    });
 
 });
-/* eslint-enable */


### PR DESCRIPTION
The PR is intended to passdown api error response to the smart components. An error response is used to detect error status and handle correspondingly inside Smart components. e.g ([Systems.js](https://github.com/RedHatInsights/patchman-ui/blob/master/src/SmartComponents/Systems/Systems.js#L212) receives error status code and passes that to [ErrorHandler](https://github.com/RedHatInsights/patchman-ui/blob/master/src/PresentationalComponents/Snippets/ErrorHandler.js) ). Furthermore, redundant user checking before an api call is removed.

It also refactors test coverage code for api.js:

- disabled eslint rules are removed
- first test case for JSON response is removed as it is not necessary anymore
- some dirty code cleanup.