### PR TITLE
fix(SPM-1768): Adds custom role to templates page

### DIFF
--- a/src/SmartComponents/PatchSet/PatchSet.js
+++ b/src/SmartComponents/PatchSet/PatchSet.js
@@ -117,7 +117,8 @@ const PatchSet = ({ history }) => {
     };
 
     const { hasAccess } = usePermissionsWithContext([
-        'patch:*:*'
+        'patch:*:*',
+        'patch:template:write'
     ]);
     const CreatePatchSetButton = createPatchSetButton(setPatchSetState, hasAccess);
     const actionsConfig = patchSetRowActions(openPatchSetEditModal, handlePatchSetDelete);


### PR DESCRIPTION
# Description

Associated Jira ticket: # (SPM-[1768](https://issues.redhat.com/browse/SPM-1768))

This adds a new role to the allow list of roles that can create/edit patch templates. Admin has access to everything, and I had set it so that only admin can perform template actions. The custom role should have access too it as well. This change allows both admin and a user with patch:template:write permissions to perform template actions

# How to test the PR

Navigate the Templates page with an account that has patch:template:write access and read permissions, and verify that you can create and edit a template
Do the same for an account with admin permissions
Verify that if a user with read permissions goes to the page they dont have access to the button and cant edit the templates.

If you need access to accounts with these permission's, please let me know
# Before the change

The custom role didnt work

# After the change
The custom role works

# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
