### PR TITLE
fix(InventoryTable): avoids broken systems page by using different pr…

### DIFF
--- a/src/SmartComponents/Systems/Systems.js
+++ b/src/SmartComponents/Systems/Systems.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 import { TableVariant } from '@patternfly/react-table';
 import { Button } from '@patternfly/react-core';
 import { InventoryTable } from '@redhat-cloud-services/frontend-components/Inventory';
@@ -35,7 +35,7 @@ import PatchSetWrapper from '../../PresentationalComponents/PatchSetWrapper/Patc
 import useOsVersionFilter from '../../PresentationalComponents/Filters/OsVersionFilter';
 
 const Systems = () => {
-    const inventory = useRef(null);
+    const inventory = React.createRef();
     const pageTitle = intl.formatMessage(messages.titlesSystems);
 
     setPageTitle(pageTitle);
@@ -157,7 +157,7 @@ const Systems = () => {
                         initialLoading
                         hideFilters={{ all: true, tags: false }}
                         columns={(defaultColumns) => systemsColumnsMerger(defaultColumns, isPatchSetEnabled)}
-                        showTags
+                        showTagModal
                         customFilters={{
                             patchParams: {
                                 search,


### PR DESCRIPTION
This PR fixes the broken systems page by using a different prop for the tags modal. The reloading inventory issue still exists.

To test:

1. run this PR against stage/beta
2. navigate to systems page
3. leave this open idle for 2-3 mins
4. observe that the systems table gets reloaded, but the page does not brake.