### PR TITLE
wip: pass Systems as a child to Router, wrap with useMemo

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -106,7 +106,9 @@ export const Routes = (props) => {
                     path={paths.inventoryDetail.to}
                     component={InventoryDetail}
                 />
-                <Route exact path={paths.systems.to} component={Systems} />
+                <Route exact path={paths.systems.to}>
+                    <Systems/>
+                </Route>
                 <Route
                     exact
                     path={paths.advisoryDetail.to}

--- a/src/SmartComponents/Systems/Systems.js
+++ b/src/SmartComponents/Systems/Systems.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, memo } from 'react';
 import { TableVariant } from '@patternfly/react-table';
 import { Button } from '@patternfly/react-core';
 import { InventoryTable } from '@redhat-cloud-services/frontend-components/Inventory';
@@ -225,4 +225,6 @@ const Systems = () => {
     );
 };
 
-export default Systems;
+export default memo(Systems, (prevProps, nextProps) => {
+    return JSON.stringify(prevProps) === JSON.stringify(nextProps);
+});


### PR DESCRIPTION
A trial PR for fixing the inventory reloading issue by passing the Systems component as a child. Wrapping the component with useMemo.