### PR TITLE
feat(SPM-1707): paginate remediation pair fetching

### DIFF
--- a/src/SmartComponents/Advisories/Advisories.test.js
+++ b/src/SmartComponents/Advisories/Advisories.test.js
@@ -180,8 +180,16 @@ describe('Advisories.js', () => {
     });
 
     it('should handle remediation', () => {
-        const remediationProvider = wrapper.find('TableView').props().remediationProvider;
-        remediationProvider().catch((err) => console.log(err));
+        const rejectedState = { ...mockState, selectedRows: { 'RHEA-2020:2743': true } };
+        useSelector.mockImplementation(callback => {
+            return callback({ AdvisoryListStore: rejectedState });
+        });
+        const tempStore = initStore(rejectedState);
+        const tempWrapper = mount(<Provider store={tempStore}>
+            <Router><Advisories /></Router>
+        </Provider>);
+        const remediationProvider = tempWrapper.find('TableView').props().remediationProvider;
+        act(() => remediationProvider(['RHEA-2020:2743'], () => {}, 'advisories'));
         expect(fetchViewAdvisoriesSystems).toHaveBeenCalled();
     });
 });

--- a/src/Utilities/useRemediationDataProvider.js
+++ b/src/Utilities/useRemediationDataProvider.js
@@ -1,4 +1,4 @@
-import { chunk } from 'lodash';
+import chunk from 'lodash/chunk';
 import { remediationIdentifiers } from './constants';
 import {
     remediationProviderWithPairs,
@@ -22,14 +22,12 @@ export const prepareRemediationPairs = (payload = [], remediationType) => {
         fetchPromises.push(fetchFunction({ [remediationType]: payloadChunks[i] }));
     }
 
-    const result = Promise.all(fetchPromises).then(result =>
+    return Promise.all(fetchPromises).then(result =>
         result.reduce(
             (prev, current) => ({ data: { ...prev.data, ...current.data } }),
             { data: {} }
         )
     );
-
-    return result;
 };
 
 /**

--- a/src/Utilities/useRemediationDataProvider.test.js
+++ b/src/Utilities/useRemediationDataProvider.test.js
@@ -7,6 +7,10 @@ import {
     remediationProviderWithPairs,
     transformPairs
 } from './Helpers';
+import {
+    fetchViewAdvisoriesSystems,
+    fetchViewSystemsAdvisories
+} from './api';
 
 jest.mock('./Helpers', () => ({
     ...jest.requireActual('./Helpers'),
@@ -18,14 +22,14 @@ jest.mock('./Helpers', () => ({
     }).catch((err) => console.log(err)))
 }));
 
+jest.mock('./api', () => ({
+    ...jest.requireActual('./api'),
+    fetchViewAdvisoriesSystems: jest.fn().mockReturnValue({ data: { testPair: 'advisor-system-pair-issue' } }),
+    fetchViewSystemsAdvisories: jest.fn().mockReturnValue({ data: { testPair: 'advisor-system-pair-issue' } })
+}));
+
 const setRemediationLoading = jest.fn();
 describe('useRemediationDataProvider', () => {
-
-    global.Headers = jest.fn();
-    global.fetch = jest.fn(() => Promise.resolve({
-        json: () => ({ testPair: 'advisor-system-pair-issue' })
-    }).catch((err) => console.log(err)));
-
     it('Should return remediation data pairs', async () => {
         const testSystems = {
             'test-system-id-1': true,
@@ -37,12 +41,67 @@ describe('useRemediationDataProvider', () => {
 
         expect(remediationProviderWithPairs)
         .toHaveBeenCalledWith(
-            { testPair: 'advisor-system-pair-issue' },
+            { data: { testPair: 'advisor-system-pair-issue' } },
             transformPairs,
             'patch-advisory'
         );
         expect(setRemediationLoading).toHaveBeenCalledTimes(2);
         expect(setRemediationLoading).toHaveBeenCalledWith(true);
         expect(setRemediationLoading).toHaveBeenCalledWith(false);
+    });
+});
+
+describe('prepareRemedationPairs', () => {
+    let manySystems = [{ 'test-system-id': true }];
+    for (let i = 0; i < 100; i++) {
+        manySystems.push({ [`test-system-id-${i}`]: true });
+    }
+
+    it('Should create correct number of api requests with chunk size of 100', async () => {
+        const advisoryRemediationProvider = useRemediationDataProvider(manySystems, setRemediationLoading, 'systems');
+        await act(() => advisoryRemediationProvider());
+
+        expect(fetchViewSystemsAdvisories).toHaveBeenCalledTimes(2);
+    });
+
+    it('Should create only one api requests with chunk size of 100', async () => {
+        let testSystems = [{ 'test-system-id': true }];
+
+        const advisoryRemediationProvider = useRemediationDataProvider(testSystems, setRemediationLoading, 'systems');
+        await act(() => advisoryRemediationProvider());
+
+        expect(fetchViewSystemsAdvisories).toHaveBeenCalledTimes(3);
+    });
+
+    it('Should call the right API function according to remediationType', async () => {
+        const testSystems = {
+            'test-system-id-1': true,
+            'test-system-id-2': true
+        };
+
+        const advisoryRemediationProvider = useRemediationDataProvider(testSystems, setRemediationLoading, 'advisories');
+        await act(() => advisoryRemediationProvider());
+
+        expect(fetchViewAdvisoriesSystems).toHaveBeenCalled();
+
+        const sytemRemediationProvider = useRemediationDataProvider(testSystems, setRemediationLoading, 'systems');
+        await act(() => sytemRemediationProvider());
+
+        expect(fetchViewSystemsAdvisories).toHaveBeenCalled();
+    });
+
+    it('Should merge chunked API responses', async () => {
+        fetchViewAdvisoriesSystems.mockReturnValueOnce({ data: { testPair1: 'advisor-system-pair-issue' } })
+        .mockReturnValueOnce({ data: { testPair2: 'advisor-system-pair-issue' } });
+
+        const advisoryRemediationProvider = useRemediationDataProvider(manySystems, setRemediationLoading, 'advisories');
+        await act(() => advisoryRemediationProvider());
+
+        expect(remediationProviderWithPairs)
+        .toHaveBeenCalledWith(
+            { data: { testPair1: 'advisor-system-pair-issue', testPair2: 'advisor-system-pair-issue' } },
+            transformPairs,
+            'patch-advisory'
+        );
     });
 });


### PR DESCRIPTION
This will enable paginating the request to fetch remediation pairs on Systems and Advisories pages.

To test:
1. Visit the advisories page
2. bulk select a page/all rows
3. click on Remediate
4. Observe that there are multiple requests made to fetch paginated result
5. Observe that those results are being aggregated correctly
6. Observe that Remediation modal opens up as expected and you can successfully remediate
7. Please do so on the Systems page as well.