### PR TITLE
chore(RHCLOUD-23128): Remove get registry dependency and use create store directly

### DIFF
--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -2,14 +2,14 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { BrowserRouter as Router } from 'react-router-dom';
 import App from './App';
-import { getStore } from './store';
+import { store } from './store';
 import getBaseName from './Utilities/getBaseName';
 import { IntlProvider } from '@redhat-cloud-services/frontend-components-translations';
 import messages from '../locales/en.json';
 
 const Patchman = () => (<div className="patch-root">
     <IntlProvider locale={navigator.language.slice(0, 2)} messages={messages}>
-        <Provider store={getStore()}>
+        <Provider store={store}>
             <Router basename={getBaseName(window.location.pathname)}>
                 <App style={{ overflow: 'clip', background: 'red', 'z-index': '1000' }} />
             </Router>

--- a/src/SmartComponents/AdvisorySystems/AdvisorySystems.js
+++ b/src/SmartComponents/AdvisorySystems/AdvisorySystems.js
@@ -2,13 +2,14 @@ import { TableVariant } from '@patternfly/react-table';
 import { InventoryTable } from '@redhat-cloud-services/frontend-components/Inventory';
 import propTypes from 'prop-types';
 import React from 'react';
-import { shallowEqual, useDispatch, useSelector } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector, useStore } from 'react-redux';
+import { combineReducers } from 'redux';
 import { useHistory } from 'react-router-dom';
 import messages from '../../Messages';
 import searchFilter from '../../PresentationalComponents/Filters/SearchFilter';
 import useOsVersionFilter from '../../PresentationalComponents/Filters/OsVersionFilter';
 import ErrorHandler from '../../PresentationalComponents/Snippets/ErrorHandler';
-import { register } from '../../store';
+import { defaultReducers } from '../../store';
 import { changeAffectedSystemsParams, clearAdvisorySystemsReducer,
     clearInventoryReducer, systemSelectAction } from '../../store/Actions/Actions';
 import { inventoryEntitiesReducer, modifyInventory } from '../../store/Reducers/InventoryEntitiesReducer';
@@ -29,6 +30,7 @@ import { useOnSelect, ID_API_ENDPOINTS } from '../../Utilities/useOnSelect';
 
 const AdvisorySystems = ({ advisoryName }) => {
     const dispatch = useDispatch();
+    const store = useStore();
     const [isRemediationOpen, setRemediationOpen] = React.useState(false);
     const [
         RemediationModalCmp,
@@ -149,12 +151,13 @@ const AdvisorySystems = ({ advisoryName }) => {
                         isDisabled: totalItems === 0
                     }}
                     onLoad={({ mergeWithEntities }) => {
-                        register({
+                        store.replaceReducer(combineReducers({
+                            ...defaultReducers,
                             ...mergeWithEntities(
                                 inventoryEntitiesReducer(systemsListColumns(false), modifyInventory),
                                 persistantParams({ page, perPage, sort, search }, decodedParams)
                             )
-                        });
+                        }));
                     }}
                     getEntities={getEntites}
                     actions={systemsRowActions(showRemediationModal)}

--- a/src/SmartComponents/PackageSystems/PackageSystems.js
+++ b/src/SmartComponents/PackageSystems/PackageSystems.js
@@ -2,14 +2,14 @@ import { TableVariant } from '@patternfly/react-table';
 import { InventoryTable } from '@redhat-cloud-services/frontend-components/Inventory';
 import propTypes from 'prop-types';
 import React from 'react';
-import { shallowEqual, useDispatch, useSelector } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector, useStore } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import messages from '../../Messages';
 import searchFilter from '../../PresentationalComponents/Filters/SearchFilter';
 import statusFilter from '../../PresentationalComponents/Filters/StatusFilter';
 import versionFilter from '../../PresentationalComponents/Filters/VersionFilter';
 import ErrorHandler from '../../PresentationalComponents/Snippets/ErrorHandler';
-import { register } from '../../store';
+import { defaultReducers } from '../../store';
 import { changePackageSystemsParams, clearInventoryReducer,
     clearPackageSystemsReducer, systemSelectAction } from '../../store/Actions/Actions';
 import { inventoryEntitiesReducer, modifyPackageSystems } from '../../store/Reducers/InventoryEntitiesReducer';
@@ -28,9 +28,11 @@ import { intl } from '../../Utilities/IntlProvider';
 import AsyncRemediationButton from '../Remediation/AsyncRemediationButton';
 import { packageSystemsColumns } from '../Systems/SystemsListAssets';
 import { useOnSelect, ID_API_ENDPOINTS } from '../../Utilities/useOnSelect';
