### PR TITLE
chore(PatchTemplate): add notifications when api req fails

### DIFF
--- a/src/SmartComponents/PatchSetWizard/WizardAssets.js
+++ b/src/SmartComponents/PatchSetWizard/WizardAssets.js
@@ -137,3 +137,9 @@ export const validatorMapper = {
     },
     'validate-date': () => dateValidator
 };
+
+export const apiFailedNotification = (description) => ({
+    title: 'There was an error while processing your request',
+    description,
+    variant: 'danger'
+});

--- a/src/SmartComponents/PatchSetWizard/steps/RequestProgress.js
+++ b/src/SmartComponents/PatchSetWizard/steps/RequestProgress.js
@@ -19,9 +19,21 @@ import {
 } from '@patternfly/react-icons';
 import { intl } from '../../../Utilities/IntlProvider';
 import messages from '../../../Messages';
+import { useDispatch } from 'react-redux';
+import { apiFailedNotification } from '../WizardAssets';
+import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
 
 const RequestProgress = ({ onClose, state }) => {
-    const { requestPending, failed } = state;
+    const { requestPending, failed, error } = state;
+    const dispatch = useDispatch();
+
+    if (failed) {
+        dispatch(
+            addNotification(
+                apiFailedNotification(error.detail)
+            )
+        );
+    }
 
     return (
         <EmptyState

--- a/src/Utilities/Hooks.js
+++ b/src/Utilities/Hooks.js
@@ -309,8 +309,8 @@ export const usePatchSetApi = (wizardState, setWizardState, patchSetID) => {
     .then(() => {
         setWizardState({ ...wizardState, submitted: true, failed: false, requestPending: false });
     })
-    .catch(() => {
-        setWizardState({ ...wizardState, submitted: true, failed: true, requestPending: false });
+    .catch((error) => {
+        setWizardState({ ...wizardState, submitted: true, failed: true, requestPending: false, error });
     });
 
     const onSubmit = React.useCallback((formValues) => {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,4 +1,3 @@
-/* eslint new-cap: 0 */
 import notificationsMiddleware from '@redhat-cloud-services/frontend-components-notifications/notificationsMiddleware';
 import { notificationsReducer } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import { getRegistry } from '@redhat-cloud-services/frontend-components-utilities/Registry';


### PR DESCRIPTION
This adds an error notification when a user tries to create a patch template with a name that already exists.

to reproduce:
1. Click on the Templates nav,
2. Randomly choose an existing template name from the table,
3. Click on the 'Create a template' button on the table toolbar.
4. Create a patch template with the name that you have chosen.
5. After you click on the 'Submit' button on the last step, an error notification should pop up.

