### PR TITLE
fix(Date): improve validation, introduce date start limit

### DIFF
--- a/src/Messages.js
+++ b/src/Messages.js
@@ -141,6 +141,16 @@ export default defineMessages({
         description: 'Label',
         defaultMessage: 'Description'
     },
+    labelsErrorDateLimit: {
+        id: 'labelsErrorDateLimit',
+        description: 'Label',
+        defaultMessage: 'Date is before the allowable range.'
+    },
+    labelsErrorInvalidDate: {
+        id: 'labelsErrorInvalidDate',
+        description: 'Label',
+        defaultMessage: 'The date should be valid of a type YYYY-MM-DD'
+    },
     labelsFiltersClear: {
         id: 'labelsFiltersClear',
         description: 'label for remove filter chips',

--- a/src/SmartComponents/PatchSetWizard/InputFields/ToDateField.js
+++ b/src/SmartComponents/PatchSetWizard/InputFields/ToDateField.js
@@ -7,6 +7,9 @@ import {
 } from '@patternfly/react-core';
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
 import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
+import dateValidator from '../../../Utilities/dateValidator';
+import { intl } from '../../../Utilities/IntlProvider';
+import messages from '../../../Messages';
 
 const ToDateField = (props) => {
     const { input } = useFieldApi(props);
@@ -35,6 +38,8 @@ const ToDateField = (props) => {
                         }}
                         popoverProps={{ position: 'right' }}
                         aria-label="toDate"
+                        validators={[dateValidator]}
+                        invalidFormatText={intl.formatMessage(messages.labelsErrorInvalidDate)}
                     />
                 </FlexItem>
             </Flex>

--- a/src/SmartComponents/PatchSetWizard/InputFields/ToDateField.test.js
+++ b/src/SmartComponents/PatchSetWizard/InputFields/ToDateField.test.js
@@ -1,5 +1,6 @@
 import ToDateField from './ToDateField';
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
+import dateValidator from '../../../Utilities/dateValidator';
 
 jest.mock('@data-driven-forms/react-form-renderer/use-form-api',
     () => ({
@@ -14,6 +15,10 @@ jest.mock('@data-driven-forms/react-form-renderer/use-field-api',
             onChange: jest.fn()
         }
     }))
+);
+
+jest.mock('../../../Utilities/dateValidator',
+    () => jest.fn(() => ({}))
 );
 
 describe('ConfigurationFields.js', () => {
@@ -37,6 +42,12 @@ describe('ConfigurationFields.js', () => {
 
         const wrapper = mount(<ToDateField />);
         expect(wrapper.find('input').props().value).toBeFalsy();
+    });
+
+    it('Should pass dateValidator', () => {
+        const wrapper = mount(<ToDateField />);
+        const validators = wrapper.find('DatePicker').props().validators;
+        expect(validators).toContain(dateValidator);
     });
 });
 

--- a/src/SmartComponents/PatchSetWizard/WizardAssets.js
+++ b/src/SmartComponents/PatchSetWizard/WizardAssets.js
@@ -3,6 +3,7 @@ import validatorTypes from '@data-driven-forms/react-form-renderer/validator-typ
 import { intl } from '../../Utilities/IntlProvider';
 import messages from '../../Messages';
 import { filterSelectedActiveSystemIDs } from '../../Utilities/Helpers';
+import dateValidator from '../../Utilities/dateValidator';
 
 export const reviewSystemColumns = [{
     key: 'display_name',
@@ -55,9 +56,7 @@ export const toDateComponent = [{
     component: 'toDateField',
     validate: [
         { type: validatorTypes.REQUIRED },
-        { type: validatorTypes.PATTERN,
-            pattern: /^(\d{4})-(\d{2})-(\d{2})$/
-        }
+        { type: 'validate-date' }
     ]
 }];
 
@@ -135,5 +134,6 @@ export const validatorMapper = {
         } else {
             return intl.formatMessage(messages.templateNoSystemSelected);
         }
-    }
+    },
+    'validate-date': () => dateValidator
 };

--- a/src/Utilities/dateValidator.js
+++ b/src/Utilities/dateValidator.js
@@ -1,0 +1,32 @@
+import { intl } from './IntlProvider';
+import messages from '../Messages';
+
+/*
+validates date of a type YYYY-MM-DD with starting limit 1990-01-01.
+regex is used to comply the Patternfly date format.
+*/
+const dateValidator = (dateStr) => {
+    const regex = /^(\d{4})-(0[1-9]|1[012])-(0?[1-9]|[12][0-9]|3[01])$/;
+
+    if (dateStr && typeof dateStr === 'string' && dateStr.match(regex) === null) {
+        return intl.formatMessage(messages.labelsErrorInvalidDate);
+    }
+
+    const date = new Date(dateStr);
+    const timestamp = date.getTime();
+
+    //Month had to be set to equal 0 to get the first month of the year.
+    const minDate = new Date(1990, 0, 1);
+
+    if (typeof timestamp !== 'number' || Number.isNaN(timestamp)) {
+        return intl.formatMessage(messages.labelsErrorInvalidDate);
+    }
+
+    if (date < minDate) {
+        return intl.formatMessage(messages.labelsErrorDateLimit);
+    }
+
+    return;
+};
+
+export default dateValidator;

--- a/src/Utilities/dateValidator.test.js
+++ b/src/Utilities/dateValidator.test.js
@@ -1,0 +1,17 @@
+import dateValidator from './dateValidator';
+
+describe('dateValidator', () =>{
+    it.each`
+    date | result
+    ${'1990-01-01'} | ${undefined}
+    ${'2022-01-01'} | ${undefined}
+    ${'2022-12-01'} | ${undefined}
+    ${'1428-02-03'} | ${'Date is before the allowable range.'}
+    ${'1989-12-31'} | ${'Date is before the allowable range.'}
+    ${'2022-1-01'}  | ${'The date should be valid of a type YYYY-MM-DD'}
+    ${'random-text'}| ${'The date should be valid of a type YYYY-MM-DD'}
+    `('dateValidator: Should match validate date', ({ date, result }) => {
+        let validatedResult = dateValidator(date);
+        expect(validatedResult).toEqual(result);
+    });
+});


### PR DESCRIPTION
This is to improve date field validation and introduce start limit.

To check locally:

- make sure that the date input does not let users select a date prior to 1990.01.01
- make sure that input field validates: wrong date, date input format