+import { combineReducers } from 'redux';
 
 const PackageSystems = ({ packageName }) => {
     const dispatch = useDispatch();
+    const store = useStore();
     const history = useHistory();
     const [packageVersions, setPackageVersions] = React.useState([]);
 
@@ -165,12 +167,13 @@ const PackageSystems = ({ packageName }) => {
                         isDisabled: totalItems === 0
                     }}
                     onLoad={({ mergeWithEntities }) => {
-                        register({
+                        store.replaceReducer(combineReducers({
+                            ...defaultReducers,
                             ...mergeWithEntities(
                                 inventoryEntitiesReducer(packageSystemsColumns, modifyPackageSystems),
                                 persistantParams({ page, perPage, sort, search }, decodedParams)
                             )
-                        });
+                        }));
 
                     }}
                     tableProps={{

--- a/src/SmartComponents/SystemDetail/InventoryDetail.js
+++ b/src/SmartComponents/SystemDetail/InventoryDetail.js
@@ -1,8 +1,9 @@
 import React, { useEffect } from 'react';
 import { Main } from '@redhat-cloud-services/frontend-components/Main';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector, useDispatch, useStore } from 'react-redux';
+import { combineReducers } from 'redux';
 import Header from '../../PresentationalComponents/Header/Header';
-import { register } from '../../store';
+import { defaultReducers } from '../../store';
 import { SystemDetailStore } from '../../store/Reducers/SystemDetailStore';
 import { intl } from '../../Utilities/IntlProvider';
 import messages from '../../Messages';
@@ -19,6 +20,7 @@ import { useParams } from 'react-router-dom';
 
 const InventoryDetail = () => {
     const {  inventoryId } = useParams();
+    const store = useStore();
 
     const dispatch = useDispatch();
     const { loaded, hasThirdPartyRepo, patchSetName } = useSelector(
@@ -50,9 +52,10 @@ const InventoryDetail = () => {
     return (
         <DetailWrapper
             onLoad={({ mergeWithDetail }) => {
-                register({
+                store.replaceReducer(combineReducers({
+                    ...defaultReducers,
                     ...mergeWithDetail(SystemDetailStore)
-                });
+                }));
             }}
         >
             <PatchSetWrapper patchSetState={patchSetState} setPatchSetState={setPatchSetState} />

--- a/src/SmartComponents/Systems/Systems.js
+++ b/src/SmartComponents/Systems/Systems.js
@@ -3,12 +3,12 @@ import { TableVariant } from '@patternfly/react-table';
 import { Button } from '@patternfly/react-core';
 import { InventoryTable } from '@redhat-cloud-services/frontend-components/Inventory';
 import { Main } from '@redhat-cloud-services/frontend-components/Main';
-import { shallowEqual, useDispatch, useSelector } from 'react-redux';
+import { shallowEqual, useDispatch, useSelector, useStore } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import messages from '../../Messages';
 import Header from '../../PresentationalComponents/Header/Header';
 import ErrorHandler from '../../PresentationalComponents/Snippets/ErrorHandler';
-import { register } from '../../store';
+import { defaultReducers } from '../../store';
 import { changeSystemsParams, clearInventoryReducer,
     changeSystemsMetadata, changeTags, systemSelectAction } from '../../store/Actions/Actions';
 import { inventoryEntitiesReducer, modifyInventory } from '../../store/Reducers/InventoryEntitiesReducer';
@@ -35,8 +35,10 @@ import usePatchSetState from '../../Utilities/usePatchSetState';
 import PatchSetWrapper from '../../PresentationalComponents/PatchSetWrapper/PatchSetWrapper';
 import useOsVersionFilter from '../../PresentationalComponents/Filters/OsVersionFilter';
 import { useOnSelect, ID_API_ENDPOINTS } from '../../Utilities/useOnSelect';
+import { combineReducers } from 'redux';
 
 const Systems = () => {
+    const store = useStore();
     const inventory = useRef(null);
     const pageTitle = intl.formatMessage(messages.titlesSystems);
 
@@ -177,12 +179,13 @@ const Systems = () => {
                             isDisabled: totalItems === 0
                         }}
                         onLoad={({ mergeWithEntities }) => {
-                            register({
+                            store.replaceReducer(combineReducers({
+                                ...defaultReducers,
                                 ...mergeWithEntities(
                                     inventoryEntitiesReducer(systemsListColumns(isPatchSetEnabled), modifyInventory),
                                     persistantParams({ page, perPage, sort, search }, decodedParams)
                                 )
-                            });
+                            }));
                         }}
                         getEntities={getEntities}
                         tableProps={{

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,6 +1,5 @@
 import notificationsMiddleware from '@redhat-cloud-services/frontend-components-notifications/notificationsMiddleware';
 import { notificationsReducer } from '@redhat-cloud-services/frontend-components-notifications/redux';
-import { getRegistry } from '@redhat-cloud-services/frontend-components-utilities/Registry';
 import promiseMiddleware from 'redux-promise-middleware';
 import { AdvisoryDetailStore } from './Reducers/AdvisoryDetailStore';
 import { AdvisoryListStore } from './Reducers/AdvisoryListStore';
@@ -16,9 +15,9 @@ import { AdvisorySystemsStore } from './Reducers/AdvisorySystemsStore';
 import { GlobalFilterStore } from './Reducers/GlobalFilterStore';
 import { PatchSetsReducer } from './Reducers/PatchSetsReducer';
 import { SpecificPatchSetReducer } from './Reducers/SpecificPatchSetReducer';
+import { legacy_createStore as createStore, applyMiddleware, combineReducers } from 'redux';
 
-const registry = getRegistry({}, [promiseMiddleware, notificationsMiddleware()]);
-registry.register({
+export const defaultReducers = {
     AdvisoryListStore,
     SystemDetailStore,
     SystemAdvisoryListStore,
@@ -34,10 +33,6 @@ registry.register({
     PatchSetsStore: PatchSetsReducer,
     SpecificPatchSetReducer,
     notifications: notificationsReducer
-});
-
-export const getStore = () => registry.getStore();
-
-export const register = newReducers => {
-    registry.register(newReducers);
 };
+
+export const store = createStore(combineReducers(defaultReducers), applyMiddleware(promiseMiddleware, notificationsMiddleware()));


### PR DESCRIPTION
# Description

Associated Jira ticket: #RHCLOUD-23128

The function `getRegistry` is no longer needed, on contrary with module federation it can bring additonal problems because of incorrect access of a store instance. This PR removes the usage of said function and replaces it with proper `store.replaceReducer` function.

# How to test the PR

Run patch locally and test if everything works as before (pay closer attention to pages with inventory in them).