### PR TITLE
fix(SPM-1838): remove unselected items completely, ignore expanded rows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "@semantic-release/changelog": "^6.0.1",
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/npm": "^9.0.1",
+        "@testing-library/react-hooks": "^8.0.1",
         "@wojtekmaj/enzyme-adapter-react-17": "^0.6.5",
         "babel-core": "^7.0.0-bridge.0",
         "babel-jest": "^26.6.3",
@@ -5050,6 +5051,36 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@testing-library/react-hooks": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz",
+      "integrity": "sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "react-error-boundary": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.9.0 || ^17.0.0",
+        "react": "^16.9.0 || ^17.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0",
+        "react-test-renderer": "^16.9.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-test-renderer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@tootallnate/once": {
@@ -22732,6 +22763,22 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
     "node_modules/react-final-form": {
       "version": "6.5.9",
       "resolved": "https://registry.npmjs.org/react-final-form/-/react-final-form-6.5.9.tgz",
@@ -32791,6 +32838,16 @@
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@testing-library/react-hooks": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz",
+      "integrity": "sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "react-error-boundary": "^3.1.0"
       }
     },
     "@tootallnate/once": {
@@ -46141,6 +46198,15 @@
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
           "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
+      }
+    },
+    "react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5"
       }
     },
     "react-final-form": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/npm": "^9.0.1",
+    "@testing-library/react-hooks": "^8.0.1",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.5",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^26.6.3",

--- a/src/SmartComponents/SystemAdvisories/SystemAdvisories.js
+++ b/src/SmartComponents/SystemAdvisories/SystemAdvisories.js
@@ -78,7 +78,7 @@ const SystemAdvisories = ({ history, handleNoSystemData }) => {
         ), [JSON.stringify(advisories)]
     );
 
