### PR TITLE
fix(SPM-1802): pass correct remediation issue ID

### DIFF
--- a/src/SmartComponents/PackageSystems/PackageSystems.js
+++ b/src/SmartComponents/PackageSystems/PackageSystems.js
@@ -113,15 +113,17 @@ const PackageSystems = ({ packageName }) => {
 
     const prepareRemediationPairs = (systemIDs) => {
         const pairs = [];
+
         systemIDs.forEach(id => {
             const packageEvra = selectedRows[id];
-            const index = pairs.findIndex(pair => pair.id === packageEvra);
+            const issueID = `patch-package:${packageEvra}`;
+            const index = pairs.findIndex(pair => pair.id === issueID);
 
             if (index !== -1) {
                 pairs[index].systems.push(id);
             } else if (packageEvra) {
                 pairs.push({
-                    id: packageEvra,
+                    id: issueID,
                     description: packageEvra,
                     systems: [id]
                 });

--- a/src/SmartComponents/PackageSystems/PackageSystems.test.js
+++ b/src/SmartComponents/PackageSystems/PackageSystems.test.js
@@ -56,7 +56,7 @@ const mockState = {
             total_items: 10
         },
         expandedRows: {},
-        selectedRows: { 'test-system-1': true },
+        selectedRows: { 'test-system-1': 'packageEvra' },
         error: {},
         status: 'resolved',
         total: 2
@@ -104,6 +104,16 @@ describe('PackageSystems.js', () => {
 
     it('Should open remediation modal', () => {
         const { dedicatedAction } = wrapper.find('.testInventroyComponentChild').parent().props();
+        const remediationPairs = dedicatedAction.props.remediationProvider('test-system-1');
+        expect(remediationPairs).toEqual({
+            issues: [
+                {
+                    id: 'patch-package:packageEvra',
+                    description: 'packageEvra',
+                    systems: ['test-system-1']
+                }
+            ]
+        });
         expect(dedicatedAction).toMatchSnapshot();
     });
 


### PR DESCRIPTION
Fixes: [SPM-1802](https://issues.redhat.com/browse/SPM-1802) by sending the expected remediation issue ID according to the new validation.

To test:

1. Visit the packages page
2. click on any package name and open the details 
3. select some systems which have updatable package evra version
4. observe that the remediation modal is loaded & works as expected.  