### PR TITLE
chore(RHIF-160): decouple advisory detail header and table

### DIFF
--- a/src/PresentationalComponents/AdvisoryHeader/AdvisoryHeader.js
+++ b/src/PresentationalComponents/AdvisoryHeader/AdvisoryHeader.js
@@ -4,16 +4,21 @@ import {
 } from '@patternfly/react-core';
 import { processDate } from '@redhat-cloud-services/frontend-components-utilities/helpers';
 import propTypes from 'prop-types';
-import React, { useState } from 'react';
+import React, { useState, lazy, Suspense, Fragment } from 'react';
 import messages from '../../Messages';
 import WithLoader, { WithLoaderVariants } from '../../PresentationalComponents/WithLoader/WithLoader';
-import CvesModal from '../../SmartComponents/AdvisoryDetail/CvesModal';
 import { getSeverityById, isRHAdvisory, truncateDescription } from '../../Utilities/Helpers';
 import { intl } from '../../Utilities/IntlProvider';
 import RebootRequired from '../Snippets/RebootRequired';
 import AdvisorySeverityInfo from '../Snippets/AdvisorySeverityInfo';
 import ExternalLink from '../Snippets/ExternalLink';
 import AdvisoryType from '../AdvisoryType/AdvisoryType';
+
+const CvesModal = lazy(() =>
+    import(
+        /* webpackChunkName: "CvesModal" */ '../../SmartComponents/AdvisoryDetail/CvesModal'
+    )
+);
 
 const AdvisoryHeader = ({ attributes, isLoading }) => {
     const [CvesInfoModal, setCvesModal] = useState(() => () => null);
@@ -112,7 +117,9 @@ const AdvisoryHeader = ({ attributes, isLoading }) => {
                     </TextContent>
                 </GridItem>
             )}
-            <CvesInfoModal />
+            <Suspense fallback={<Fragment/>}>
+                <CvesInfoModal />
+            </Suspense>
         </Grid>
     );
 };

--- a/src/PresentationalComponents/AdvisoryHeader/__snapshots__/AdvisoryHeader.test.js.snap
+++ b/src/PresentationalComponents/AdvisoryHeader/__snapshots__/AdvisoryHeader.test.js.snap
@@ -107,7 +107,11 @@ exports[`AdvisoryHeader Should match the snapshots when loaded 1`] = `
       </FlexItem>
     </Flex>
   </GridItem>
-  <Component />
+  <Suspense
+    fallback={<React.Fragment />}
+  >
+    <Component />
+  </Suspense>
 </Grid>
 `;
 
@@ -218,6 +222,10 @@ exports[`AdvisoryHeader Should match the snapshots when loading 1`] = `
       </FlexItem>
     </Flex>
   </GridItem>
-  <Component />
+  <Suspense
+    fallback={<React.Fragment />}
+  >
+    <Component />
+  </Suspense>
 </Grid>
 `;

--- a/src/SmartComponents/AdvisoryDetail/AdvisoryDetail.js
+++ b/src/SmartComponents/AdvisoryDetail/AdvisoryDetail.js
@@ -12,7 +12,6 @@ import { clearAdvisoryDetailStore, clearEntitiesStore, fetchAvisoryDetails } fro
 import { setPageTitle } from '../../Utilities/Hooks';
 import { intl } from '../../Utilities/IntlProvider';
 import AdvisorySystems from '../AdvisorySystems/AdvisorySystems';
-import ErrorHandler from '../../PresentationalComponents/Snippets/ErrorHandler';
 import { clearNotifications } from '@redhat-cloud-services/frontend-components-notifications/redux';
 
 const AdvisoryDetail = ({ match }) => {
@@ -72,9 +71,7 @@ const AdvisoryDetail = ({ match }) => {
                         </TextContent>
                     </StackItem>
                     <StackItem>
-                        {status.hasError
-                            && < ErrorHandler />
-                            || <AdvisorySystems advisoryName={advisoryName} />}
+                        <AdvisorySystems advisoryName={advisoryName} />
                     </StackItem>
                 </Stack>
             </Main>

--- a/src/SmartComponents/AdvisoryDetail/__snapshots__/AdvisoryDetail.test.js.snap
+++ b/src/SmartComponents/AdvisoryDetail/__snapshots__/AdvisoryDetail.test.js.snap
@@ -285,7 +285,13 @@ exports[`AdvisoryDetail.js Should match the snapshots 1`] = `
                     <StackItem>
                       <div
                         className="pf-l-stack__item"
-                      />
+                      >
+                        <Component>
+                          <div>
+                             hello 
+                          </div>
+                        </Component>
+                      </div>
                     </StackItem>
                   </div>
                 </Stack>


### PR DESCRIPTION
# Description

Associated Jira ticket: # [RHIF-160](https://issues.redhat.com/browse/RHIF-160)

The affected systems table has to wait for the header. There is no need to have this approach as error handling is done in the affected systems table as well.

# How to test the PR

This should not change functionality overall, just run the PR locally and verify that there is nothing weird in Advisory detail page.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
