### PR TITLE
feat(SPM-624): open packages tab directly from systes page.

### DIFF
--- a/src/SmartComponents/SystemDetail/SystemDetail.js
+++ b/src/SmartComponents/SystemDetail/SystemDetail.js
@@ -1,5 +1,6 @@
+import React, { useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { Tab, Tabs, TabTitleText } from '@patternfly/react-core';
-import React from 'react';
 import SystemAdvisories from '../SystemAdvisories/SystemAdvisories';
 import { useSelector } from 'react-redux';
 import SystemPackages from '../SystemPackages/SystemPackages';
@@ -10,8 +11,12 @@ import { NotConnected } from '@redhat-cloud-services/frontend-components/NotConn
 import propTypes from 'prop-types';
 
 const SystemDetail = ({ isInventoryApp }) => {
-    const [activeTabKey, setActiveTabKey] = React.useState(0);
-    const [areTabsHidden, setTabsHidden] = React.useState(false);
+    const { state } = useLocation();
+
+    const [activeTabKey, setActiveTabKey] = useState(
+        (state?.tab === 'packages') ? 1 : 0
+    );
+    const [areTabsHidden, setTabsHidden] = useState(false);
 
     const entity = useSelector(({ entityDetails }) => entityDetails.entity || {});
     const onTabSelect = (event, id) => {

--- a/src/SmartComponents/SystemDetail/SystemDetail.test.js
+++ b/src/SmartComponents/SystemDetail/SystemDetail.test.js
@@ -1,33 +1,26 @@
 import SystemDetail from './SystemDetail';
-import toJson from 'enzyme-to-json';
-import { initMocks } from '../../Utilities/unitTestingUtilities.js';
-
-/* eslint-disable */
-initMocks()
+import { useLocation } from 'react-router-dom';
 
 jest.mock('react-redux', () => ({
     ...jest.requireActual('react-redux'),
-    useSelector: () => ({ entity: {}})
+    useSelector: () => ({ id: 'entity-id' })
 }));
 
-beforeEach(() => {  
-   console.error = () => {};
-});
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useLocation: jest.fn(() => ({ state: 'advisories' }))
+}));
 
 describe('SystemDetail.js', () => {
     it('Should match the snapshots', () => {
-        const wrapper = shallow(<SystemDetail entity = {{entity: { id: 1 }}} />); 
-        expect(toJson(wrapper.update())).toMatchSnapshot();
+        const wrapper = shallow(<SystemDetail />);
+        expect(wrapper.debug()).toMatchSnapshot();
     });
 
-    // was not able to mock the store. 
-    //Let's push this as hot fix and implement the test later
-
-    // it('Should change the tab', () => {
-    //     const wrapper = shallow(<SystemDetail />);
-    //     const onSelect = wrapper.find('Tabs').props().onSelect;
-    //     act(() => onSelect());
-    //     expect(wrapper.find('SystemPackages')).toBeTruthy();
-    // });
+    it('Should match the snapshot when Package tab is active by default', () => {
+        useLocation.mockImplementation(() => ({ state: { tab: 'packages' } }));
+        const wrapper = shallow(<SystemDetail />);
+        expect(wrapper.debug()).toMatchSnapshot();
+    });
 });
-/* eslint-enable */
+

