### PR TITLE
chore(PatchTemplate): put all patch template work under a feature flag and fix wizard title bug

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -4,6 +4,8 @@ import React, { Fragment, lazy, Suspense, useState } from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import { fetchSystems } from './Utilities/api';
 import { useHistory } from 'react-router-dom';
+import { useFeatureFlag } from './Utilities/Hooks';
+import { featureFlags } from './Utilities/constants';
 
 const Advisories = lazy(() =>
     import(
@@ -116,6 +118,8 @@ export const Routes = (props) => {
 
     const path = props.childProps.location.pathname;
 
+    const isPatchSetEnabled = useFeatureFlag(featureFlags.patch_set);
+
     return (
         // I recommend discussing with UX some nice loading placeholder
         <Suspense fallback={Fragment}>
@@ -158,16 +162,18 @@ export const Routes = (props) => {
                     path={paths.packageDetail.to}
                     component={PackageDetail}
                 />
-                <Route
+                {isPatchSetEnabled && <Route
                     exact
                     path={paths.templates.to}
                     component={Templates}
-                />
+                />}
 
                 <Route
                     render={() =>
-                        !some(paths, p => p.to === path) && (
-                            <Redirect to={paths.advisories.to} />
+                        (
+                            (!isPatchSetEnabled || !some(paths, p => p.to === path)) && (
+                                <Redirect to={paths.advisories.to} />
+                            )
                         )
                     }
                 />

--- a/src/SmartComponents/PatchSetWizard/InputFields/ToDateField.js
+++ b/src/SmartComponents/PatchSetWizard/InputFields/ToDateField.js
@@ -30,7 +30,6 @@ const ToDateField = (props) => {
                 </FlexItem>
                 <FlexItem lg={10} md={10}>
                     <DatePicker
-                        isRequired
                         value={toDate}
                         onChange={(val) => {
                             input.onChange(val);

--- a/src/SmartComponents/PatchSetWizard/PatchSetWizard.js
+++ b/src/SmartComponents/PatchSetWizard/PatchSetWizard.js
@@ -16,7 +16,7 @@ import ToDateField from './InputFields/ToDateField';
 import DescriptionField from './InputFields/DescriptionField';
 import ReviewSystems from './steps/ReviewSystems';
 import ReviewPatchSet from './steps/ReviewPatchSet';
-import { schema, validatorMapper } from './WizardAssets';
+import { schema, validatorMapper, getWizardTitle } from './WizardAssets';
 import RequestProgress from './steps/RequestProgress';
 import { usePatchSetApi } from '../../Utilities/Hooks';
 import { intl } from '../../Utilities/IntlProvider';
@@ -113,7 +113,7 @@ export const PatchSetWizard = ({ systemsIDs, setBaselineState, patchSetID }) => 
                 >
                     <Wizard
                         className="patch-set"
-                        title={intl.formatMessage(messages.templateTitle)}
+                        title={getWizardTitle(wizardType)}
                         description={intl.formatMessage(messages.templateDescription)}
                         steps={[
                             {

--- a/src/SmartComponents/PatchSetWizard/WizardAssets.js
+++ b/src/SmartComponents/PatchSetWizard/WizardAssets.js
@@ -60,7 +60,7 @@ export const toDateComponent = [{
     ]
 }];
 
-export const schema = (wizardType) =>{
+export const getWizardTitle = (wizardType) => {
     let wizardTitle = '';
 
     switch (wizardType) {
@@ -74,6 +74,10 @@ export const schema = (wizardType) =>{
             wizardTitle = intl.formatMessage(messages.templateTitle);
     }
 
+    return wizardTitle;
+};
+
+export const schema = (wizardType) =>{
     return ({
         fields: [
             {
@@ -82,7 +86,7 @@ export const schema = (wizardType) =>{
                 isDynamic: true,
                 inModal: true,
                 showTitles: true,
-                title: wizardTitle,
+                title: getWizardTitle(wizardType),
                 description: intl.formatMessage(messages.templateDescription),
                 fields: [
                     {

--- a/src/SmartComponents/SystemDetail/InventoryDetail.js
+++ b/src/SmartComponents/SystemDetail/InventoryDetail.js
@@ -7,7 +7,7 @@ import { register } from '../../store';
 import { SystemDetailStore } from '../../store/Reducers/SystemDetailStore';
 import { intl } from '../../Utilities/IntlProvider';
 import messages from '../../Messages';
-import { setPageTitle } from '../../Utilities/Hooks';
+import { setPageTitle, useFeatureFlag } from '../../Utilities/Hooks';
 import { InventoryDetailHead, AppInfo, DetailWrapper } from '@redhat-cloud-services/frontend-components/Inventory';
 import { Alert, Grid, GridItem, TextContent, Text } from '@patternfly/react-core';
 import { fetchSystemDetailsAction } from '../../store/Actions/Actions';
@@ -16,6 +16,7 @@ import { clearNotifications } from '@redhat-cloud-services/frontend-components-n
 import ErrorHandler from '../../PresentationalComponents/Snippets/ErrorHandler';
 import PatchSetWrapper from '../../PresentationalComponents/PatchSetWrapper/PatchSetWrapper';
 import usePatchSetState from '../../Utilities/usePatchSetState';
+import { featureFlags } from '../../Utilities/constants';
 
 const InventoryDetail = ({ match }) => {
     const dispatch = useDispatch();
@@ -44,6 +45,8 @@ const InventoryDetail = ({ match }) => {
         openPatchSetAssignWizard(entityId);
     };
 
+    const isPatchSetEnabled = useFeatureFlag(featureFlags.patch_set);
+
     return (
         <DetailWrapper
             onLoad={({ mergeWithDetail }) => {
@@ -70,7 +73,7 @@ const InventoryDetail = ({ match }) => {
             >
                 {(!loaded || insightsID) && <InventoryDetailHead hideBack
                     showTags
-                    actions={[
+                    actions={isPatchSetEnabled && [
                         {
                             title: intl.formatMessage(messages.titlesTemplateAssign),
                             key: 'assign-to-template',

--- a/src/SmartComponents/SystemDetail/InventoryDetail.test.js
+++ b/src/SmartComponents/SystemDetail/InventoryDetail.test.js
@@ -9,12 +9,13 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { InventoryDetailHead } from '@redhat-cloud-services/frontend-components/Inventory';
 import UnassignSystemsModal from '../Modals/UnassignSystemsModal';
+import { useFeatureFlag } from '../../Utilities/Hooks';
 
 initMocks();
 
 jest.mock('../../Utilities/Hooks', () => ({
     ...jest.requireActual('../../Utilities/Hooks'),
-    useFeatureFlag: jest.fn()
+    useFeatureFlag: jest.fn(() => true)
 }));
 
 jest.mock('react-redux', () => ({
@@ -124,6 +125,16 @@ describe('InventoryPage.js', () => {
         });
 
         expect(store.getActions().filter(action => action.type === 'FETCH_SYSTEM_DETAIL').length).toEqual(2);
+    });
+
+    it('Should hide all dropdown actions when patch template flag is disabled', () => {
+        useFeatureFlag.mockReturnValueOnce(false);
+        const tempWrapper = mountWithIntl(<Provider store={store}>
+            <Router><InventoryDetail match={{ params: { inventoryId: 'test' } }} /></Router>
+        </Provider>);
+
+        const { actions } = tempWrapper.find(InventoryDetailHead).props();
+        expect(actions.length).toEqual(undefined);
     });
 });
 

--- a/src/SmartComponents/Systems/System.test.js
+++ b/src/SmartComponents/Systems/System.test.js
@@ -8,8 +8,9 @@ import { initMocks, mountWithIntl } from '../../Utilities/unitTestingUtilities.j
 import Systems from './Systems';
 import toJson from 'enzyme-to-json';
 import { useFeatureFlag } from '../../Utilities/Hooks';
-
 import UnassignSystemsModal from '../Modals/UnassignSystemsModal';
+import { systemsColumnsMerger } from '../../Utilities/Helpers';
+
 initMocks();
 
 jest.mock('react-redux', () => ({
@@ -50,6 +51,11 @@ jest.mock('../../Utilities/api', () => ({
 jest.mock('../../Utilities/Hooks', () => ({
     ...jest.requireActual('../../Utilities/Hooks'),
     useFeatureFlag: jest.fn()
+}));
+
+jest.mock('../../Utilities/Helpers', () => ({
+    ...jest.requireActual('../../Utilities/Helpers'),
+    systemsColumnsMerger: jest.fn()
 }));
 
 const mockState = {
@@ -230,6 +236,18 @@ describe('Systems.js', () => {
                 </Provider>);
 
                 expect(tempWrapper.find(UnassignSystemsModal)).toHaveLength(0);
+            });
+
+            it('should Patch template column be hidden when flag is not enabled', () => {
+                useFeatureFlag.mockReturnValue(false);
+                systemsColumnsMerger.mockImplementation(() => {});
+
+                const tempWrapper = mountWithIntl(<Provider store={store}>
+                    <Router><Systems /></Router>
+                </Provider>);
+
+                tempWrapper.find('.testInventroyComponentChild').parent().props().columns(['test-column']);
+                expect(systemsColumnsMerger).toHaveBeenCalledWith(['test-column'], false);
             });
         });
 

--- a/src/SmartComponents/Systems/Systems.js
+++ b/src/SmartComponents/Systems/Systems.js
@@ -146,7 +146,7 @@ const Systems = () => {
                         autoRefresh
                         initialLoading
                         hideFilters={{ all: true, tags: false }}
-                        columns={(defaultColumns) => systemsColumnsMerger(defaultColumns, true)}
+                        columns={(defaultColumns) => systemsColumnsMerger(defaultColumns, isPatchSetEnabled)}
                         showTags
                         customFilters={{
                             patchParams: {


### PR DESCRIPTION
Introduces a feature flag again for all patch template work and fixes the wizard title bug.

Please verify:

1. When you click on the 'Templates' nav, the page gets redirected to the Advisories page(landing page).
2. Systems page has no 'Assign to patch set' button, Patch template column, and row actions do not include any action related to patch templates.
3. Inventory details header has no patch template name and no actions in the dropdown.
4. On The last step in the wizard after a patch template has been created/edited/assigned, the wizard title dynamically changes. Please refer video below:
[screencast-2022-07-19-132703.webm](https://user-images.githubusercontent.com/59481011/179709041-021c8902-e726-42a6-b081-2451d842e9e9.webm)


