### PR TITLE
fix(inventory-load-bug): removes showTag param

### DIFF
--- a/src/SmartComponents/AdvisorySystems/AdvisorySystems.js
+++ b/src/SmartComponents/AdvisorySystems/AdvisorySystems.js
@@ -135,7 +135,6 @@ const AdvisorySystems = ({ advisoryName }) => {
                     ignoreRefresh
                     hideFilters={{ all: true, tags: false }}
                     columns={(defaultColumns) => systemsColumnsMerger(defaultColumns, false)}
-                    showTags
                     customFilters={{
                         patchParams: {
                             search,

--- a/src/SmartComponents/PackageSystems/PackageSystems.js
+++ b/src/SmartComponents/PackageSystems/PackageSystems.js
@@ -145,7 +145,6 @@ const PackageSystems = ({ packageName }) => {
                     initialLoading
                     hideFilters={{ all: true, tags: false }}
                     columns={packageSystemsColumns}
-                    showTags
                     getEntities={getEntites}
                     customFilters={{
                         patchParams: {

--- a/src/SmartComponents/SystemDetail/InventoryDetail.js
+++ b/src/SmartComponents/SystemDetail/InventoryDetail.js
@@ -72,7 +72,6 @@ const InventoryDetail = ({ match }) => {
                 ]}
             >
                 {(!loaded || insightsID) && <InventoryDetailHead hideBack
-                    showTags
                     actions={isPatchSetEnabled && [
                         {
                             title: intl.formatMessage(messages.titlesTemplateAssign),

--- a/src/SmartComponents/Systems/Systems.js
+++ b/src/SmartComponents/Systems/Systems.js
@@ -139,7 +139,6 @@ const Systems = () => {
     const remediationDataProvider = useRemediationProvier(selectedRows, setRemediationLoading, 'systems');
 
     const bulkSelectConfig = useBulkSelectConfig(selectedCount, onSelect, { total_items: totalItems }, systems);
-
     return (
         <React.Fragment>
             <Header title={intl.formatMessage(messages.titlesPatchSystems)} headerOUIA={'systems'} />
@@ -157,7 +156,6 @@ const Systems = () => {
                         initialLoading
                         hideFilters={{ all: true, tags: false }}
                         columns={(defaultColumns) => systemsColumnsMerger(defaultColumns, isPatchSetEnabled)}
-                        showTags
                         customFilters={{
                             patchParams: {
                                 search,


### PR DESCRIPTION
Just for testing atm
Please test to see if you encounter the Inventory reload bug.

To test, head over to systems tab (anywhere theres an inventory component) 
- wait at least 3 minutes
- paginate to the next page


notes: if youre going to retest, paginate back to the original 20 results and refresh.
Desired result:
Inventory loads no problem

Attempting to fix:
Inventory component breaking on certain loads