### PR TITLE
fix(TableView): wrap table toolbar with ErrorHandler

### DIFF
--- a/src/PresentationalComponents/TableView/TableView.js
+++ b/src/PresentationalComponents/TableView/TableView.js
@@ -56,50 +56,50 @@ const TableView = ({
         <React.Fragment>
             {
                 (<React.Fragment>
-                    <PrimaryToolbar
-                        pagination={{
-                            itemCount: metadata.total_items,
-                            page,
-                            perPage,
-                            isCompact: true,
-                            onSetPage,
-                            onPerPageSelect,
-                            ouiaId: `top-${paginationOUIA}`,
-                            isDisabled: metadata.total_items === 0
-                        }}
-                        filterConfig={filterConfig}
-                        activeFiltersConfig={{
-                            filters: buildFilterChips(filter, search, searchChipLabel),
-                            onDelete: deleteFilters,
-                            deleteTitle: intl.formatMessage(defaultFilters
-                                && messages.labelsFiltersReset || messages.labelsFiltersClear)
-                        }}
-                        actionsConfig={{
-                            actions: [remediationProvider && (
-                                <AsyncRemediationButton
-                                    remediationProvider={remediationProvider}
-                                    isDisabled={
-                                        Object.values(selectedRows).filter(isSelected => isSelected).length === 0
-                                    } />
-                            )]
-                        }}
-                        exportConfig={{
-                            isDisabled: metadata.total_items === 0,
-                            onSelect: onExport
-                        }}
-                        bulkSelect={onSelect && useBulkSelectConfig(selectedCount, onSelect, metadata, rows, onCollapse)}
-
-                    >
-                        { CreatePatchSet && <ToolbarItem>
-                            <CreatePatchSet />
-                        </ToolbarItem>}
-                        { EditPatchSet && <ToolbarItem>
-                            <EditPatchSet />
-                        </ToolbarItem>}
-                    </PrimaryToolbar>
                     {isLoading && <SkeletonTable colSize={5} rowSize={20} />
-                        || hasError && <ErrorHandler code={code} ErrorState={errorState} EmptyState={emptyState}/>
+                        || hasError && <ErrorHandler code={code} ErrorState={errorState} EmptyState={emptyState} />
                         || <React.Fragment>
+                            <PrimaryToolbar
+                                pagination={{
+                                    itemCount: metadata.total_items,
+                                    page,
+                                    perPage,
+                                    isCompact: true,
+                                    onSetPage,
+                                    onPerPageSelect,
+                                    ouiaId: `top-${paginationOUIA}`,
+                                    isDisabled: metadata.total_items === 0
+                                }}
+                                filterConfig={filterConfig}
+                                activeFiltersConfig={{
+                                    filters: buildFilterChips(filter, search, searchChipLabel),
+                                    onDelete: deleteFilters,
+                                    deleteTitle: intl.formatMessage(defaultFilters
+                                && messages.labelsFiltersReset || messages.labelsFiltersClear)
+                                }}
+                                actionsConfig={{
+                                    actions: [remediationProvider && (
+                                        <AsyncRemediationButton
+                                            remediationProvider={remediationProvider}
+                                            isDisabled={
+                                                Object.values(selectedRows).filter(isSelected => isSelected).length === 0
+                                            } />
+                                    )]
+                                }}
+                                exportConfig={{
+                                    isDisabled: metadata.total_items === 0,
+                                    onSelect: onExport
+                                }}
+                                bulkSelect={onSelect && useBulkSelectConfig(selectedCount, onSelect, metadata, rows, onCollapse)}
+
+                            >
+                                { CreatePatchSet && <ToolbarItem>
+                                    <CreatePatchSet />
+                                </ToolbarItem>}
+                                { EditPatchSet && <ToolbarItem>
+                                    <EditPatchSet />
+                                </ToolbarItem>}
+                            </PrimaryToolbar>
                             <Table
                                 aria-label="Patch table view"
                                 cells={columns}

--- a/src/SmartComponents/Systems/Systems.js
+++ b/src/SmartComponents/Systems/Systems.js
@@ -69,7 +69,7 @@ const Systems = () => {
     const selectedRows = useSelector(
         ({ entities }) => entities?.selectedRows || []
     );
-    const status = useSelector(
+    const { hasError, code } = useSelector(
         ({ entities }) => entities?.status || {}
     );
     const queryParams = useSelector(
@@ -199,91 +199,90 @@ const Systems = () => {
     return (
         <React.Fragment>
             <Header title={intl.formatMessage(messages.titlesPatchSystems)} headerOUIA={'systems'} />
-            <SystemsStatusReport apply={apply} queryParams={queryParams}/>
-            {(patchSetState.isUnassignSystemsModalOpen && isPatchSetEnabled) && <UnassignSystemsModal
-                unassignSystemsModalState={patchSetState}
-                setUnassignSystemsModalOpen={setPatchSetState}
-                systemsIDs={patchSetState.systemsIDs}
-            />}
-            {(patchSetState.isPatchSetWizardOpen && isPatchSetEnabled) &&
-                <PatchSetWizard systemsIDs={patchSetState.systemsIDs} setBaselineState={setPatchSetState}/>}
-            {isRemediationOpen && <RemediationModalCmp /> || null}
-            <Main>
-                {status.hasError && <ErrorHandler code={status.code} /> ||
-                    (
-                        <InventoryTable
-                            ref={inventory}
-                            isFullView
-                            autoRefresh
-                            initialLoading
-                            hideFilters={{ all: true, tags: false }}
-                            columns={(defaultColumns) => systemsColumnsMerger(defaultColumns, true)}
-                            showTags
-                            customFilters={{
-                                patchParams: {
-                                    search,
-                                    filter,
-                                    systemProfile,
-                                    selectedTags
-                                }
-                            }}
-                            paginationProps={{
-                                isDisabled: totalItems === 0
-                            }}
-                            onLoad={({ mergeWithEntities }) => {
-                                register({
-                                    ...mergeWithEntities(
-                                        inventoryEntitiesReducer(systemsListColumns(isPatchSetEnabled), modifyInventory),
-                                        persistantParams({ page, perPage, sort, search }, decodedParams)
-                                    )
-                                });
-                            }}
-                            getEntities={getEntities}
-                            actions={systemsRowActions(
-                                showRemediationModal, showBaselineModal, isPatchSetEnabled, openUnassignSystemsModal
-                            )}
-                            tableProps={{
-                                actionResolver: (row) => systemsRowActions(
-                                    showRemediationModal, showBaselineModal, isPatchSetEnabled, openUnassignSystemsModal, row
-                                ),
-                                canSelectAll: false,
-                                variant: TableVariant.compact, className: 'patchCompactInventory', isStickyHeader: true
-                            }}
-                            bulkSelect={useBulkSelectConfig(selectedCount, onSelect, { total_items: totalItems }, systems)}
-                            exportConfig={{
-                                isDisabled: totalItems === 0,
-                                onSelect: onExport
-                            }}
-                            actionsConfig={isPatchSetEnabled && {
-                                actions: [
-                                    <Button onClick={assignMultipleSystems}
-                                        key='assign-multiple-systems'
-                                        isDisabled={selectedCount === 0}>
-                                        {intl.formatMessage(messages.titlesPatchSetAssign)}
-                                    </Button>,
-                                    {
-                                        key: 'remove-multiple-systems',
-                                        label: intl.formatMessage(messages.titlesPatchSetRemoveMultipleButton),
-                                        onClick: () => openUnassignSystemsModal(filterSelectedActiveSystemIDs(selectedRows)),
-                                        props: { isDisabled: selectedCount === 0 }
-                                    }
-                                ] }
+            {hasError && <ErrorHandler code={code} /> || <React.Fragment>
+                <SystemsStatusReport apply={apply} queryParams={queryParams} />
+                {(patchSetState.isUnassignSystemsModalOpen && isPatchSetEnabled) && <UnassignSystemsModal
+                    unassignSystemsModalState={patchSetState}
+                    setUnassignSystemsModalOpen={setPatchSetState}
+                    systemsIDs={patchSetState.systemsIDs}
+                />}
+                {(patchSetState.isPatchSetWizardOpen && isPatchSetEnabled) &&
+                    <PatchSetWizard systemsIDs={patchSetState.systemsIDs} setBaselineState={setPatchSetState} />}
+                {isRemediationOpen && <RemediationModalCmp /> || null}
+                <Main>
+                    <InventoryTable
+                        ref={inventory}
+                        isFullView
+                        autoRefresh
+                        initialLoading
+                        hideFilters={{ all: true, tags: false }}
+                        columns={(defaultColumns) => systemsColumnsMerger(defaultColumns, true)}
+                        showTags
+                        customFilters={{
+                            patchParams: {
+                                search,
+                                filter,
+                                systemProfile,
+                                selectedTags
                             }
-                            filterConfig={filterConfig}
-                            activeFiltersConfig={activeFiltersConfig}
-                            dedicatedAction={(
-                                <AsyncRemediationButton
-                                    remediationProvider={remediationDataProvider}
-                                    isDisabled={
-                                        arrayFromObj(selectedRows).length === 0
-                                    }
-                                    isLoading={isRemediationLoading}
-                                />
-                            )}
-                        />
-                    )
-                }
-            </Main>
+                        }}
+                        paginationProps={{
+                            isDisabled: totalItems === 0
+                        }}
+                        onLoad={({ mergeWithEntities }) => {
+                            register({
+                                ...mergeWithEntities(
+                                    inventoryEntitiesReducer(systemsListColumns(isPatchSetEnabled), modifyInventory),
+                                    persistantParams({ page, perPage, sort, search }, decodedParams)
+                                )
+                            });
+                        }}
+                        getEntities={getEntities}
+                        actions={systemsRowActions(
+                            showRemediationModal, showBaselineModal, isPatchSetEnabled, openUnassignSystemsModal
+                        )}
+                        tableProps={{
+                            actionResolver: (row) => systemsRowActions(
+                                showRemediationModal, showBaselineModal, isPatchSetEnabled, openUnassignSystemsModal, row
+                            ),
+                            canSelectAll: false,
+                            variant: TableVariant.compact, className: 'patchCompactInventory', isStickyHeader: true
+                        }}
+                        bulkSelect={useBulkSelectConfig(selectedCount, onSelect, { total_items: totalItems }, systems)}
+                        exportConfig={{
+                            isDisabled: totalItems === 0,
+                            onSelect: onExport
+                        }}
+                        actionsConfig={isPatchSetEnabled && {
+                            actions: [
+                                <Button onClick={assignMultipleSystems}
+                                    key='assign-multiple-systems'
+                                    isDisabled={selectedCount === 0}>
+                                    {intl.formatMessage(messages.titlesPatchSetAssign)}
+                                </Button>,
+                                {
+                                    key: 'remove-multiple-systems',
+                                    label: intl.formatMessage(messages.titlesPatchSetRemoveMultipleButton),
+                                    onClick: () => openUnassignSystemsModal(filterSelectedActiveSystemIDs(selectedRows)),
+                                    props: { isDisabled: selectedCount === 0 }
+                                }
+                            ]
+                        }
+                        }
+                        filterConfig={filterConfig}
+                        activeFiltersConfig={activeFiltersConfig}
+                        dedicatedAction={(
+                            <AsyncRemediationButton
+                                remediationProvider={remediationDataProvider}
+                                isDisabled={
+                                    arrayFromObj(selectedRows).length === 0
+                                }
+                                isLoading={isRemediationLoading}
+                            />
+                        )}
+                    />
+                </Main>
+            </React.Fragment>}
         </React.Fragment>
     );
 };

--- a/src/store/Reducers/InventoryEntitiesReducer.js
+++ b/src/store/Reducers/InventoryEntitiesReducer.js
@@ -1,6 +1,6 @@
 import { createSystemsRows } from '../../Utilities/DataMappers';
 import { createPackageSystemsRows } from '../../Utilities/DataMappers';
-import { selectRows } from './HelperReducers';
+import { selectRows, fetchRejected } from './HelperReducers';
 import * as ActionTypes from '../ActionTypes';
 
 // Initial State. It should not include page and perPage to persist them dynamically
@@ -54,8 +54,7 @@ export const inventoryEntitiesReducer = (columns, inventoryModifier) => (state =
             return newState;
 
         case 'LOAD_ENTITIES_REJECTED':
-            newState.status = { isLoading: true, hasError: true };
-            return newState;
+            return fetchRejected(newState, action);
 
         case 'SELECT_ENTITY': {
             const stateAfterSelection = selectRows(newState, action);

--- a/src/store/Reducers/InventoryEntitiesReducer.test.js
+++ b/src/store/Reducers/InventoryEntitiesReducer.test.js
@@ -7,8 +7,8 @@ describe('InventoryEntitiesReducer tests', () => {
     it.each`
     columns                 |  state                                                                | action                                                | result
     ${[]}                   |  ${{ ...initialState, loaded: false, columns: [{ key: 'testCol' }] }} | ${{ type: 'LOAD_ENTITIES_FULFILLED', payload: {} }}   | ${{ ...initialState, loaded: false, columns: [{ key: 'testCol' }] }}
-    ${[]}                   |  ${{ ...initialState, loaded: false, columns: [{ key: 'testCol' }] }} | ${{ type: 'LOAD_ENTITIES_PENDING', payload: {} }}   | ${{ ...initialState, loaded: false, status: { isLoading: true, hasError: false }, columns: [{ key: 'testCol' }] }}
-    ${[]}                   |  ${{ ...initialState, loaded: false, columns: [{ key: 'testCol' }] }} | ${{ type: 'LOAD_ENTITIES_REJECTED', payload: {} }}   | ${{ ...initialState, loaded: false, status: { isLoading: true, hasError: true }, columns: [{ key: 'testCol' }] }}
+    ${[]}                   |  ${{ ...initialState, loaded: false, columns: [{ key: 'testCol' }] }} | ${{ type: 'LOAD_ENTITIES_PENDING', payload: {} }}   | ${{ ...initialState, loaded: false, status: { isLoading: true, hasError: false,  }, columns: [{ key: 'testCol' }] }}
+    ${[]}                   |  ${{ ...initialState, loaded: false, columns: [{ key: 'testCol' }] }} | ${{ type: 'LOAD_ENTITIES_REJECTED', payload: { status: 400 } }}   | ${{ ...initialState, loaded: false, status: { isLoading: false, code: 400, hasError: true }, error: { status: 400 }, metadata: {}, columns: [{ key: 'testCol' }] }}
     ${[]}                   |  ${{ ...initialState, loaded: false, columns: [{ key: 'testCol' }] }} | ${{ type: 'SELECT_ENTITY', payload: [{ id: '83e97cde-74b4-4752-819d-704687bbc286' }] }}}   | ${{ ...initialState, loaded: false, columns: [{ key: 'testCol' }], selectedRows: { "83e97cde-74b4-4752-819d-704687bbc286": undefined } }}
 
     `('$action', ({ columns, state, action: { type, payload }, result }) => {


### PR DESCRIPTION
This will hide the table toolbar when there is an some error.

Before: 

![image](https://user-images.githubusercontent.com/59481011/173809261-ffba1b7e-ee70-4aaa-9583-86c21151efb4.png)




After:
![image](https://user-images.githubusercontent.com/59481011/173808940-22c21d3a-e04f-4c7c-b0cd-786a11c6324e.png)