--- a/src/SmartComponents/SystemDetail/__snapshots__/SystemDetail.test.js.snap
+++ b/src/SmartComponents/SystemDetail/__snapshots__/SystemDetail.test.js.snap
@@ -1,3 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SystemDetail.js Should match the snapshots 1`] = `""`;
+exports[`SystemDetail.js Should match the snapshot when Package tab is active by default 1`] = `
+"<Tabs activeKey={1} onSelect={[Function: onTabSelect]} className=\\"patchTabSelect\\" isHidden={true} isFilled={false} isSecondary={false} isVertical={false} isBox={false} hasBorderBottom={true} leftScrollAriaLabel=\\"Scroll left\\" rightScrollAriaLabel=\\"Scroll right\\" component=\\"div\\" mountOnEnter={false} unmountOnExit={false} ouiaSafe={true} variant=\\"default\\" onToggle={[Function: onToggle]}>
+  <Tab eventKey={0} title={{...}} data-ouia-component-type=\\"system-advisories-tab\\" data-ouia-component-id=\\"system-advisories-tab\\">
+    <withRouter(SystemAdvisories) handleNoSystemData={[Function: handleNoSystemData]} />
+  </Tab>
+  <Tab eventKey={1} title={{...}} data-ouia-component-type=\\"system-packages-tab\\" data-ouia-component-id=\\"system-packages-tab\\">
+    <SystemPackages handleNoSystemData={[Function: handleNoSystemData]} />
+  </Tab>
+</Tabs>"
+`;
+
+exports[`SystemDetail.js Should match the snapshots 1`] = `
+"<Tabs activeKey={0} onSelect={[Function: onTabSelect]} className=\\"patchTabSelect\\" isHidden={true} isFilled={false} isSecondary={false} isVertical={false} isBox={false} hasBorderBottom={true} leftScrollAriaLabel=\\"Scroll left\\" rightScrollAriaLabel=\\"Scroll right\\" component=\\"div\\" mountOnEnter={false} unmountOnExit={false} ouiaSafe={true} variant=\\"default\\" onToggle={[Function: onToggle]}>
+  <Tab eventKey={0} title={{...}} data-ouia-component-type=\\"system-advisories-tab\\" data-ouia-component-id=\\"system-advisories-tab\\">
+    <withRouter(SystemAdvisories) handleNoSystemData={[Function: handleNoSystemData]} />
+  </Tab>
+  <Tab eventKey={1} title={{...}} data-ouia-component-type=\\"system-packages-tab\\" data-ouia-component-id=\\"system-packages-tab\\">
+    <SystemPackages handleNoSystemData={[Function: handleNoSystemData]} />
+  </Tab>
+</Tabs>"
+`;

--- a/src/SmartComponents/SystemPackages/SystemPackages.js
+++ b/src/SmartComponents/SystemPackages/SystemPackages.js
@@ -1,6 +1,6 @@
+import React, { useMemo, useEffect } from 'react';
 import { Unavailable } from '@redhat-cloud-services/frontend-components/Unavailable';
 import propTypes from 'prop-types';
-import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import messages from '../../Messages';
 import searchFilter from '../../PresentationalComponents/Filters/SearchFilter';
@@ -40,17 +40,17 @@ const SystemPackages = ({ handleNoSystemData }) => {
     const error = useSelector(
         ({ SystemPackageListStore }) => SystemPackageListStore.error
     );
-    const rows = React.useMemo(
+    const rows = useMemo(
         () =>
             createSystemPackagesRows(packages, selectedRows),
         [packages,  selectedRows]
     );
 
-    React.useEffect(() => {
+    useEffect(() => {
         return () => dispatch(clearSystemPackagesStore());
     }, []);
 
-    React.useEffect(()=> {
+    useEffect(()=> {
         dispatch(fetchApplicableSystemPackages({ id: entity.id, ...queryParams }));
     }, [queryParams]);
 
@@ -78,7 +78,7 @@ const SystemPackages = ({ handleNoSystemData }) => {
     }
 
     const onSort = useSortColumn(systemPackagesColumns, apply, 1);
-    const sortBy = React.useMemo(
+    const sortBy = useMemo(
         () => createSortBy(systemPackagesColumns, metadata.sort, 1),
         [metadata.sort]
     );

--- a/src/SmartComponents/Systems/SystemsListAssets.js
+++ b/src/SmartComponents/Systems/SystemsListAssets.js
@@ -1,7 +1,7 @@
 import { fetchApplicableSystemAdvisoriesApi } from '../../Utilities/api';
 import { remediationIdentifiers } from '../../Utilities/constants';
 import { createAdvisoriesIcons, createUpgradableColumn,
-    remediationProvider, createOSColumn } from '../../Utilities/Helpers';
+    remediationProvider, createOSColumn, createPackagesColumn } from '../../Utilities/Helpers';
 import './SystemsListAssets.scss';
 
 export const systemsListColumns = (isPatchSetEnabled = false) => [
@@ -23,6 +23,7 @@ export const systemsListColumns = (isPatchSetEnabled = false) => [
     {
         key: 'packages_installed',
         title: 'Packages',
+        renderFunc: (packageCount, systemID) => createPackagesColumn(packageCount, systemID),
         props: {
             width: 10
         }

--- a/src/Utilities/Helpers.js
+++ b/src/Utilities/Helpers.js
@@ -212,6 +212,15 @@ export function getSeverityById(id) {
     );
 }
 
+export const createPackagesColumn = (packageCount, systemID) => (
+    <Link to={{
+        pathname: `/systems/${systemID}`,
+        state: { tab: 'packages' }
+    }}>
+        {packageCount}
+    </Link>
+);
+
 export function handlePatchLink(type, name, body) {
     if (location.href.indexOf('inventory') === -1) {
         return (

--- a/src/Utilities/Hooks.js
+++ b/src/Utilities/Hooks.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useCallback } from 'react';
+import { useLocation, useHistory } from 'react-router-dom';
 import { SortByDirection } from '@patternfly/react-table/dist/js';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux/actions/notifications';
 import { downloadFile } from '@redhat-cloud-services/frontend-components-utilities/helpers';
@@ -375,4 +376,20 @@ export const useFeatureFlag = (flag) => {
     // const flagStatus = useFlag(flag);
 
     return insights.chrome.isBeta();
+};
+
+/***
+ * Pushes new URL params together location state into the history
+ * @param {object} [queryParams] query params to build the URL params
+ * @returns {historyPusher} function to trigger the push
+ */
+export const usePushUrlParams = (queryParams) => {
+    const history = useHistory();
+    const location = useLocation();
+
+    const historyPusher = useCallback(() => {
+        history.push({ pathname: `${location.pathname}${encodeURLParams(queryParams)}`, state: location.state });
+    }, [JSON.stringify(queryParams), location.state, location.pathname]);
+
+    return historyPusher;
 };

--- a/src/Utilities/Hooks.js
+++ b/src/Utilities/Hooks.js
@@ -388,7 +388,7 @@ export const usePushUrlParams = (queryParams) => {
     const location = useLocation();
 
     const historyPusher = useCallback(() => {
-        history.push({ pathname: `${location.pathname}${encodeURLParams(queryParams)}`, state: location.state });
+        history.push({ pathname: location.pathname, search: encodeURLParams(queryParams), state: location.state });
     }, [JSON.stringify(queryParams), location.state, location.pathname]);
 
     return historyPusher;


### PR DESCRIPTION
This enables to open the Packages tab directly by clicking the package number on the Systems page.

To test:
1. Visit the Systems page,
2. click on a package number in the table
3. Observe that the packages tab is opened by default.
4. In any other case, the advisor tab is active by default.
5. When systems detail page is opened using URL, advisor tab should be active, page should not break.