### PR TITLE
fix: Fix patch templates page not receiving redux updates

### DIFF
--- a/src/PresentationalComponents/TableView/TableView.js
+++ b/src/PresentationalComponents/TableView/TableView.js
@@ -101,7 +101,7 @@ const TableView = ({
                                     <CreatePatchSetButton />
                                 </ToolbarItem>}
                             </PrimaryToolbar>
-                            {isLoading ? <SkeletonTable colSize={5} rowSize={20} /> :
+                            {isLoading ? <SkeletonTable colSize={5} rowSize={20} variant={compact && TableVariant.compact}/> :
                                 <><Table
                                     aria-label="Patch table view"
                                     cells={columns}

--- a/src/SmartComponents/SystemPackages/__snapshots__/SystemPackages.test.js.snap
+++ b/src/SmartComponents/SystemPackages/__snapshots__/SystemPackages.test.js.snap
@@ -2612,6 +2612,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
           <SkeletonTable
             colSize={5}
             rowSize={20}
+            variant="compact"
           >
             <Table
               aria-label="Loading"
@@ -3372,7 +3373,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                 ]
               }
               selectVariant="checkbox"
-              variant={null}
+              variant="compact"
             >
               <Provider
                 aria-label="Loading"
@@ -3670,7 +3671,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                   }
                 }
                 role="grid"
-                variant={null}
+                variant="compact"
               >
                 <TableComposable
                   aria-label="Loading"
@@ -3682,7 +3683,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                   isTreeTable={false}
                   ouiaSafe={true}
                   role="grid"
-                  variant={null}
+                  variant="compact"
                 >
                   <TableComposableBase
                     aria-label="Loading"
@@ -3695,11 +3696,11 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                     isTreeTable={false}
                     ouiaSafe={true}
                     role="grid"
-                    variant={null}
+                    variant="compact"
                   >
                     <table
                       aria-label="Loading"
-                      className="pf-c-table pf-m-grid-md"
+                      className="pf-c-table pf-m-grid-md pf-m-compact"
                       data-ouia-component-id="OUIA-Generated-Table-2"
                       data-ouia-component-type="PF4/Table"
                       data-ouia-safe={true}

--- a/src/store/Reducers/PatchSetsReducer.js
+++ b/src/store/Reducers/PatchSetsReducer.js
@@ -26,10 +26,12 @@ export const initialState = {
 };
 
 export const PatchSetsReducer = (state = initialState, action) => {
+    let newState = { ...state };
+
     switch (action.type) {
         case ActionTypes.FETCH_ALL_PATCH_SETS + '_FULFILLED':
             return {
-                ...state,
+                ...newState,
                 rows: action.payload.data?.map(set => ({ ...set.attributes, id: set.id })),
                 metadata: action.payload.meta || {},
                 error: {},
@@ -37,21 +39,21 @@ export const PatchSetsReducer = (state = initialState, action) => {
             };
 
         case ActionTypes.FETCH_ALL_PATCH_SETS + '_PENDING':
-            return fetchPending(state);
+            return fetchPending(newState);
 
         case ActionTypes.FETCH_ALL_PATCH_SETS + '_REJECTED':
-            return fetchRejected(state, action);
+            return fetchRejected(newState, action);
 
         case ActionTypes.CHANGE_PATCH_SET_PARAMS:
-            return changeFilters(state, action);
+            return changeFilters(newState, action);
 
         case ActionTypes.SELECT_PATCH_SET_ROW:
-            return selectRows(state, action);
+            return selectRows(newState, action);
 
         case ActionTypes.CLEAR_PATCH_SETS:
             return initialState;
 
         default:
-            return state;
+            return newState;
     }
 };


### PR DESCRIPTION
# Description

Associated Jira ticket: [SPM-1805](https://issues.redhat.com/browse/SPM-1805).

Filter, page and per page update did not work in the Patch templates table due to Redux updates not propagating. Also updated skeleton table to be compact if the loaded table is compact. Sorting does not work yet due to [SPM-1894](https://issues.redhat.com/browse/SPM-1894).

# How to test the PR

Try changing page, per page and filter in the Patch Templates page.

# Before the change
Filter did not always work. Page and per page update did not work at all.

# After the change
Filter, page and per page update should now work.

# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [x] README.md is updated if necessary
- [ ] Needs additional dependent work
