### PR TITLE
fix(PackageSystem): remove unneccessary onSelect prop

### DIFF
--- a/src/SmartComponents/PackageSystems/PackageSystems.js
+++ b/src/SmartComponents/PackageSystems/PackageSystems.js
@@ -178,7 +178,7 @@ const PackageSystems = ({ packageName }) => {
                     }}
                     tableProps={{
                         canSelectAll: false,
-                        onSelect, variant: TableVariant.compact, className: 'patchCompactInventory', isStickyHeader: true
+                        variant: TableVariant.compact, className: 'patchCompactInventory', isStickyHeader: true
                     }}
                     filterConfig={filterConfig}
                     activeFiltersConfig={activeFiltersConfig}


### PR DESCRIPTION
# Description

Associated Jira ticket: No ticket needed
Removes unnecessary onSelect prop from Package systems table. This will prevent unwanted checkboxes on an empty table.

# How to test the PR

1. Visit the package page
2. click on a package to open details
3. search for non existing system to get empty table
4. observe that there are no any checkbox in the table rows


# Before the change
![image](https://user-images.githubusercontent.com/59481011/204550620-43a92eaa-7a91-4cae-9ae8-ea9770c70baf.png)


# After the change

![image](https://user-images.githubusercontent.com/59481011/204550715-bc65a6b8-ce61-45a3-a0fb-6812bafca3a3.png)

# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
