### PR TITLE
perf(RHIF-171): Get rid of activeApps in redux

### DIFF
--- a/src/SmartComponents/SystemAdvisories/SystemAdvisories.js
+++ b/src/SmartComponents/SystemAdvisories/SystemAdvisories.js
@@ -21,14 +21,12 @@ import { intl } from '../../Utilities/IntlProvider';
 import messages from '../../Messages';
 import { useOnSelect, ID_API_ENDPOINTS } from '../../Utilities/useOnSelect';
 
-const SystemAdvisories = ({ history, handleNoSystemData }) => {
+const SystemAdvisories = ({ history, handleNoSystemData, inventoryId }) => {
     const dispatch = useDispatch();
     const [firstMount, setFirstMount] = useState(true);
     const advisories = useSelector(
         ({ SystemAdvisoryListStore }) => SystemAdvisoryListStore.rows
     );
-
-    const entity = useSelector(({ entityDetails }) => entityDetails.entity);
 
     const expandedRows = useSelector(
         ({ SystemAdvisoryListStore }) => SystemAdvisoryListStore.expandedRows
@@ -64,7 +62,7 @@ const SystemAdvisories = ({ history, handleNoSystemData }) => {
         } else {
             historyPusher();
             dispatch(
-                fetchApplicableSystemAdvisories({ id: entity.id, ...queryParams })
+                fetchApplicableSystemAdvisories({ id: inventoryId, ...queryParams })
             );
         }
     }, [queryParams]);
@@ -83,7 +81,7 @@ const SystemAdvisories = ({ history, handleNoSystemData }) => {
         rows,
         selectedRows,
         {
-            endpoint: ID_API_ENDPOINTS.systemAdvisories(entity.id),
+            endpoint: ID_API_ENDPOINTS.systemAdvisories(inventoryId),
             queryParams,
             selectionDispatcher: selectSystemAdvisoryRow,
             constructFilename
@@ -99,12 +97,12 @@ const SystemAdvisories = ({ history, handleNoSystemData }) => {
     const onPerPageSelect = usePerPageSelect(apply);
 
     function apply(params) {
-        dispatch(changeSystemAdvisoryListParams({ id: entity.id, ...params }));
+        dispatch(changeSystemAdvisoryListParams({ id: inventoryId, ...params }));
     }
 
     const errorState = status.code === 404 ? handleNoSystemData() : <Unavailable/>;
 
-    const onExport = useOnExport(entity.id, queryParams, {
+    const onExport = useOnExport(inventoryId, queryParams, {
         csv: exportSystemAdvisoriesCSV,
         json: exportSystemAdvisoriesJSON
     }, dispatch);
@@ -124,12 +122,12 @@ const SystemAdvisories = ({ history, handleNoSystemData }) => {
                 remediationProvider={() =>
                     remediationProvider(
                         arrayFromObj(selectedRows),
-                        entity.id,
+                        inventoryId,
                         remediationIdentifiers.advisory
                     )
                 }
                 selectedRows={selectedRows}
-                systemId={entity.id}
+                systemId={inventoryId}
                 apply={apply}
                 store={{ rows, metadata, status, queryParams }}
                 remediationButtonOUIA={'toolbar-remediation-button'}
@@ -155,6 +153,7 @@ const SystemAdvisories = ({ history, handleNoSystemData }) => {
 
 SystemAdvisories.propTypes = {
     history: propTypes.object,
-    handleNoSystemData: propTypes.func
+    handleNoSystemData: propTypes.func,
+    inventoryId: propTypes.string.isRequired
 };
 export default withRouter(SystemAdvisories);

--- a/src/SmartComponents/SystemAdvisories/SystemAdvisories.test.js
+++ b/src/SmartComponents/SystemAdvisories/SystemAdvisories.test.js
@@ -15,12 +15,14 @@ jest.mock('react-redux', () => ({
     ...jest.requireActual('react-redux'),
     useSelector: jest.fn()
 }));
-
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useParams: jest.fn(() => ({ inventoryId: 'test' }))
+}));
 jest.mock('../../Utilities/Helpers', () => ({
     ...jest.requireActual('../../Utilities/Helpers'),
     remediationProvider: jest.fn()
 }));
-
 jest.mock('../../Utilities/api', () => ({
     ...jest.requireActual('../../Utilities/api'),
     fetchIDs: jest.fn()

--- a/src/SmartComponents/SystemAdvisories/SystemAdvisories.test.js
+++ b/src/SmartComponents/SystemAdvisories/SystemAdvisories.test.js
@@ -15,10 +15,6 @@ jest.mock('react-redux', () => ({
     ...jest.requireActual('react-redux'),
     useSelector: jest.fn()
 }));
-jest.mock('react-router-dom', () => ({
-    ...jest.requireActual('react-router-dom'),
-    useParams: jest.fn(() => ({ inventoryId: 'test' }))
-}));
 jest.mock('../../Utilities/Helpers', () => ({
     ...jest.requireActual('../../Utilities/Helpers'),
     remediationProvider: jest.fn()
@@ -46,13 +42,13 @@ const mockState = {
 const initStore = (state) => {
     const customMiddleWare = () => next => action => {
         useSelector.mockImplementation(callback => {
-            return callback({  SystemAdvisoryListStore: state, entityDetails: { entity: { id: 'test' } } });
+            return callback({  SystemAdvisoryListStore: state });
         });
         next(action);
     };
 
     const mockStore = configureStore([customMiddleWare]);
-    return mockStore({  SystemAdvisoryListStore: state, entityDetails: { entity: { id: 'test' } } });
+    return mockStore({  SystemAdvisoryListStore: state });
 };
 
 let wrapper;
@@ -61,10 +57,10 @@ let store = initStore(mockState);
 beforeEach(() => {
     store.clearActions();
     useSelector.mockImplementation(callback => {
-        return callback({ SystemAdvisoryListStore: mockState, entityDetails: { entity: { id: 'test' } } });
+        return callback({ SystemAdvisoryListStore: mockState });
     });
     wrapper = mount(<Provider store={store}>
-        <Router><SystemAdvisories/></Router>
+        <Router><SystemAdvisories inventoryId='test' /></Router>
     </Provider>);
 });
 
@@ -187,7 +183,7 @@ describe('SystemAdvisories.js', () => {
 
         const tempStore = initStore(mockState);
         const tempWrapper = mount(<Provider store={tempStore}>
-            <Router><SystemAdvisories/></Router>
+            <Router><SystemAdvisories inventoryId='test' /></Router>
         </Provider>);
 
         expect(tempWrapper.find('SystemUpToDate')).toBeTruthy();

--- a/src/SmartComponents/SystemDetail/InventoryDetail.js
+++ b/src/SmartComponents/SystemDetail/InventoryDetail.js
@@ -116,7 +116,7 @@ const InventoryDetail = () => {
             {(!insightsID && loaded)
                 ? <ErrorHandler code={204} />
                 : (<Main>
-                    <SystemDetail />
+                    <SystemDetail inventoryId={inventoryId}/>
                 </Main>)}
         </DetailWrapper>);
 };

--- a/src/SmartComponents/SystemDetail/InventoryDetail.js
+++ b/src/SmartComponents/SystemDetail/InventoryDetail.js
@@ -12,7 +12,6 @@ import { InventoryDetailHead, DetailWrapper } from '@redhat-cloud-services/front
 import { Alert, Grid, GridItem, TextContent, Text } from '@patternfly/react-core';
 import { fetchSystemDetailsAction } from '../../store/Actions/Actions';
 import { clearNotifications } from '@redhat-cloud-services/frontend-components-notifications/redux';;
-import ErrorHandler from '../../PresentationalComponents/Snippets/ErrorHandler';
 import PatchSetWrapper from '../../PresentationalComponents/PatchSetWrapper/PatchSetWrapper';
 import usePatchSetState from '../../Utilities/usePatchSetState';
 import { featureFlags } from '../../Utilities/constants';
@@ -24,11 +23,11 @@ const InventoryDetail = () => {
     const store = useStore();
 
     const dispatch = useDispatch();
-    const { loaded, hasThirdPartyRepo, patchSetName } = useSelector(
+    const { hasThirdPartyRepo, patchSetName } = useSelector(
         ({ entityDetails }) => entityDetails && entityDetails || {}
     );
 
-    const { display_name: displayName, insights_id: insightsID } = useSelector(
+    const { display_name: displayName } = useSelector(
         ({ entityDetails }) => entityDetails?.entity ?? {}
     );
 
@@ -52,6 +51,13 @@ const InventoryDetail = () => {
 
     return (
         <DetailWrapper
+            onLoad={({ mergeWithDetail }) => {
+                store.replaceReducer(combineReducers({
+                    ...defaultReducers,
+                    ...mergeWithDetail(SystemDetailStore)
+                }));
+            }}
+            inventoryId={inventoryId}
         >
             <PatchSetWrapper patchSetState={patchSetState} setPatchSetState={setPatchSetState} />
             <Header
@@ -85,12 +91,6 @@ const InventoryDetail = () => {
                             isDisabled: !patchSetName,
                             onClick: () => openUnassignSystemsModal([inventoryId])
                         }]}
-                    onLoad={({ mergeWithDetail }) => {
-                        store.replaceReducer(combineReducers({
-                            ...defaultReducers,
-                            ...mergeWithDetail(SystemDetailStore)
-                        }));
-                    }}
                     //FIXME: remove this prop after inventory detail gets rid of activeApps in redux
                     appList={[]}
                 >
@@ -113,11 +113,9 @@ const InventoryDetail = () => {
                     </Grid>
                 </InventoryDetailHead>
             </Header>
-            {(!insightsID && loaded)
-                ? <ErrorHandler code={204} />
-                : (<Main>
-                    <SystemDetail inventoryId={inventoryId}/>
-                </Main>)}
+            <Main>
+                <SystemDetail inventoryId={inventoryId}/>
+            </Main>
         </DetailWrapper>);
 };
 

--- a/src/SmartComponents/SystemDetail/InventoryDetail.js
+++ b/src/SmartComponents/SystemDetail/InventoryDetail.js
@@ -8,7 +8,7 @@ import { SystemDetailStore } from '../../store/Reducers/SystemDetailStore';
 import { intl } from '../../Utilities/IntlProvider';
 import messages from '../../Messages';
 import { setPageTitle, useFeatureFlag } from '../../Utilities/Hooks';
-import { InventoryDetailHead, AppInfo, DetailWrapper } from '@redhat-cloud-services/frontend-components/Inventory';
+import { InventoryDetailHead, DetailWrapper } from '@redhat-cloud-services/frontend-components/Inventory';
 import { Alert, Grid, GridItem, TextContent, Text } from '@patternfly/react-core';
 import { fetchSystemDetailsAction } from '../../store/Actions/Actions';
 import { clearNotifications } from '@redhat-cloud-services/frontend-components-notifications/redux';;
@@ -17,6 +17,7 @@ import PatchSetWrapper from '../../PresentationalComponents/PatchSetWrapper/Patc
 import usePatchSetState from '../../Utilities/usePatchSetState';
 import { featureFlags } from '../../Utilities/constants';
 import { useParams } from 'react-router-dom';
+import SystemDetail from './SystemDetail';
 
 const InventoryDetail = () => {
     const {  inventoryId } = useParams();
@@ -51,12 +52,6 @@ const InventoryDetail = () => {
 
     return (
         <DetailWrapper
-            onLoad={({ mergeWithDetail }) => {
-                store.replaceReducer(combineReducers({
-                    ...defaultReducers,
-                    ...mergeWithDetail(SystemDetailStore)
-                }));
-            }}
         >
             <PatchSetWrapper patchSetState={patchSetState} setPatchSetState={setPatchSetState} />
             <Header
@@ -74,8 +69,10 @@ const InventoryDetail = () => {
                     }
                 ]}
             >
-                {(!loaded || insightsID) && <InventoryDetailHead hideBack
+                <InventoryDetailHead
+                    hideBack
                     showTags
+                    inventoryId={inventoryId}
                     actions={isPatchSetEnabled && [
                         {
                             title: intl.formatMessage(messages.titlesTemplateAssign),
@@ -88,6 +85,14 @@ const InventoryDetail = () => {
                             isDisabled: !patchSetName,
                             onClick: () => openUnassignSystemsModal([inventoryId])
                         }]}
+                    onLoad={({ mergeWithDetail }) => {
+                        store.replaceReducer(combineReducers({
+                            ...defaultReducers,
+                            ...mergeWithDetail(SystemDetailStore)
+                        }));
+                    }}
+                    //FIXME: remove this prop after inventory detail gets rid of activeApps in redux
+                    appList={[]}
                 >
                     <Grid>
                         <GridItem>
@@ -100,18 +105,18 @@ const InventoryDetail = () => {
                         </GridItem>
                         <GridItem>
                             {hasThirdPartyRepo &&
-                                (<Alert className='pf-u-mt-md' isInline variant="info"
-                                    title={intl.formatMessage(messages.textThirdPartyInfo)}>
-                                </Alert>)
+                    (<Alert className='pf-u-mt-md' isInline variant="info"
+                        title={intl.formatMessage(messages.textThirdPartyInfo)}>
+                    </Alert>)
                             }
                         </GridItem>
                     </Grid>
-                </InventoryDetailHead>}
+                </InventoryDetailHead>
             </Header>
             {(!insightsID && loaded)
                 ? <ErrorHandler code={204} />
                 : (<Main>
-                    <AppInfo/>
+                    <SystemDetail />
                 </Main>)}
         </DetailWrapper>);
 };

--- a/src/SmartComponents/SystemDetail/InventoryDetail.test.js
+++ b/src/SmartComponents/SystemDetail/InventoryDetail.test.js
@@ -132,7 +132,7 @@ describe('InventoryPage.js', () => {
             });
         });
 
-        expect(store.getActions().filter(action => action.type === 'FETCH_SYSTEM_DETAIL').length).toEqual(2);
+        expect(store.getActions().filter(action => action.type === 'LOAD_ENTITY_FULFILLED').length).toEqual(2);
     });
 
     it('Should hide all dropdown actions when patch template flag is disabled', () => {

--- a/src/SmartComponents/SystemDetail/InventoryDetail.test.js
+++ b/src/SmartComponents/SystemDetail/InventoryDetail.test.js
@@ -33,11 +33,10 @@ jest.mock('react-redux', () => ({
 
 jest.mock('@redhat-cloud-services/frontend-components/Inventory', () => ({
     ...jest.requireActual('@redhat-cloud-services/frontend-components/Inventory'),
-    InventoryTable: jest.fn(() => <div className='testInventroyComponent'><div>This is child</div></div>),
     InventoryDetailHead: jest.fn(() => <div className='testInventoryDetailHead'><div>This is child</div></div>),
-    AppInfo: jest.fn(() => <div className='testInventroyAppInfo'><div>This is child</div></div>),
     DetailWrapper: jest.fn(({ children }) => <div className='testDetailWrapper'><div>{children}</div></div>)
 }));
+jest.mock('./SystemDetail', () => () => <div>This is system detail</div>);
 
 const mockState = { ...entityDetail };
 
@@ -132,7 +131,7 @@ describe('InventoryPage.js', () => {
             });
         });
 
-        expect(store.getActions().filter(action => action.type === 'LOAD_ENTITY_FULFILLED').length).toEqual(2);
+        expect(store.getActions().filter(action => action.type === 'FETCH_SYSTEM_DETAIL').length).toEqual(2);
     });
 
     it('Should hide all dropdown actions when patch template flag is disabled', () => {

--- a/src/SmartComponents/SystemDetail/SystemDetail.js
+++ b/src/SmartComponents/SystemDetail/SystemDetail.js
@@ -18,7 +18,7 @@ const SystemDetail = ({ isInventoryApp }) => {
     );
     const [areTabsHidden, setTabsHidden] = useState(false);
 
-    const entity = useSelector(({ entityDetails }) => entityDetails.entity || {});
+    const entity = useSelector(({ entityDetails }) => entityDetails?.entity || {});
     const onTabSelect = (event, id) => {
         setActiveTabKey(id);
     };

--- a/src/SmartComponents/SystemDetail/SystemDetail.js
+++ b/src/SmartComponents/SystemDetail/SystemDetail.js
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 import SystemAdvisories from '../SystemAdvisories/SystemAdvisories';
-import { useSelector } from 'react-redux';
 import SystemPackages from '../SystemPackages/SystemPackages';
 import './SystemDetail.scss';
 import { intl } from '../../Utilities/IntlProvider';
@@ -18,7 +17,6 @@ const SystemDetail = ({ isInventoryApp }) => {
     );
     const [areTabsHidden, setTabsHidden] = useState(false);
 
-    const entity = useSelector(({ entityDetails }) => entityDetails?.entity || {});
     const onTabSelect = (event, id) => {
         setActiveTabKey(id);
     };
@@ -28,7 +26,7 @@ const SystemDetail = ({ isInventoryApp }) => {
         return isInventoryApp && null || <NotConnected />;
     };
 
-    return !entity.id ? null : (!areTabsHidden && (
+    return (!areTabsHidden && (
         <Tabs activeKey={activeTabKey} onSelect={onTabSelect} className={'patchTabSelect'} isHidden>
             <Tab eventKey={0} title={<TabTitleText>{intl.formatMessage(messages.titlesAdvisories)}</TabTitleText>}
                 data-ouia-component-type={`system-advisories-tab`}

--- a/src/SmartComponents/SystemDetail/SystemDetail.js
+++ b/src/SmartComponents/SystemDetail/SystemDetail.js
@@ -9,7 +9,7 @@ import messages from '../../Messages';
 import { NotConnected } from '@redhat-cloud-services/frontend-components/NotConnected';
 import propTypes from 'prop-types';
 
-const SystemDetail = ({ isInventoryApp }) => {
+const SystemDetail = ({ isInventoryApp, inventoryId }) => {
     const { state } = useLocation();
 
     const [activeTabKey, setActiveTabKey] = useState(
@@ -32,7 +32,10 @@ const SystemDetail = ({ isInventoryApp }) => {
                 data-ouia-component-type={`system-advisories-tab`}
                 data-ouia-component-id={`system-advisories-tab`}
             >
-                <SystemAdvisories handleNoSystemData={handleNoSystemData}/>
+                <SystemAdvisories
+                    handleNoSystemData={handleNoSystemData}
+                    inventoryId={inventoryId}
+                />
             </Tab>
             <Tab
                 eventKey={1}
@@ -40,13 +43,17 @@ const SystemDetail = ({ isInventoryApp }) => {
                 data-ouia-component-type={`system-packages-tab`}
                 data-ouia-component-id={`system-packages-tab`}
             >
-                <SystemPackages handleNoSystemData={handleNoSystemData}/>
+                <SystemPackages
+                    handleNoSystemData={handleNoSystemData}
+                    inventoryId={inventoryId}
+                />
             </Tab>
         </Tabs>
     ) || <NotConnected/>);
 };
 
 SystemDetail.propTypes = {
-    isInventoryApp: propTypes.bool
+    isInventoryApp: propTypes.bool,
+    inventoryId: propTypes.string.isRequired
 };
 export default SystemDetail;

--- a/src/SmartComponents/SystemDetail/__snapshots__/InventoryDetail.test.js.snap
+++ b/src/SmartComponents/SystemDetail/__snapshots__/InventoryDetail.test.js.snap
@@ -37,7 +37,10 @@ exports[`InventoryPage.js Should match the snapshots 1`] = `
       }
     >
       <InventoryDetail>
-        <mockConstructor>
+        <mockConstructor
+          inventoryId="test-system-id"
+          onLoad={[Function]}
+        >
           <div
             className="testDetailWrapper"
           >
@@ -171,7 +174,6 @@ exports[`InventoryPage.js Should match the snapshots 1`] = `
                       appList={Array []}
                       hideBack={true}
                       inventoryId="test-system-id"
-                      onLoad={[Function]}
                       showTags={true}
                     >
                       <div

--- a/src/SmartComponents/SystemDetail/__snapshots__/InventoryDetail.test.js.snap
+++ b/src/SmartComponents/SystemDetail/__snapshots__/InventoryDetail.test.js.snap
@@ -191,7 +191,9 @@ exports[`InventoryPage.js Should match the snapshots 1`] = `
                     className="pf-l-page__main-section pf-c-page__main-section"
                     page-type=""
                   >
-                    <Component>
+                    <Component
+                      inventoryId="test-system-id"
+                    >
                       <div>
                         This is system detail
                       </div>

--- a/src/SmartComponents/SystemDetail/__snapshots__/InventoryDetail.test.js.snap
+++ b/src/SmartComponents/SystemDetail/__snapshots__/InventoryDetail.test.js.snap
@@ -37,9 +37,7 @@ exports[`InventoryPage.js Should match the snapshots 1`] = `
       }
     >
       <InventoryDetail>
-        <mockConstructor
-          onLoad={[Function]}
-        >
+        <mockConstructor>
           <div
             className="testDetailWrapper"
           >
@@ -170,7 +168,10 @@ exports[`InventoryPage.js Should match the snapshots 1`] = `
                           },
                         ]
                       }
+                      appList={Array []}
                       hideBack={true}
+                      inventoryId="test-system-id"
+                      onLoad={[Function]}
                       showTags={true}
                     >
                       <div
@@ -190,15 +191,11 @@ exports[`InventoryPage.js Should match the snapshots 1`] = `
                     className="pf-l-page__main-section pf-c-page__main-section"
                     page-type=""
                   >
-                    <mockConstructor>
-                      <div
-                        className="testInventroyAppInfo"
-                      >
-                        <div>
-                          This is child
-                        </div>
+                    <Component>
+                      <div>
+                        This is system detail
                       </div>
-                    </mockConstructor>
+                    </Component>
                   </section>
                 </InternalMain>
               </Connect(InternalMain)>

--- a/src/SmartComponents/SystemDetail/__snapshots__/SystemDetail.test.js.snap
+++ b/src/SmartComponents/SystemDetail/__snapshots__/SystemDetail.test.js.snap
@@ -3,10 +3,10 @@
 exports[`SystemDetail.js Should match the snapshot when Package tab is active by default 1`] = `
 "<Tabs activeKey={1} onSelect={[Function: onTabSelect]} className=\\"patchTabSelect\\" isHidden={true} isFilled={false} isSecondary={false} isVertical={false} isBox={false} hasBorderBottom={true} leftScrollAriaLabel=\\"Scroll left\\" rightScrollAriaLabel=\\"Scroll right\\" component=\\"div\\" mountOnEnter={false} unmountOnExit={false} ouiaSafe={true} variant=\\"default\\" onToggle={[Function: onToggle]}>
   <Tab eventKey={0} title={{...}} data-ouia-component-type=\\"system-advisories-tab\\" data-ouia-component-id=\\"system-advisories-tab\\">
-    <withRouter(SystemAdvisories) handleNoSystemData={[Function: handleNoSystemData]} />
+    <withRouter(SystemAdvisories) handleNoSystemData={[Function: handleNoSystemData]} inventoryId={[undefined]} />
   </Tab>
   <Tab eventKey={1} title={{...}} data-ouia-component-type=\\"system-packages-tab\\" data-ouia-component-id=\\"system-packages-tab\\">
-    <SystemPackages handleNoSystemData={[Function: handleNoSystemData]} />
+    <SystemPackages handleNoSystemData={[Function: handleNoSystemData]} inventoryId={[undefined]} />
   </Tab>
 </Tabs>"
 `;
@@ -14,10 +14,10 @@ exports[`SystemDetail.js Should match the snapshot when Package tab is active by
 exports[`SystemDetail.js Should match the snapshots 1`] = `
 "<Tabs activeKey={0} onSelect={[Function: onTabSelect]} className=\\"patchTabSelect\\" isHidden={true} isFilled={false} isSecondary={false} isVertical={false} isBox={false} hasBorderBottom={true} leftScrollAriaLabel=\\"Scroll left\\" rightScrollAriaLabel=\\"Scroll right\\" component=\\"div\\" mountOnEnter={false} unmountOnExit={false} ouiaSafe={true} variant=\\"default\\" onToggle={[Function: onToggle]}>
   <Tab eventKey={0} title={{...}} data-ouia-component-type=\\"system-advisories-tab\\" data-ouia-component-id=\\"system-advisories-tab\\">
-    <withRouter(SystemAdvisories) handleNoSystemData={[Function: handleNoSystemData]} />
+    <withRouter(SystemAdvisories) handleNoSystemData={[Function: handleNoSystemData]} inventoryId={[undefined]} />
   </Tab>
   <Tab eventKey={1} title={{...}} data-ouia-component-type=\\"system-packages-tab\\" data-ouia-component-id=\\"system-packages-tab\\">
-    <SystemPackages handleNoSystemData={[Function: handleNoSystemData]} />
+    <SystemPackages handleNoSystemData={[Function: handleNoSystemData]} inventoryId={[undefined]} />
   </Tab>
 </Tabs>"
 `;

--- a/src/SmartComponents/SystemPackages/SystemPackages.js
+++ b/src/SmartComponents/SystemPackages/SystemPackages.js
@@ -20,9 +20,8 @@ import { usePerPageSelect, useSetPage, useSortColumn, useOnExport } from '../../
 import { intl } from '../../Utilities/IntlProvider';
 import { useOnSelect, ID_API_ENDPOINTS } from '../../Utilities/useOnSelect';
 
-const SystemPackages = ({ handleNoSystemData }) => {
+const SystemPackages = ({ handleNoSystemData, inventoryId }) => {
     const dispatch = useDispatch();
-    const entity = useSelector(({ entityDetails }) => entityDetails.entity);
     const packages = useSelector(
         ({ SystemPackageListStore }) => SystemPackageListStore.rows
     );
@@ -52,7 +51,7 @@ const SystemPackages = ({ handleNoSystemData }) => {
     }, []);
 
     useEffect(()=> {
-        dispatch(fetchApplicableSystemPackages({ id: entity.id, ...queryParams }));
+        dispatch(fetchApplicableSystemPackages({ id: inventoryId, ...queryParams }));
     }, [queryParams]);
 
     const constructFilename = (pkg) => {
@@ -69,7 +68,7 @@ const SystemPackages = ({ handleNoSystemData }) => {
         packages,
         selectedRows,
         {
-            endpoint: ID_API_ENDPOINTS.systemPackages(entity.id),
+            endpoint: ID_API_ENDPOINTS.systemPackages(inventoryId),
             queryParams,
             selectionDispatcher: selectSystemPackagesRow,
             constructFilename,
@@ -78,7 +77,7 @@ const SystemPackages = ({ handleNoSystemData }) => {
     );
 
     function apply(params) {
-        dispatch(changeSystemPackagesParams({ id: entity.id, ...params }));
+        dispatch(changeSystemPackagesParams({ id: inventoryId, ...params }));
     }
 
     const onSort = useSortColumn(systemPackagesColumns, apply, 1);
@@ -92,7 +91,7 @@ const SystemPackages = ({ handleNoSystemData }) => {
     const errorState = error.status === 404 ?  handleNoSystemData() : <Unavailable/>;
     const emptyState = (!status.isLoading && !status.hasError && metadata.total_items === 0
                             && Object.keys(queryParams).length === 0) && <SystemUpToDate/>;
-    const onExport = useOnExport(entity.id, queryParams, {
+    const onExport = useOnExport(inventoryId, queryParams, {
         csv: exportSystemPackagesCSV,
         json: exportSystemPackagesJSON
     }, dispatch);
@@ -113,7 +112,7 @@ const SystemPackages = ({ handleNoSystemData }) => {
                 remediationProvider={() =>
                     remediationProvider(
                         arrayFromObj(selectedRows),
-                        entity.id,
+                        inventoryId,
                         remediationIdentifiers.package
                     )
                 }
@@ -140,7 +139,8 @@ const SystemPackages = ({ handleNoSystemData }) => {
 };
 
 SystemPackages.propTypes = {
-    handleNoSystemData: propTypes.func
+    handleNoSystemData: propTypes.func,
+    inventoryId: propTypes.string.isRequired
 };
 export default SystemPackages;
 

--- a/src/SmartComponents/SystemPackages/SystemPackages.test.js
+++ b/src/SmartComponents/SystemPackages/SystemPackages.test.js
@@ -18,11 +18,6 @@ jest.mock('react-redux', () => ({
     useSelector: jest.fn()
 }));
 
-jest.mock('react-router-dom', () => ({
-    ...jest.requireActual('react-router-dom'),
-    useParams: jest.fn(() => ({ inventoryId: 'entity' }))
-}));
-
 jest.mock('../../Utilities/api', () => ({
     ...jest.requireActual('../../Utilities/api'),
     fetchIDs: jest.fn(() => Promise.resolve({
@@ -51,13 +46,13 @@ const mockState = { ...storeListDefaults, rows: systemPackages };
 const initStore = (state) => {
     const customMiddleWare = () => next => action => {
         useSelector.mockImplementation(callback => {
-            return callback({  SystemPackageListStore: state, entityDetails: { entity: { id: 'entity' } } });
+            return callback({  SystemPackageListStore: state });
         });
         next(action);
     };
 
     const mockStore = configureStore([customMiddleWare]);
-    return mockStore({  SystemPackageListStore: state, entityDetails: { entity: { id: 'entity' } } });
+    return mockStore({  SystemPackageListStore: state });
 };
 
 let wrapper;
@@ -66,10 +61,10 @@ let store = initStore(mockState);
 beforeEach(() => {
     store.clearActions();
     useSelector.mockImplementation(callback => {
-        return callback({ SystemPackageListStore: mockState, entityDetails: { entity: { id: 'entity' } } });
+        return callback({ SystemPackageListStore: mockState });
     });
     wrapper = mount(<Provider store={store}>
-        <Router><SystemPackages/></Router>
+        <Router><SystemPackages inventoryId='entity'/></Router>
     </Provider>);
 });
 
@@ -94,11 +89,11 @@ describe('SystemPackages.js', () => {
             error: { detail: 'test' }
         };
         useSelector.mockImplementation(callback => {
-            return callback({ SystemPackageListStore: rejectedState, entityDetails: { entity: { id: 'entity' } } });
+            return callback({ SystemPackageListStore: rejectedState });
         });
         const tempStore = initStore(rejectedState);
         const tempWrapper = mount(<Provider store={tempStore}>
-            <Router><SystemPackages/></Router>
+            <Router><SystemPackages inventoryId='entity' /></Router>
         </Provider>);
         expect(tempWrapper.find('Error')).toBeTruthy();
     });
@@ -156,7 +151,7 @@ describe('SystemPackages.js', () => {
 
         const tempStore = initStore(emptyState);
         const tempWrapper = mount(<Provider store={tempStore}>
-            <Router><SystemPackages/></Router>
+            <Router><SystemPackages inventoryId='entity' /></Router>
         </Provider>);
 
         expect(tempWrapper.find('SystemUpToDate')).toBeTruthy();
@@ -179,7 +174,7 @@ describe('SystemPackages.js', () => {
 
         const tempStore = initStore(notFoundState);
         const tempWrapper = mount(<Provider store={tempStore}>
-            <Router><SystemPackages handleNoSystemData={() => <NotConnected /> }/></Router>
+            <Router><SystemPackages handleNoSystemData={() => <NotConnected />} inventoryId='entity' /></Router>
         </Provider>);
         expect(tempWrapper.find('NotConnected')).toBeTruthy();
 

--- a/src/SmartComponents/SystemPackages/SystemPackages.test.js
+++ b/src/SmartComponents/SystemPackages/SystemPackages.test.js
@@ -18,6 +18,11 @@ jest.mock('react-redux', () => ({
     useSelector: jest.fn()
 }));
 
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useParams: jest.fn(() => ({ inventoryId: 'entity' }))
+}));
+
 jest.mock('../../Utilities/api', () => ({
     ...jest.requireActual('../../Utilities/api'),
     fetchIDs: jest.fn(() => Promise.resolve({

--- a/src/SmartComponents/SystemPackages/__snapshots__/SystemPackages.test.js.snap
+++ b/src/SmartComponents/SystemPackages/__snapshots__/SystemPackages.test.js.snap
@@ -36,7 +36,9 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
         }
       }
     >
-      <SystemPackages>
+      <SystemPackages
+        inventoryId="entity"
+      >
         <TableView
           apply={[Function]}
           columns={

--- a/src/store/Reducers/SystemDetailStore.js
+++ b/src/store/Reducers/SystemDetailStore.js
@@ -1,6 +1,3 @@
-import React from 'react';
-import SystemDetail from '../../SmartComponents/SystemDetail/SystemDetail';
-
 let initialState = {
     loaded: false
 };
@@ -15,38 +12,17 @@ export const SystemDetailStore = (state = initialState, { type, payload }) => {
         case 'LOAD_ENTITY_PENDING':
             return {
                 ...state,
-                loaded: false,
-                activeApps: [
-                    {
-                        title: 'Patch',
-                        name: 'patch',
-                        component: () => <SystemDetail />
-                    }
-                ]
+                loaded: false
             };
         case 'LOAD_ENTITY_FULFILLED':
             return {
                 ...state,
-                loaded: true,
-                activeApps: [
-                    {
-                        title: 'Patch',
-                        name: 'patch',
-                        component: () => <SystemDetail />
-                    }
-                ]
+                loaded: true
             };
         case 'LOAD_ENTITY_REJECTED':
             return {
                 ...state,
-                loaded: true,
-                activeApps: [
-                    {
-                        title: 'Patch',
-                        name: 'patch',
-                        component: () => <SystemDetail />
-                    }
-                ]
+                loaded: true
             };
         default:
             return state;

--- a/src/store/Reducers/SystemDetailStore.test.js
+++ b/src/store/Reducers/SystemDetailStore.test.js
@@ -20,7 +20,7 @@ describe('SystemDetailStore', () => {
     ${{ ...initialState, test: 'testState' }}           | ${{ type: 'LOAD_ENTITY_FULFILLED', payload: {} }}    | ${{ ...initialState, ...stateAfterAction, test: 'testState' }}
     ${undefined}                                        | ${{ type: 'LOAD_ENTITY_REJECTED', payload: {} }}     | ${{ ...initialState, ...stateAfterAction, }}
     ${{ ...initialState, test: 'testState' }}           | ${{ type: 'LOAD_ENTITY_REJECTED', payload: {} }}     | ${{ ...initialState, ...stateAfterAction, test: 'testState' }}
-    ${initialState}                                     | ${{ type: 'FETCH_SYSTEM_DETAIL_FULFILLED', payload: { data: { attributes: { third_party: true } } } }}    | ${{ ...initialState, loaded: false, hasThirdPartyRepo: true }}
+    ${initialState}                                     | ${{ type: 'LOAD_ENTITY_FULFILLED', payload: { data: { attributes: { third_party: true } } } }}    | ${{ ...initialState, loaded: false, hasThirdPartyRepo: true }}
     `('$action', ({ state, action: { type, payload }, result }) => {
         const res = SystemDetailStore(state, { type, payload });
         expect(res).toEqual(result);

--- a/src/store/Reducers/SystemDetailStore.test.js
+++ b/src/store/Reducers/SystemDetailStore.test.js
@@ -3,14 +3,7 @@ import { initialState, SystemDetailStore } from './SystemDetailStore';
 /* eslint-disable */
 
 const stateAfterAction = {
-    loaded: true,
-    activeApps: [
-        {
-            title: 'Patch',
-            name: 'patch',
-            component: expect.any(Function)
-        }
-    ]
+    loaded: true
 };
 describe('SystemDetailStore', () => {
     it.each`
@@ -20,24 +13,11 @@ describe('SystemDetailStore', () => {
     ${{ ...initialState, test: 'testState' }}           | ${{ type: 'LOAD_ENTITY_FULFILLED', payload: {} }}    | ${{ ...initialState, ...stateAfterAction, test: 'testState' }}
     ${undefined}                                        | ${{ type: 'LOAD_ENTITY_REJECTED', payload: {} }}     | ${{ ...initialState, ...stateAfterAction, }}
     ${{ ...initialState, test: 'testState' }}           | ${{ type: 'LOAD_ENTITY_REJECTED', payload: {} }}     | ${{ ...initialState, ...stateAfterAction, test: 'testState' }}
-    ${initialState}                                     | ${{ type: 'LOAD_ENTITY_FULFILLED', payload: { data: { attributes: { third_party: true } } } }}    | ${{ ...initialState, loaded: false, hasThirdPartyRepo: true }}
+    ${initialState}                                     | ${{ type: 'LOAD_ENTITY_FULFILLED', payload: { data: { attributes: { third_party: true } } } }}    | ${{ ...initialState, loaded: true }}
     `('$action', ({ state, action: { type, payload }, result }) => {
         const res = SystemDetailStore(state, { type, payload });
         expect(res).toEqual(result);
     });
-
-
-    it.each`
-    state                   | action                                                                  | result
-    ${initialState}         | ${{ type: 'LOAD_ENTITY_REJECTED', payload: {} }}                        | ${'SystemDetail'}
-    ${initialState}         | ${{ type: 'LOAD_ENTITY_FULFILLED', payload: {} }}                       | ${'SystemDetail'}
-
-    `('$component', ({ state, action: { type, payload }, result }) => {
-        const res = SystemDetailStore(state, { type, payload });
-        const component = res.activeApps[0].component();
-        expect(component.type.name).toEqual(expect.stringMatching(result))
-    });
-
 });
 
 /* eslint-enable */

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -15,7 +15,9 @@ import { AdvisorySystemsStore } from './Reducers/AdvisorySystemsStore';
 import { GlobalFilterStore } from './Reducers/GlobalFilterStore';
 import { PatchSetsReducer } from './Reducers/PatchSetsReducer';
 import { SpecificPatchSetReducer } from './Reducers/SpecificPatchSetReducer';
-import { legacy_createStore as createStore, applyMiddleware, combineReducers } from 'redux';
+import { legacy_createStore as createStore, applyMiddleware, combineReducers, compose } from 'redux';
+
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
 export const defaultReducers = {
     AdvisoryListStore,
@@ -35,4 +37,7 @@ export const defaultReducers = {
     notifications: notificationsReducer
 };
 
-export const store = createStore(combineReducers(defaultReducers), applyMiddleware(promiseMiddleware, notificationsMiddleware()));
+export const store = createStore(
+    combineReducers(defaultReducers),
+    composeEnhancers(applyMiddleware(promiseMiddleware, notificationsMiddleware()))
+);


### PR DESCRIPTION
# Description

Associated Jira ticket: # [RHIF-171](https://issues.redhat.com/browse/RHIF-171)

This PR removes AppInfo federated module usage together with rendering the SystemDetail component using activeApps in redux. Thus, making the application's complexity and performance.

NEEDS TO BE MERGED AFTER: https://github.com/RedHatInsights/insights-inventory-frontend/pull/1766

# How to test the PR

Run both PRs together and make sure no app breaks. Basic functionality should not change. Observe that the system details page works as expected.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