-    const constructFilename = (advisory) => advisory?.id || true;
+    const constructFilename = (advisory) => advisory?.id || advisory;
     const onSelect = useOnSelect(
         rows,
         selectedRows,

--- a/src/Utilities/Helpers.js
+++ b/src/Utilities/Helpers.js
@@ -6,7 +6,9 @@ import {
     SecurityIcon
 } from '@patternfly/react-icons';
 import { SortByDirection } from '@patternfly/react-table/dist/js';
-import { findIndex, flatten } from 'lodash';
+import flatten from 'lodash/flatten';
+import findIndex from 'lodash/findIndex';
+import pickBy from 'lodash/pickBy';
 import qs from 'query-string';
 import React from 'react';
 import LinesEllipsis from 'react-lines-ellipsis';
@@ -104,10 +106,12 @@ export const addOrRemoveItemFromSet = (targetObj, inputArr) => {
 
 export const getNewSelectedItems = (selectedItems, currentItems) => {
     let payload = [].concat(selectedItems).map(item => ({ rowId: item.id, value: item.selected }));
-    return addOrRemoveItemFromSet(
+    const mergedSelection = addOrRemoveItemFromSet(
         currentItems,
         payload
     );
+
+    return pickBy(mergedSelection, v => !!v);
 };
 
 // for expandable rows only

--- a/src/Utilities/Helpers.test.js
+++ b/src/Utilities/Helpers.test.js
@@ -281,8 +281,10 @@ describe('Helpers tests', () => {
     });
 
     it.each`
-    selectedItems                | currentItems | result
-    ${{id: "a", selected: true}}  | ${{c: true, d: false}} | ${{"a": true, "c": true, "d": false}}
+    selectedItems                   | currentItems                  | result
+    ${{ id: "a", selected: true}}   | ${{c: true, d: false}}        | ${{"a": true, "c": true}}
+    ${{ id: "a", selected: true }}  | ${{ c: undefined, d: true }}  | ${{ "a": true, "d": true }}
+    ${{ id: "a", selected: true }}  | ${{ c: '', d: true }}         | ${{ "a": true, "d": true }}
      `('getNewSelectedItems: Should return new set of selected items', ({selectedItems, currentItems,result}) => {
         expect(getNewSelectedItems(selectedItems, currentItems)).toEqual(result);
     });

--- a/src/Utilities/useOnSelect.js
+++ b/src/Utilities/useOnSelect.js
@@ -32,13 +32,16 @@ const useCreateSelectedRow = (transformKey, constructFilename) =>
         const items = shouldUseOnlyIDs ? ids : data;
 
         items.forEach((item) => {
+            //expanded rows does not have ID and should be disabled for selection
             const id = shouldUseOnlyIDs ? item : item.id;
-            toSelect.push(
-                {
-                    id: transformKey ? transformKey(item) : id,
-                    selected: constructFilename ? constructFilename(item) : id
-                }
-            );
+            if (id) {
+                toSelect.push(
+                    {
+                        id: transformKey ? transformKey(item) : id,
+                        selected: constructFilename ? constructFilename(item) : id
+                    }
+                );
+            }
         });
 
         return toSelect;

--- a/src/Utilities/useOnSelect.test.js
+++ b/src/Utilities/useOnSelect.test.js
@@ -1,0 +1,170 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { fetchIDs } from './api';
+import { useOnSelect } from './useOnSelect';
+
+jest.mock('react-redux', () => ({
+    ...jest.requireActual('react-redux'),
+    useDispatch: jest.fn(() => () => {})
+}));
+jest.mock('./api', () => ({
+    ...jest.requireActual('./api'),
+    fetchIDs: jest.fn(() => Promise.resolve({
+        data: [{ id: 'db-item' }]
+    }))
+}));
+
+const rows = [
+    {
+        id: 'row-1',
+        selected: true
+    },
+    {
+        id: 'row-2',
+        selected: true
+    }
+];
+
+let selectedRows = {};
+let config = {
+    endpoint: '/some/api/endpoint',
+    queryParams: { search: 'test-search' },
+    selectionDispatcher: jest.fn((...args) => args)
+};
+
+describe('useOnSelect', () => {
+    it('Should select single item', () => {
+        const { result } = renderHook(() =>
+            useOnSelect(rows, selectedRows, config)
+        );
+
+        act(() => {
+            result.current('default-single', { 'row-2': true }, 0);
+        });
+
+        expect(config.selectionDispatcher).toHaveBeenCalledWith([
+            { id: 'row-1', selected: true }
+        ]);
+    });
+
+    it('Should select single item while constructing new selection name', () => {
+        config.constructFilename = jest.fn(() => 'constructed-name');
+
+        const { result } = renderHook(() =>
+            useOnSelect(rows, selectedRows, config)
+        );
+
+        act(() => {
+            result.current('default-single', { 'row-2': true }, 0);
+        });
+
+        expect(config.selectionDispatcher).toHaveBeenCalledWith([
+            { id: 'row-1', selected: 'constructed-name' }
+        ]);
+    });
+
+    it('Should select single item while transforming the selection id', () => {
+        config.transformKey = jest.fn(() => 'transformed-name');
+
+        const { result } = renderHook(() =>
+            useOnSelect(rows, selectedRows, config)
+        );
+
+        act(() => {
+            result.current('default-single', {}, 0);
+        });
+
+        expect(config.selectionDispatcher).toHaveBeenCalledWith([
+            { id: 'transformed-name', selected: 'constructed-name' }
+        ]);
+    });
+
+    it('Should should use custom selector if provided', () => {
+        config.customSelector = jest.fn(() => {});
+
+        const { result } = renderHook(() =>
+            useOnSelect(rows, selectedRows, config)
+        );
+
+        act(() => {
+            result.current('default-single', {}, 0);
+        });
+
+        expect(config.customSelector).toHaveBeenCalledWith([
+            { id: 'transformed-name', selected: 'constructed-name' }
+        ]);
+    });
+
+    it('Should deselect all', () => {
+        const { result } = renderHook(() =>
+            useOnSelect(rows, { 'row-1': true, 'row-2': true }, config)
+        );
+
+        act(() => {
+            result.current('none', {}, 0);
+        });
+
+        expect(config.customSelector).toHaveBeenCalledWith([
+            { id: 'row-1', selected: false },
+            { id: 'row-2', selected: false }
+        ]);
+    });
+
+    it('Should select page', () => {
+        config.transformKey = undefined;
+        config.constructFilename = undefined;
+
+        const { result } = renderHook(() =>
+            useOnSelect(rows, {}, config)
+        );
+
+        act(() => {
+            result.current('page', {});
+        });
+
+        expect(config.customSelector).toHaveBeenCalledWith([
+            { id: 'row-1', selected: 'row-1' },
+            { id: 'row-2', selected: 'row-2' }
+        ]);
+    });
+
+    it('Should select all items from db', () => {
+        const { result } = renderHook(() =>
+            useOnSelect(rows, {}, config)
+        );
+
+        act(() => {
+            result.current('all', {});
+        });
+
+        expect(fetchIDs).toHaveBeenCalledWith('/some/api/endpoint', { limit: -1, search: 'test-search' });
+    });
+
+    it('Should skip invalid rows while selection', () => {
+        const rows = [
+            {
+                id: 'valid-1',
+                selected: true
+            },
+            {
+                key: 'not-valid-row'
+            },
+            {
+                id: 'valid-2',
+                selected: true
+            }
+        ];
+
+        const { result } = renderHook(() =>
+            useOnSelect(rows, {}, config)
+        );
+
+        act(() => {
+            result.current('page', {});
+        });
+
+        expect(config.customSelector).toHaveBeenCalledWith([
+            { id: 'valid-1', selected: 'valid-1' },
+            { id: 'valid-2', selected: 'valid-2' }
+        ]);
+    });
+});


### PR DESCRIPTION
# Description

Associated Jira ticket: # ([SPM-1838](https://issues.redhat.com/browse/SPM-1838))

Fixes the selection on the System advisories table by removing the unselected item completely from the selected rows object, instead of setting it to selected=falsy. Also, if expanded rows are ignored while turning a row as selected. 


# How to test the PR
1. This touches selection across pages, thus please play with it and try remediating your selected items.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [ ] Screenshots before and after the change are added
- [x] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
