### PR TITLE
Fix remediations

### DIFF
--- a/src/Utilities/Helpers.js
+++ b/src/Utilities/Helpers.js
@@ -61,13 +61,14 @@ export const transformSystemsPairs = (input, remediationIdentifier) => {
     Object.entries(input.data).map(
         ([systemID, advisories]) => {
             advisories.map(advisory => {
-                const index = pairs.findIndex(pair => pair.id === advisory);
+                const pairID = `${remediationIdentifier}:${advisory}`;
+                const index = pairs.findIndex(pair => pair.id === pairID);
                 if (index >= 0) {
                     pairs[index].systems.push(systemID);
                 } else {
                     pairs.push(
                         {
-                            id: `${remediationIdentifier}:${advisory}`,
+                            id: pairID,
                             description: advisory,
                             systems: [systemID]
                         }

--- a/src/Utilities/Helpers.js
+++ b/src/Utilities/Helpers.js
@@ -51,6 +51,34 @@ export const transformPairs = (input, remediationIdentifier) => {
     };
 };
 
+export const transformSystemsPairs = (input, remediationIdentifier) => {
+    //displays NoDataModal when there is no patch updates available
+    if (!Object.keys(input?.data || {}).length) {
+        return false;
+    }
+
+    const pairs = [];
+    Object.entries(input.data).map(
+        ([systemID, advisories]) => {
+            advisories.map(advisory => {
+                const index = pairs.findIndex(pair => pair.id === advisory);
+                if (index >= 0) {
+                    pairs[index].systems.push(systemID);
+                } else {
+                    pairs.push(
+                        {
+                            id: `${remediationIdentifier}:${advisory}`,
+                            description: advisory,
+                            systems: [systemID]
+                        }
+                    );
+                }
+            });
+        });
+
+    return { issues: pairs };
+};
+
 export const createSortBy = (header, values, offset) => {
     if (values) {
         let [column] = values;

--- a/src/Utilities/api.js
+++ b/src/Utilities/api.js
@@ -226,3 +226,17 @@ export const removePatchSetApi = (payload) => {
 export const getOperatingSystems = () => {
     return systemProfile.apiSystemProfileGetOperatingSystem();
 };
+
+export const fetchViewSystemsAdvisories = async (input) => {
+    const result = await fetch(`/api/patch/v1/views/systems/advisories`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(input)
+    }).then(res => res.json()).then(data => data);
+
+    return result;
+};

--- a/src/Utilities/useRemediationDataProvider.js
+++ b/src/Utilities/useRemediationDataProvider.js
@@ -2,14 +2,17 @@ import { remediationIdentifiers } from './constants';
 import {
     remediationProviderWithPairs,
     removeUndefinedObjectKeys,
-    transformPairs
+    transformPairs,
+    transformSystemsPairs
 } from './Helpers';
 import {
-    fetchViewAdvisoriesSystems
+    fetchViewAdvisoriesSystems,
+    fetchViewSystemsAdvisories
 } from './api';
 
-export const prepareRemediationPairs = ({ advisories, systems } = {}) => {
-    return fetchViewAdvisoriesSystems({ advisories, systems });
+export const prepareRemediationPairs = (payload = {}, remediationType) => {
+    return remediationType === 'systems' ? fetchViewSystemsAdvisories(payload)
+        : fetchViewAdvisoriesSystems(payload);
 };
 
 /**
@@ -22,15 +25,16 @@ const useRemediationDataProvider = (selectedRows, setRemediationLoading, remedia
     const remediationDataProvider = async () => {
         setRemediationLoading(true);
 
-        const remediationPairs = await prepareRemediationPairs({
-            [remediationType]: removeUndefinedObjectKeys(selectedRows)
-        });
+        const remediationPairs = await prepareRemediationPairs(
+            { [remediationType]: removeUndefinedObjectKeys(selectedRows) },
+            remediationType
+        );
 
         setRemediationLoading(false);
 
         return remediationProviderWithPairs(
             remediationPairs,
-            transformPairs,
+            remediationType === 'systems' ? transformSystemsPairs : transformPairs,
             remediationIdentifiers.advisory
         );
     };


### PR DESCRIPTION
This fixes the remediation on the Systems page after it broke because of the new pagination enabled on `/view/advisories/systems `endpoint. Now remediation issue pairs are fetched from` /view/systems/advisories`, then passed to the Remediation module. 

To test:

1. Visit the systems page
2. Select one or more systems
3. Click on remediation
4. Observe that the request to fetch remediation pairs is made to /view/systems/advisories
5. Remediation modal does not brake
6. You can remediate selected system advisories