### PR TITLE
Fix rbac

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -84,60 +84,61 @@ const Templates = lazy(() =>
 );
 
 const isPatchSetEnabled = useFeatureFlag(featureFlags.patch_set);
+const generalPermissions = ['patch:*:*', 'patch:*:read'];
 
 export const paths = [
     {
         path: '/advisories/:advisoryId/:inventoryId',
         isExact: true,
-        requiredPermissions: ['patch:*:read'],
+        requiredPermissions: generalPermissions,
         component: InventoryDetail
     },
     {
         path: '/advisories/:advisoryId',
         isExact: true,
-        requiredPermissions: ['patch:*:read'],
+        requiredPermissions: generalPermissions,
         component: AdvisoryPage
     },
     {
         path: '/advisories',
         isExact: true,
-        requiredPermissions: ['patch:*:read'],
+        requiredPermissions: generalPermissions,
         component: Advisories
     },
     {
         path: '/systems/:inventoryId',
         isExact: true,
-        requiredPermissions: ['patch:*:read'],
+        requiredPermissions: generalPermissions,
         component: InventoryDetail
     },
     {
         path: '/systems',
         isExact: true,
-        requiredPermissions: ['patch:*:read'],
+        requiredPermissions: generalPermissions,
         component: Systems
     },
     {
         path: '/packages/:packageName/:inventoryId',
         isExact: true,
-        requiredPermissions: ['patch:*:read'],
+        requiredPermissions: generalPermissions,
         component: InventoryDetail
     },
     {
         path: '/packages/:packageName',
         isExact: true,
-        requiredPermissions: ['patch:*:read'],
+        requiredPermissions: generalPermissions,
         component: PackageDetail
     },
     {
         path: '/packages',
         isExact: true,
-        requiredPermissions: ['patch:*:read'],
+        requiredPermissions: generalPermissions,
         component: PackagsPage
     },
     ...(isPatchSetEnabled ? [{
         path: '/templates',
         isExact: true,
-        requiredPermissions: ['patch:*:read'],
+        requiredPermissions: generalPermissions,
         component: Templates
     }] : [])
 


### PR DESCRIPTION
# Description

Associated Jira ticket: # [(SPM-1852)](https://issues.redhat.com/browse/SPM-1852)

Fixes RBAC issue. Previously, a user was required to have both admins and 'parch read' access. Now read review is removed.


# How to test the PR

Steps to Reproduce:
1. Navigate to 'https://console.redhat.com/settings/rbac/groups'
5. Edit corresponding group to add Patch Administrator role and remove Patch Viewer role

Actual results:
Navigate to 'https://console.redhat.com/insights/patch/advisories' which will result in below error:
You do not have access to patch

Expected results:
Access to Patch with only the Patch Administrator role (without the Patch Viewer also needed)

Additional info:
The other Insights apps are working and can be used as a cross reference/comparison

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
