### PR TITLE
fix: Pagination fixes (loading skeletons, margins)

### DIFF
--- a/src/PresentationalComponents/TableView/TableFooter.js
+++ b/src/PresentationalComponents/TableView/TableFooter.js
@@ -1,27 +1,33 @@
-import { Pagination, PaginationVariant } from '@patternfly/react-core';
-import { TableToolbar } from '@redhat-cloud-services/frontend-components/TableToolbar';
+import { Pagination, PaginationVariant, Skeleton } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const TableFooter = ({ page, perPage, onSetPage, totalItems, onPerPageSelect, paginationOUIA }) => {
+const TableFooter = ({ isLoading, page, perPage, onSetPage, totalItems, onPerPageSelect, paginationOUIA }) => {
     return (
-        <TableToolbar>
-            <Pagination
-                itemCount={totalItems}
-                perPage={perPage}
-                page={page}
-                onSetPage={onSetPage}
-                onPerPageSelect={onPerPageSelect}
-                widgetId={`pagination-options-menu-bottom`}
-                variant={PaginationVariant.bottom}
-                ouiaId={paginationOUIA}
-                isDisabled={totalItems === 0}
-            />
-        </TableToolbar>
+        <>
+            {isLoading ? (
+                <div className="pf-c-pagination pf-m-bottom">
+                    <Skeleton fontSize="xl" width="350px" style={{ margin: 10 }} />
+                </div>
+            ) :
+                <Pagination
+                    itemCount={totalItems}
+                    perPage={perPage}
+                    page={page}
+                    onSetPage={onSetPage}
+                    onPerPageSelect={onPerPageSelect}
+                    widgetId={`pagination-options-menu-bottom`}
+                    variant={PaginationVariant.bottom}
+                    ouiaId={paginationOUIA}
+                    isDisabled={totalItems === 0}
+                />
+            }
+        </>
     );
 };
 
 TableFooter.propTypes = {
+    isLoading: PropTypes.bool,
     onSetPage: PropTypes.func,
     onPerPageSelect: PropTypes.func,
     page: PropTypes.number,

--- a/src/PresentationalComponents/TableView/TableView.js
+++ b/src/PresentationalComponents/TableView/TableView.js
@@ -10,7 +10,7 @@ import { useRemoveFilter, useBulkSelectConfig } from '../../Utilities/Hooks';
 import { intl } from '../../Utilities/IntlProvider';
 import TableFooter from './TableFooter';
 import ErrorHandler from '../../PresentationalComponents/Snippets/ErrorHandler';
-import { ToolbarItem } from '@patternfly/react-core';
+import { Skeleton, ToolbarItem } from '@patternfly/react-core';
 
 const TableView = ({
     columns,
@@ -59,19 +59,21 @@ const TableView = ({
             {
                 (<React.Fragment>
                     {(hasError || metadata.has_systems === false)
-                        ? <ErrorHandler code={code} ErrorState={errorState} EmptyState={emptyState}  metadata={metadata} />
+                        ? <ErrorHandler code={code} ErrorState={errorState} EmptyState={emptyState} metadata={metadata} />
                         : <React.Fragment>
                             <PrimaryToolbar
-                                pagination={{
-                                    itemCount: metadata.total_items,
-                                    page,
-                                    perPage,
-                                    isCompact: true,
-                                    onSetPage,
-                                    onPerPageSelect,
-                                    ouiaId: `top-${paginationOUIA}`,
-                                    isDisabled: metadata.total_items === 0
-                                }}
+                                pagination={isLoading
+                                    ? <Skeleton fontSize="xl" width="200px" style={{ margin: 10 }} />
+                                    : {
+                                        itemCount: metadata.total_items,
+                                        page,
+                                        perPage,
+                                        isCompact: true,
+                                        onSetPage,
+                                        onPerPageSelect,
+                                        ouiaId: `top-${paginationOUIA}`,
+                                        isDisabled: metadata.total_items === 0
+                                    }}
                                 filterConfig={filterConfig}
                                 activeFiltersConfig={{
                                     filters: buildFilterChips(filter, search, searchChipLabel),
@@ -102,7 +104,7 @@ const TableView = ({
                                 </ToolbarItem>}
                             </PrimaryToolbar>
                             {isLoading ? <SkeletonTable colSize={5} rowSize={20} variant={compact && TableVariant.compact}/> :
-                                <><Table
+                                <Table
                                     aria-label="Patch table view"
                                     cells={columns}
                                     onSelect={metadata.total_items && onSelect}
@@ -119,14 +121,17 @@ const TableView = ({
                                 >
                                     <TableHeader />
                                     <TableBody />
-                                </Table><TableFooter
-                                    totalItems={metadata.total_items}
-                                    perPage={perPage}
-                                    page={page}
-                                    onSetPage={onSetPage}
-                                    onPerPageSelect={onPerPageSelect}
-                                    paginationOUIA={`bottom-${paginationOUIA}`} />
-                                </>}
+                                </Table>
+                            }
+                            <TableFooter
+                                isLoading={isLoading}
+                                totalItems={metadata.total_items}
+                                perPage={perPage}
+                                page={page}
+                                onSetPage={onSetPage}
+                                onPerPageSelect={onPerPageSelect}
+                                paginationOUIA={`bottom-${paginationOUIA}`}
+                            />
                         </React.Fragment>
                     }
                 </React.Fragment>)

--- a/src/PresentationalComponents/TableView/__snapshots__/TableFooter.test.js.snap
+++ b/src/PresentationalComponents/TableView/__snapshots__/TableFooter.test.js.snap
@@ -8,314 +8,333 @@ exports[`TableFooter Should match the snapshots 1`] = `
   perPage={10}
   totalItems={10}
 >
-  <TableToolbar>
-    <Toolbar
-      className="ins-c-table__toolbar"
-      data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-1"
-      data-ouia-component-type="RHI/TableToolbar"
+  <Pagination
+    className=""
+    defaultToFullPage={false}
+    firstPage={1}
+    isCompact={false}
+    isDisabled={false}
+    isSticky={false}
+    itemCount={10}
+    itemsEnd={null}
+    itemsStart={null}
+    offset={0}
+    onFirstClick={[Function]}
+    onLastClick={[Function]}
+    onNextClick={[Function]}
+    onPageInput={[Function]}
+    onPerPageSelect={[MockFunction]}
+    onPreviousClick={[Function]}
+    onSetPage={[MockFunction]}
+    ouiaSafe={true}
+    page={1}
+    perPage={10}
+    perPageComponent="div"
+    perPageOptions={
+      Array [
+        Object {
+          "title": "10",
+          "value": 10,
+        },
+        Object {
+          "title": "20",
+          "value": 20,
+        },
+        Object {
+          "title": "50",
+          "value": 50,
+        },
+        Object {
+          "title": "100",
+          "value": 100,
+        },
+      ]
+    }
+    titles={
+      Object {
+        "currPage": "Current page",
+        "items": "",
+        "itemsPerPage": "Items per page",
+        "ofWord": "of",
+        "optionsToggle": "",
+        "page": "",
+        "pages": "",
+        "paginationTitle": "Pagination",
+        "perPageSuffix": "per page",
+        "toFirstPage": "Go to first page",
+        "toLastPage": "Go to last page",
+        "toNextPage": "Go to next page",
+        "toPreviousPage": "Go to previous page",
+      }
+    }
+    variant="bottom"
+    widgetId="pagination-options-menu-bottom"
+  >
+    <div
+      className="pf-c-pagination pf-m-bottom"
+      data-ouia-component-id="OUIA-Generated-Pagination-bottom-1"
+      data-ouia-component-type="PF4/Pagination"
       data-ouia-safe={true}
+      id="pagination-options-menu-bottom-bottom-pagination"
     >
-      <GenerateId
-        prefix="pf-random-id-"
+      <PaginationOptionsMenu
+        className=""
+        defaultToFullPage={false}
+        dropDirection="up"
+        firstIndex={1}
+        isDisabled={false}
+        itemCount={10}
+        itemsPerPageTitle="Items per page"
+        itemsTitle=""
+        lastIndex={10}
+        lastPage={1}
+        ofWord="of"
+        onPerPageSelect={[MockFunction]}
+        optionsToggle=""
+        page={1}
+        perPage={10}
+        perPageComponent="div"
+        perPageOptions={
+          Array [
+            Object {
+              "title": "10",
+              "value": 10,
+            },
+            Object {
+              "title": "20",
+              "value": 20,
+            },
+            Object {
+              "title": "50",
+              "value": 50,
+            },
+            Object {
+              "title": "100",
+              "value": 100,
+            },
+          ]
+        }
+        perPageSuffix="per page"
+        toggleTemplate={[Function]}
+        widgetId="pagination-options-menu-bottom-bottom"
       >
-        <div
-          className="pf-c-toolbar ins-c-table__toolbar"
-          data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-1"
-          data-ouia-component-type="RHI/TableToolbar"
-          data-ouia-safe={true}
-          id="pf-random-id-0"
-        >
-          <Pagination
-            className=""
-            defaultToFullPage={false}
-            firstPage={1}
-            isCompact={false}
-            isDisabled={false}
-            isSticky={false}
-            itemCount={10}
-            itemsEnd={null}
-            itemsStart={null}
-            offset={0}
-            onFirstClick={[Function]}
-            onLastClick={[Function]}
-            onNextClick={[Function]}
-            onPageInput={[Function]}
-            onPerPageSelect={[MockFunction]}
-            onPreviousClick={[Function]}
-            onSetPage={[MockFunction]}
-            ouiaSafe={true}
-            page={1}
-            perPage={10}
-            perPageComponent="div"
-            perPageOptions={
-              Array [
-                Object {
-                  "title": "10",
-                  "value": 10,
-                },
-                Object {
-                  "title": "20",
-                  "value": 20,
-                },
-                Object {
-                  "title": "50",
-                  "value": 50,
-                },
-                Object {
-                  "title": "100",
-                  "value": 100,
-                },
-              ]
-            }
-            titles={
-              Object {
-                "currPage": "Current page",
-                "items": "",
-                "itemsPerPage": "Items per page",
-                "ofWord": "of",
-                "optionsToggle": "",
-                "page": "",
-                "pages": "",
-                "paginationTitle": "Pagination",
-                "perPageSuffix": "per page",
-                "toFirstPage": "Go to first page",
-                "toLastPage": "Go to last page",
-                "toNextPage": "Go to next page",
-                "toPreviousPage": "Go to previous page",
-              }
-            }
-            variant="bottom"
-            widgetId="pagination-options-menu-bottom"
-          >
-            <div
-              className="pf-c-pagination pf-m-bottom"
-              data-ouia-component-id="OUIA-Generated-Pagination-bottom-1"
-              data-ouia-component-type="PF4/Pagination"
-              data-ouia-safe={true}
-              id="pagination-options-menu-bottom-bottom-pagination"
-            >
-              <PaginationOptionsMenu
-                className=""
-                defaultToFullPage={false}
-                dropDirection="up"
-                firstIndex={1}
-                isDisabled={false}
-                itemCount={10}
-                itemsPerPageTitle="Items per page"
-                itemsTitle=""
-                lastIndex={10}
-                lastPage={1}
-                ofWord="of"
-                onPerPageSelect={[MockFunction]}
-                optionsToggle=""
-                page={1}
-                perPage={10}
-                perPageComponent="div"
-                perPageOptions={
-                  Array [
-                    Object {
-                      "title": "10",
-                      "value": 10,
-                    },
-                    Object {
-                      "title": "20",
-                      "value": 20,
-                    },
-                    Object {
-                      "title": "50",
-                      "value": 50,
-                    },
-                    Object {
-                      "title": "100",
-                      "value": 100,
-                    },
-                  ]
-                }
-                perPageSuffix="per page"
-                toggleTemplate={[Function]}
-                widgetId="pagination-options-menu-bottom-bottom"
+        <DropdownWithContext
+          autoFocus={true}
+          className=""
+          direction="up"
+          dropdownItems={
+            Array [
+              <DropdownItem
+                className="pf-m-selected"
+                component="button"
+                data-action="per-page-10"
+                onClick={[Function]}
               >
-                <DropdownWithContext
-                  autoFocus={true}
-                  className=""
-                  direction="up"
-                  dropdownItems={
-                    Array [
-                      <DropdownItem
-                        className="pf-m-selected"
-                        component="button"
-                        data-action="per-page-10"
-                        onClick={[Function]}
-                      >
-                        10
-                         per page
-                        <div
-                          className="pf-c-options-menu__menu-item-icon"
-                        >
-                          <CheckIcon
-                            color="currentColor"
-                            noVerticalAlign={false}
-                            size="sm"
-                          />
-                        </div>
-                      </DropdownItem>,
-                      <DropdownItem
-                        className=""
-                        component="button"
-                        data-action="per-page-20"
-                        onClick={[Function]}
-                      >
-                        20
-                         per page
-                      </DropdownItem>,
-                      <DropdownItem
-                        className=""
-                        component="button"
-                        data-action="per-page-50"
-                        onClick={[Function]}
-                      >
-                        50
-                         per page
-                      </DropdownItem>,
-                      <DropdownItem
-                        className=""
-                        component="button"
-                        data-action="per-page-100"
-                        onClick={[Function]}
-                      >
-                        100
-                         per page
-                      </DropdownItem>,
-                    ]
-                  }
-                  isFlipEnabled={true}
-                  isGrouped={false}
-                  isOpen={false}
-                  isPlain={true}
-                  isText={false}
-                  menuAppendTo="inline"
-                  onSelect={[Function]}
-                  position="left"
-                  toggle={
-                    <OptionsToggle
-                      firstIndex={1}
-                      isDisabled={false}
-                      isOpen={false}
-                      itemCount={10}
-                      itemsPerPageTitle="Items per page"
-                      itemsTitle=""
-                      lastIndex={10}
-                      ofWord="of"
-                      onToggle={[Function]}
-                      optionsToggle=""
-                      parentRef={null}
-                      perPageComponent="div"
-                      showToggle={true}
-                      toggleTemplate={[Function]}
-                      widgetId="pagination-options-menu-bottom-bottom"
-                    />
-                  }
+                10
+                 per page
+                <div
+                  className="pf-c-options-menu__menu-item-icon"
                 >
-                  <div
-                    className="pf-c-options-menu pf-m-top"
+                  <CheckIcon
+                    color="currentColor"
+                    noVerticalAlign={false}
+                    size="sm"
+                  />
+                </div>
+              </DropdownItem>,
+              <DropdownItem
+                className=""
+                component="button"
+                data-action="per-page-20"
+                onClick={[Function]}
+              >
+                20
+                 per page
+              </DropdownItem>,
+              <DropdownItem
+                className=""
+                component="button"
+                data-action="per-page-50"
+                onClick={[Function]}
+              >
+                50
+                 per page
+              </DropdownItem>,
+              <DropdownItem
+                className=""
+                component="button"
+                data-action="per-page-100"
+                onClick={[Function]}
+              >
+                100
+                 per page
+              </DropdownItem>,
+            ]
+          }
+          isFlipEnabled={true}
+          isGrouped={false}
+          isOpen={false}
+          isPlain={true}
+          isText={false}
+          menuAppendTo="inline"
+          onSelect={[Function]}
+          position="left"
+          toggle={
+            <OptionsToggle
+              firstIndex={1}
+              isDisabled={false}
+              isOpen={false}
+              itemCount={10}
+              itemsPerPageTitle="Items per page"
+              itemsTitle=""
+              lastIndex={10}
+              ofWord="of"
+              onToggle={[Function]}
+              optionsToggle=""
+              parentRef={null}
+              perPageComponent="div"
+              showToggle={true}
+              toggleTemplate={[Function]}
+              widgetId="pagination-options-menu-bottom-bottom"
+            />
+          }
+        >
+          <div
+            className="pf-c-options-menu pf-m-top"
+            data-ouia-component-type="PF4/PaginationOptionsMenu"
+            data-ouia-safe={true}
+          >
+            <OptionsToggle
+              aria-haspopup={true}
+              firstIndex={1}
+              getMenuRef={[Function]}
+              id="pf-dropdown-toggle-id-0"
+              isDisabled={false}
+              isOpen={false}
+              isPlain={true}
+              isText={false}
+              itemCount={10}
+              itemsPerPageTitle="Items per page"
+              itemsTitle=""
+              key=".0"
+              lastIndex={10}
+              ofWord="of"
+              onEnter={[Function]}
+              onToggle={[Function]}
+              optionsToggle=""
+              parentRef={
+                Object {
+                  "current": <div
+                    class="pf-c-options-menu pf-m-top"
                     data-ouia-component-type="PF4/PaginationOptionsMenu"
-                    data-ouia-safe={true}
+                    data-ouia-safe="true"
                   >
-                    <OptionsToggle
-                      aria-haspopup={true}
-                      firstIndex={1}
-                      getMenuRef={[Function]}
-                      id="pf-dropdown-toggle-id-0"
-                      isDisabled={false}
-                      isOpen={false}
-                      isPlain={true}
-                      isText={false}
-                      itemCount={10}
-                      itemsPerPageTitle="Items per page"
-                      itemsTitle=""
-                      key=".0"
-                      lastIndex={10}
-                      ofWord="of"
-                      onEnter={[Function]}
-                      onToggle={[Function]}
-                      optionsToggle=""
-                      parentRef={
-                        Object {
-                          "current": <div
-                            class="pf-c-options-menu pf-m-top"
-                            data-ouia-component-type="PF4/PaginationOptionsMenu"
-                            data-ouia-safe="true"
-                          >
-                            <div
-                              class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
-                            >
-                              <span
-                                class="pf-c-options-menu__toggle-text"
-                              >
-                                <b>
-                                  1
-                                   - 
-                                  10
-                                </b>
-                                 
-                                of
-                                 
-                                <b>
-                                  10
-                                </b>
-                                 
-                                
-                              </span>
-                              <button
-                                aria-expanded="false"
-                                aria-haspopup="listbox"
-                                aria-label="Items per page"
-                                class="  pf-c-options-menu__toggle-button"
-                                data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
-                                data-ouia-component-type="PF4/DropdownToggle"
-                                data-ouia-safe="true"
-                                id="pagination-options-menu-bottom-bottom-toggle"
-                                type="button"
-                              >
-                                <span
-                                  class="pf-c-options-menu__toggle-button-icon"
-                                >
-                                  <svg
-                                    aria-hidden="true"
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    style="vertical-align: -0.125em;"
-                                    viewBox="0 0 320 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                    />
-                                  </svg>
-                                </span>
-                              </button>
-                            </div>
-                          </div>,
-                        }
-                      }
-                      perPageComponent="div"
-                      showToggle={true}
-                      toggleTemplate={[Function]}
-                      widgetId="pagination-options-menu-bottom-bottom"
+                    <div
+                      class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
                     >
-                      <div
-                        className="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+                      <span
+                        class="pf-c-options-menu__toggle-text"
+                      >
+                        <b>
+                          1
+                           - 
+                          10
+                        </b>
+                         
+                        of
+                         
+                        <b>
+                          10
+                        </b>
+                         
+                        
+                      </span>
+                      <button
+                        aria-expanded="false"
+                        aria-haspopup="listbox"
+                        aria-label="Items per page"
+                        class="  pf-c-options-menu__toggle-button"
+                        data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
+                        data-ouia-component-type="PF4/DropdownToggle"
+                        data-ouia-safe="true"
+                        id="pagination-options-menu-bottom-bottom-toggle"
+                        type="button"
                       >
                         <span
-                          className="pf-c-options-menu__toggle-text"
+                          class="pf-c-options-menu__toggle-button-icon"
                         >
-                          <ToggleTemplate
-                            firstIndex={1}
-                            itemCount={10}
-                            itemsTitle=""
-                            lastIndex={10}
-                            ofWord="of"
+                          <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style="vertical-align: -0.125em;"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                    </div>
+                  </div>,
+                }
+              }
+              perPageComponent="div"
+              showToggle={true}
+              toggleTemplate={[Function]}
+              widgetId="pagination-options-menu-bottom-bottom"
+            >
+              <div
+                className="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+              >
+                <span
+                  className="pf-c-options-menu__toggle-text"
+                >
+                  <ToggleTemplate
+                    firstIndex={1}
+                    itemCount={10}
+                    itemsTitle=""
+                    lastIndex={10}
+                    ofWord="of"
+                  >
+                    <b>
+                      1
+                       - 
+                      10
+                    </b>
+                     
+                    of
+                     
+                    <b>
+                      10
+                    </b>
+                     
+                  </ToggleTemplate>
+                </span>
+                <DropdownToggle
+                  aria-haspopup="listbox"
+                  aria-label="Items per page"
+                  className="pf-c-options-menu__toggle-button"
+                  id="pagination-options-menu-bottom-bottom-toggle"
+                  isDisabled={false}
+                  isOpen={false}
+                  onEnter={[Function]}
+                  onToggle={[Function]}
+                  parentRef={
+                    Object {
+                      "current": <div
+                        class="pf-c-options-menu pf-m-top"
+                        data-ouia-component-type="PF4/PaginationOptionsMenu"
+                        data-ouia-safe="true"
+                      >
+                        <div
+                          class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+                        >
+                          <span
+                            class="pf-c-options-menu__toggle-text"
                           >
                             <b>
                               1
@@ -329,545 +348,467 @@ exports[`TableFooter Should match the snapshots 1`] = `
                               10
                             </b>
                              
-                          </ToggleTemplate>
-                        </span>
-                        <DropdownToggle
-                          aria-haspopup="listbox"
-                          aria-label="Items per page"
-                          className="pf-c-options-menu__toggle-button"
-                          id="pagination-options-menu-bottom-bottom-toggle"
-                          isDisabled={false}
-                          isOpen={false}
-                          onEnter={[Function]}
-                          onToggle={[Function]}
-                          parentRef={
-                            Object {
-                              "current": <div
-                                class="pf-c-options-menu pf-m-top"
-                                data-ouia-component-type="PF4/PaginationOptionsMenu"
-                                data-ouia-safe="true"
-                              >
-                                <div
-                                  class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
-                                >
-                                  <span
-                                    class="pf-c-options-menu__toggle-text"
-                                  >
-                                    <b>
-                                      1
-                                       - 
-                                      10
-                                    </b>
-                                     
-                                    of
-                                     
-                                    <b>
-                                      10
-                                    </b>
-                                     
-                                    
-                                  </span>
-                                  <button
-                                    aria-expanded="false"
-                                    aria-haspopup="listbox"
-                                    aria-label="Items per page"
-                                    class="  pf-c-options-menu__toggle-button"
-                                    data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
-                                    data-ouia-component-type="PF4/DropdownToggle"
-                                    data-ouia-safe="true"
-                                    id="pagination-options-menu-bottom-bottom-toggle"
-                                    type="button"
-                                  >
-                                    <span
-                                      class="pf-c-options-menu__toggle-button-icon"
-                                    >
-                                      <svg
-                                        aria-hidden="true"
-                                        fill="currentColor"
-                                        height="1em"
-                                        role="img"
-                                        style="vertical-align: -0.125em;"
-                                        viewBox="0 0 320 512"
-                                        width="1em"
-                                      >
-                                        <path
-                                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                        />
-                                      </svg>
-                                    </span>
-                                  </button>
-                                </div>
-                              </div>,
-                            }
-                          }
-                        >
-                          <Toggle
+                            
+                          </span>
+                          <button
+                            aria-expanded="false"
                             aria-haspopup="listbox"
                             aria-label="Items per page"
-                            bubbleEvent={false}
-                            className="pf-c-options-menu__toggle-button"
+                            class="  pf-c-options-menu__toggle-button"
                             data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
                             data-ouia-component-type="PF4/DropdownToggle"
-                            data-ouia-safe={true}
-                            getMenuRef={null}
+                            data-ouia-safe="true"
                             id="pagination-options-menu-bottom-bottom-toggle"
-                            isActive={false}
-                            isDisabled={false}
-                            isOpen={false}
-                            isPlain={false}
-                            isPrimary={false}
-                            isSplitButton={false}
-                            isText={false}
-                            onEnter={[Function]}
-                            onToggle={[Function]}
-                            parentRef={
-                              Object {
-                                "current": <div
-                                  class="pf-c-options-menu pf-m-top"
-                                  data-ouia-component-type="PF4/PaginationOptionsMenu"
-                                  data-ouia-safe="true"
-                                >
-                                  <div
-                                    class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
-                                  >
-                                    <span
-                                      class="pf-c-options-menu__toggle-text"
-                                    >
-                                      <b>
-                                        1
-                                         - 
-                                        10
-                                      </b>
-                                       
-                                      of
-                                       
-                                      <b>
-                                        10
-                                      </b>
-                                       
-                                      
-                                    </span>
-                                    <button
-                                      aria-expanded="false"
-                                      aria-haspopup="listbox"
-                                      aria-label="Items per page"
-                                      class="  pf-c-options-menu__toggle-button"
-                                      data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
-                                      data-ouia-component-type="PF4/DropdownToggle"
-                                      data-ouia-safe="true"
-                                      id="pagination-options-menu-bottom-bottom-toggle"
-                                      type="button"
-                                    >
-                                      <span
-                                        class="pf-c-options-menu__toggle-button-icon"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          fill="currentColor"
-                                          height="1em"
-                                          role="img"
-                                          style="vertical-align: -0.125em;"
-                                          viewBox="0 0 320 512"
-                                          width="1em"
-                                        >
-                                          <path
-                                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                          />
-                                        </svg>
-                                      </span>
-                                    </button>
-                                  </div>
-                                </div>,
-                              }
-                            }
-                            toggleVariant="default"
+                            type="button"
                           >
+                            <span
+                              class="pf-c-options-menu__toggle-button-icon"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                style="vertical-align: -0.125em;"
+                                viewBox="0 0 320 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                />
+                              </svg>
+                            </span>
+                          </button>
+                        </div>
+                      </div>,
+                    }
+                  }
+                >
+                  <Toggle
+                    aria-haspopup="listbox"
+                    aria-label="Items per page"
+                    bubbleEvent={false}
+                    className="pf-c-options-menu__toggle-button"
+                    data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
+                    data-ouia-component-type="PF4/DropdownToggle"
+                    data-ouia-safe={true}
+                    getMenuRef={null}
+                    id="pagination-options-menu-bottom-bottom-toggle"
+                    isActive={false}
+                    isDisabled={false}
+                    isOpen={false}
+                    isPlain={false}
+                    isPrimary={false}
+                    isSplitButton={false}
+                    isText={false}
+                    onEnter={[Function]}
+                    onToggle={[Function]}
+                    parentRef={
+                      Object {
+                        "current": <div
+                          class="pf-c-options-menu pf-m-top"
+                          data-ouia-component-type="PF4/PaginationOptionsMenu"
+                          data-ouia-safe="true"
+                        >
+                          <div
+                            class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+                          >
+                            <span
+                              class="pf-c-options-menu__toggle-text"
+                            >
+                              <b>
+                                1
+                                 - 
+                                10
+                              </b>
+                               
+                              of
+                               
+                              <b>
+                                10
+                              </b>
+                               
+                              
+                            </span>
                             <button
-                              aria-expanded={false}
+                              aria-expanded="false"
                               aria-haspopup="listbox"
                               aria-label="Items per page"
-                              className="  pf-c-options-menu__toggle-button"
+                              class="  pf-c-options-menu__toggle-button"
                               data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
                               data-ouia-component-type="PF4/DropdownToggle"
-                              data-ouia-safe={true}
-                              disabled={false}
+                              data-ouia-safe="true"
                               id="pagination-options-menu-bottom-bottom-toggle"
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
                               type="button"
                             >
                               <span
-                                className="pf-c-options-menu__toggle-button-icon"
+                                class="pf-c-options-menu__toggle-button-icon"
                               >
-                                <CaretDownIcon
-                                  color="currentColor"
-                                  noVerticalAlign={false}
-                                  size="sm"
+                                <svg
+                                  aria-hidden="true"
+                                  fill="currentColor"
+                                  height="1em"
+                                  role="img"
+                                  style="vertical-align: -0.125em;"
+                                  viewBox="0 0 320 512"
+                                  width="1em"
                                 >
-                                  <svg
-                                    aria-hidden={true}
-                                    aria-labelledby={null}
-                                    fill="currentColor"
-                                    height="1em"
-                                    role="img"
-                                    style={
-                                      Object {
-                                        "verticalAlign": "-0.125em",
-                                      }
-                                    }
-                                    viewBox="0 0 320 512"
-                                    width="1em"
-                                  >
-                                    <path
-                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                    />
-                                  </svg>
-                                </CaretDownIcon>
+                                  <path
+                                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                  />
+                                </svg>
                               </span>
                             </button>
-                          </Toggle>
-                        </DropdownToggle>
-                      </div>
-                    </OptionsToggle>
-                  </div>
-                </DropdownWithContext>
-              </PaginationOptionsMenu>
-              <Navigation
-                className=""
-                currPage="Current page"
-                firstPage={1}
-                isCompact={false}
-                isDisabled={false}
-                itemCount={10}
-                lastPage={1}
-                ofWord="of"
-                onFirstClick={[Function]}
-                onLastClick={[Function]}
-                onNextClick={[Function]}
-                onPageInput={[Function]}
-                onPreviousClick={[Function]}
-                onSetPage={[MockFunction]}
-                page={1}
-                pagesTitle=""
-                pagesTitlePlural=""
-                paginationTitle="Pagination"
-                perPage={10}
-                toFirstPage="Go to first page"
-                toLastPage="Go to last page"
-                toNextPage="Go to next page"
-                toPreviousPage="Go to previous page"
-              >
-                <nav
-                  aria-label="Pagination"
-                  className="pf-c-pagination__nav"
-                >
-                  <div
-                    className="pf-c-pagination__nav-control pf-m-first"
+                          </div>
+                        </div>,
+                      }
+                    }
+                    toggleVariant="default"
                   >
-                    <Button
-                      aria-label="Go to first page"
-                      data-action="first"
-                      isDisabled={true}
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup="listbox"
+                      aria-label="Items per page"
+                      className="  pf-c-options-menu__toggle-button"
+                      data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
+                      data-ouia-component-type="PF4/DropdownToggle"
+                      data-ouia-safe={true}
+                      disabled={false}
+                      id="pagination-options-menu-bottom-bottom-toggle"
                       onClick={[Function]}
-                      variant="plain"
-                    >
-                      <ButtonBase
-                        aria-label="Go to first page"
-                        data-action="first"
-                        innerRef={null}
-                        isDisabled={true}
-                        onClick={[Function]}
-                        variant="plain"
-                      >
-                        <button
-                          aria-disabled={true}
-                          aria-label="Go to first page"
-                          className="pf-c-button pf-m-plain pf-m-disabled"
-                          data-action="first"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-1"
-                          data-ouia-component-type="PF4/Button"
-                          data-ouia-safe={true}
-                          disabled={true}
-                          onClick={[Function]}
-                          role={null}
-                          tabIndex={null}
-                          type="button"
-                        >
-                          <AngleDoubleLeftIcon
-                            color="currentColor"
-                            noVerticalAlign={false}
-                            size="sm"
-                          >
-                            <svg
-                              aria-hidden={true}
-                              aria-labelledby={null}
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              style={
-                                Object {
-                                  "verticalAlign": "-0.125em",
-                                }
-                              }
-                              viewBox="0 0 448 512"
-                              width="1em"
-                            >
-                              <path
-                                d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                              />
-                            </svg>
-                          </AngleDoubleLeftIcon>
-                        </button>
-                      </ButtonBase>
-                    </Button>
-                  </div>
-                  <div
-                    className="pf-c-pagination__nav-control"
-                  >
-                    <Button
-                      aria-label="Go to previous page"
-                      data-action="previous"
-                      isDisabled={true}
-                      onClick={[Function]}
-                      variant="plain"
-                    >
-                      <ButtonBase
-                        aria-label="Go to previous page"
-                        data-action="previous"
-                        innerRef={null}
-                        isDisabled={true}
-                        onClick={[Function]}
-                        variant="plain"
-                      >
-                        <button
-                          aria-disabled={true}
-                          aria-label="Go to previous page"
-                          className="pf-c-button pf-m-plain pf-m-disabled"
-                          data-action="previous"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-2"
-                          data-ouia-component-type="PF4/Button"
-                          data-ouia-safe={true}
-                          disabled={true}
-                          onClick={[Function]}
-                          role={null}
-                          tabIndex={null}
-                          type="button"
-                        >
-                          <AngleLeftIcon
-                            color="currentColor"
-                            noVerticalAlign={false}
-                            size="sm"
-                          >
-                            <svg
-                              aria-hidden={true}
-                              aria-labelledby={null}
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              style={
-                                Object {
-                                  "verticalAlign": "-0.125em",
-                                }
-                              }
-                              viewBox="0 0 256 512"
-                              width="1em"
-                            >
-                              <path
-                                d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                              />
-                            </svg>
-                          </AngleLeftIcon>
-                        </button>
-                      </ButtonBase>
-                    </Button>
-                  </div>
-                  <div
-                    className="pf-c-pagination__nav-page-select"
-                  >
-                    <input
-                      aria-label="Current page"
-                      className="pf-c-form-control"
-                      disabled={true}
-                      max={1}
-                      min={1}
-                      onChange={[Function]}
                       onKeyDown={[Function]}
-                      type="number"
-                      value={1}
-                    />
-                    <span
-                      aria-hidden="true"
+                      type="button"
                     >
-                      of
-                       
-                      1
-                    </span>
-                  </div>
-                  <div
-                    className="pf-c-pagination__nav-control"
-                  >
-                    <Button
-                      aria-label="Go to next page"
-                      data-action="next"
-                      isDisabled={true}
-                      onClick={[Function]}
-                      variant="plain"
-                    >
-                      <ButtonBase
-                        aria-label="Go to next page"
-                        data-action="next"
-                        innerRef={null}
-                        isDisabled={true}
-                        onClick={[Function]}
-                        variant="plain"
+                      <span
+                        className="pf-c-options-menu__toggle-button-icon"
                       >
-                        <button
-                          aria-disabled={true}
-                          aria-label="Go to next page"
-                          className="pf-c-button pf-m-plain pf-m-disabled"
-                          data-action="next"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-3"
-                          data-ouia-component-type="PF4/Button"
-                          data-ouia-safe={true}
-                          disabled={true}
-                          onClick={[Function]}
-                          role={null}
-                          tabIndex={null}
-                          type="button"
+                        <CaretDownIcon
+                          color="currentColor"
+                          noVerticalAlign={false}
+                          size="sm"
                         >
-                          <AngleRightIcon
-                            color="currentColor"
-                            noVerticalAlign={false}
-                            size="sm"
-                          >
-                            <svg
-                              aria-hidden={true}
-                              aria-labelledby={null}
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              style={
-                                Object {
-                                  "verticalAlign": "-0.125em",
-                                }
+                          <svg
+                            aria-hidden={true}
+                            aria-labelledby={null}
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            style={
+                              Object {
+                                "verticalAlign": "-0.125em",
                               }
-                              viewBox="0 0 256 512"
-                              width="1em"
-                            >
-                              <path
-                                d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                              />
-                            </svg>
-                          </AngleRightIcon>
-                        </button>
-                      </ButtonBase>
-                    </Button>
-                  </div>
-                  <div
-                    className="pf-c-pagination__nav-control pf-m-last"
-                  >
-                    <Button
-                      aria-label="Go to last page"
-                      data-action="last"
-                      isDisabled={true}
-                      onClick={[Function]}
-                      variant="plain"
-                    >
-                      <ButtonBase
-                        aria-label="Go to last page"
-                        data-action="last"
-                        innerRef={null}
-                        isDisabled={true}
-                        onClick={[Function]}
-                        variant="plain"
-                      >
-                        <button
-                          aria-disabled={true}
-                          aria-label="Go to last page"
-                          className="pf-c-button pf-m-plain pf-m-disabled"
-                          data-action="last"
-                          data-ouia-component-id="OUIA-Generated-Button-plain-4"
-                          data-ouia-component-type="PF4/Button"
-                          data-ouia-safe={true}
-                          disabled={true}
-                          onClick={[Function]}
-                          role={null}
-                          tabIndex={null}
-                          type="button"
-                        >
-                          <AngleDoubleRightIcon
-                            color="currentColor"
-                            noVerticalAlign={false}
-                            size="sm"
+                            }
+                            viewBox="0 0 320 512"
+                            width="1em"
                           >
-                            <svg
-                              aria-hidden={true}
-                              aria-labelledby={null}
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              style={
-                                Object {
-                                  "verticalAlign": "-0.125em",
-                                }
-                              }
-                              viewBox="0 0 448 512"
-                              width="1em"
-                            >
-                              <path
-                                d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                              />
-                            </svg>
-                          </AngleDoubleRightIcon>
-                        </button>
-                      </ButtonBase>
-                    </Button>
-                  </div>
-                </nav>
-              </Navigation>
-            </div>
-          </Pagination>
-          <ToolbarChipGroupContent
-            chipGroupContentRef={
-              Object {
-                "current": <div
-                  class="pf-c-toolbar__content pf-m-hidden"
-                  hidden=""
-                >
-                  <div
-                    class="pf-c-toolbar__group"
-                  />
-                </div>,
-              }
-            }
-            clearFiltersButtonText="Clear all filters"
-            collapseListedFiltersBreakpoint="lg"
-            isExpanded={false}
-            numberOfFilters={0}
-            numberOfFiltersText={[Function]}
-            showClearFiltersButton={false}
+                            <path
+                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            />
+                          </svg>
+                        </CaretDownIcon>
+                      </span>
+                    </button>
+                  </Toggle>
+                </DropdownToggle>
+              </div>
+            </OptionsToggle>
+          </div>
+        </DropdownWithContext>
+      </PaginationOptionsMenu>
+      <Navigation
+        className=""
+        currPage="Current page"
+        firstPage={1}
+        isCompact={false}
+        isDisabled={false}
+        itemCount={10}
+        lastPage={1}
+        ofWord="of"
+        onFirstClick={[Function]}
+        onLastClick={[Function]}
+        onNextClick={[Function]}
+        onPageInput={[Function]}
+        onPreviousClick={[Function]}
+        onSetPage={[MockFunction]}
+        page={1}
+        pagesTitle=""
+        pagesTitlePlural=""
+        paginationTitle="Pagination"
+        perPage={10}
+        toFirstPage="Go to first page"
+        toLastPage="Go to last page"
+        toNextPage="Go to next page"
+        toPreviousPage="Go to previous page"
+      >
+        <nav
+          aria-label="Pagination"
+          className="pf-c-pagination__nav"
+        >
+          <div
+            className="pf-c-pagination__nav-control pf-m-first"
           >
-            <div
-              className="pf-c-toolbar__content pf-m-hidden"
-              hidden={true}
+            <Button
+              aria-label="Go to first page"
+              data-action="first"
+              isDisabled={true}
+              onClick={[Function]}
+              variant="plain"
             >
-              <ForwardRef
-                className=""
+              <ButtonBase
+                aria-label="Go to first page"
+                data-action="first"
+                innerRef={null}
+                isDisabled={true}
+                onClick={[Function]}
+                variant="plain"
               >
-                <ToolbarGroupWithRef
-                  className=""
-                  innerRef={null}
+                <button
+                  aria-disabled={true}
+                  aria-label="Go to first page"
+                  className="pf-c-button pf-m-plain pf-m-disabled"
+                  data-action="first"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-1"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe={true}
+                  disabled={true}
+                  onClick={[Function]}
+                  role={null}
+                  tabIndex={null}
+                  type="button"
                 >
-                  <div
-                    className="pf-c-toolbar__group"
-                  />
-                </ToolbarGroupWithRef>
-              </ForwardRef>
-            </div>
-          </ToolbarChipGroupContent>
-        </div>
-      </GenerateId>
-    </Toolbar>
-  </TableToolbar>
+                  <AngleDoubleLeftIcon
+                    color="currentColor"
+                    noVerticalAlign={false}
+                    size="sm"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      aria-labelledby={null}
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style={
+                        Object {
+                          "verticalAlign": "-0.125em",
+                        }
+                      }
+                      viewBox="0 0 448 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                      />
+                    </svg>
+                  </AngleDoubleLeftIcon>
+                </button>
+              </ButtonBase>
+            </Button>
+          </div>
+          <div
+            className="pf-c-pagination__nav-control"
+          >
+            <Button
+              aria-label="Go to previous page"
+              data-action="previous"
+              isDisabled={true}
+              onClick={[Function]}
+              variant="plain"
+            >
+              <ButtonBase
+                aria-label="Go to previous page"
+                data-action="previous"
+                innerRef={null}
+                isDisabled={true}
+                onClick={[Function]}
+                variant="plain"
+              >
+                <button
+                  aria-disabled={true}
+                  aria-label="Go to previous page"
+                  className="pf-c-button pf-m-plain pf-m-disabled"
+                  data-action="previous"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-2"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe={true}
+                  disabled={true}
+                  onClick={[Function]}
+                  role={null}
+                  tabIndex={null}
+                  type="button"
+                >
+                  <AngleLeftIcon
+                    color="currentColor"
+                    noVerticalAlign={false}
+                    size="sm"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      aria-labelledby={null}
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style={
+                        Object {
+                          "verticalAlign": "-0.125em",
+                        }
+                      }
+                      viewBox="0 0 256 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                      />
+                    </svg>
+                  </AngleLeftIcon>
+                </button>
+              </ButtonBase>
+            </Button>
+          </div>
+          <div
+            className="pf-c-pagination__nav-page-select"
+          >
+            <input
+              aria-label="Current page"
+              className="pf-c-form-control"
+              disabled={true}
+              max={1}
+              min={1}
+              onChange={[Function]}
+              onKeyDown={[Function]}
+              type="number"
+              value={1}
+            />
+            <span
+              aria-hidden="true"
+            >
+              of
+               
+              1
+            </span>
+          </div>
+          <div
+            className="pf-c-pagination__nav-control"
+          >
+            <Button
+              aria-label="Go to next page"
+              data-action="next"
+              isDisabled={true}
+              onClick={[Function]}
+              variant="plain"
+            >
+              <ButtonBase
+                aria-label="Go to next page"
+                data-action="next"
+                innerRef={null}
+                isDisabled={true}
+                onClick={[Function]}
+                variant="plain"
+              >
+                <button
+                  aria-disabled={true}
+                  aria-label="Go to next page"
+                  className="pf-c-button pf-m-plain pf-m-disabled"
+                  data-action="next"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-3"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe={true}
+                  disabled={true}
+                  onClick={[Function]}
+                  role={null}
+                  tabIndex={null}
+                  type="button"
+                >
+                  <AngleRightIcon
+                    color="currentColor"
+                    noVerticalAlign={false}
+                    size="sm"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      aria-labelledby={null}
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style={
+                        Object {
+                          "verticalAlign": "-0.125em",
+                        }
+                      }
+                      viewBox="0 0 256 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                      />
+                    </svg>
+                  </AngleRightIcon>
+                </button>
+              </ButtonBase>
+            </Button>
+          </div>
+          <div
+            className="pf-c-pagination__nav-control pf-m-last"
+          >
+            <Button
+              aria-label="Go to last page"
+              data-action="last"
+              isDisabled={true}
+              onClick={[Function]}
+              variant="plain"
+            >
+              <ButtonBase
+                aria-label="Go to last page"
+                data-action="last"
+                innerRef={null}
+                isDisabled={true}
+                onClick={[Function]}
+                variant="plain"
+              >
+                <button
+                  aria-disabled={true}
+                  aria-label="Go to last page"
+                  className="pf-c-button pf-m-plain pf-m-disabled"
+                  data-action="last"
+                  data-ouia-component-id="OUIA-Generated-Button-plain-4"
+                  data-ouia-component-type="PF4/Button"
+                  data-ouia-safe={true}
+                  disabled={true}
+                  onClick={[Function]}
+                  role={null}
+                  tabIndex={null}
+                  type="button"
+                >
+                  <AngleDoubleRightIcon
+                    color="currentColor"
+                    noVerticalAlign={false}
+                    size="sm"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      aria-labelledby={null}
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      style={
+                        Object {
+                          "verticalAlign": "-0.125em",
+                        }
+                      }
+                      viewBox="0 0 448 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                      />
+                    </svg>
+                  </AngleDoubleRightIcon>
+                </button>
+              </ButtonBase>
+            </Button>
+          </div>
+        </nav>
+      </Navigation>
+    </div>
+  </Pagination>
 </TableFooter>
 `;

--- a/src/SmartComponents/AdvisoryDetail/__snapshots__/CveModal.test.js.snap
+++ b/src/SmartComponents/AdvisoryDetail/__snapshots__/CveModal.test.js.snap
@@ -214,148 +214,12 @@ exports[`CveModal.js Should match the snapshots 1`] = `
                                 class="pf-c-toolbar__item ins-c-primary-toolbar__pagination"
                               >
                                 <div
-                                  class="pf-c-pagination pf-m-compact"
-                                  data-ouia-component-id="top-cves-pagination"
-                                  data-ouia-component-type="PF4/Pagination"
-                                  data-ouia-safe="true"
-                                  id="options-menu-top-pagination"
-                                  style="--pf-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+                                  class="pf-c-skeleton pf-m-text-xl"
+                                  style="--pf-c-skeleton--Width: 200px; margin: 10px;"
                                 >
-                                  <div
-                                    class="pf-c-pagination__total-items"
-                                  >
-                                    <b>
-                                      1
-                                       - 
-                                      10
-                                    </b>
-                                     
-                                    of
-                                     
-                                    <b>
-                                      12
-                                    </b>
-                                     
-                                    
-                                  </div>
-                                  <div
-                                    class="pf-c-options-menu"
-                                    data-ouia-component-type="PF4/PaginationOptionsMenu"
-                                    data-ouia-safe="true"
-                                  >
-                                    <div
-                                      class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
-                                    >
-                                      <span
-                                        class="pf-c-options-menu__toggle-text"
-                                      >
-                                        <b>
-                                          1
-                                           - 
-                                          10
-                                        </b>
-                                         
-                                        of
-                                         
-                                        <b>
-                                          12
-                                        </b>
-                                         
-                                        
-                                      </span>
-                                      <button
-                                        aria-expanded="false"
-                                        aria-haspopup="listbox"
-                                        aria-label="Items per page"
-                                        class="  pf-c-options-menu__toggle-button"
-                                        data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
-                                        data-ouia-component-type="PF4/DropdownToggle"
-                                        data-ouia-safe="true"
-                                        id="options-menu-top-toggle"
-                                        type="button"
-                                      >
-                                        <span
-                                          class="pf-c-options-menu__toggle-button-icon"
-                                        >
-                                          <svg
-                                            aria-hidden="true"
-                                            fill="currentColor"
-                                            height="1em"
-                                            role="img"
-                                            style="vertical-align: -0.125em;"
-                                            viewBox="0 0 320 512"
-                                            width="1em"
-                                          >
-                                            <path
-                                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                            />
-                                          </svg>
-                                        </span>
-                                      </button>
-                                    </div>
-                                  </div>
-                                  <nav
-                                    aria-label="Pagination"
-                                    class="pf-c-pagination__nav"
-                                  >
-                                    <div
-                                      class="pf-c-pagination__nav-control"
-                                    >
-                                      <button
-                                        aria-disabled="true"
-                                        aria-label="Go to previous page"
-                                        class="pf-c-button pf-m-plain pf-m-disabled"
-                                        data-action="previous"
-                                        data-ouia-component-id="OUIA-Generated-Button-plain-2"
-                                        data-ouia-component-type="PF4/Button"
-                                        data-ouia-safe="true"
-                                        disabled=""
-                                        type="button"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          fill="currentColor"
-                                          height="1em"
-                                          role="img"
-                                          style="vertical-align: -0.125em;"
-                                          viewBox="0 0 256 512"
-                                          width="1em"
-                                        >
-                                          <path
-                                            d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                                          />
-                                        </svg>
-                                      </button>
-                                    </div>
-                                    <div
-                                      class="pf-c-pagination__nav-control"
-                                    >
-                                      <button
-                                        aria-disabled="false"
-                                        aria-label="Go to next page"
-                                        class="pf-c-button pf-m-plain"
-                                        data-action="next"
-                                        data-ouia-component-id="OUIA-Generated-Button-plain-3"
-                                        data-ouia-component-type="PF4/Button"
-                                        data-ouia-safe="true"
-                                        type="button"
-                                      >
-                                        <svg
-                                          aria-hidden="true"
-                                          fill="currentColor"
-                                          height="1em"
-                                          role="img"
-                                          style="vertical-align: -0.125em;"
-                                          viewBox="0 0 256 512"
-                                          width="1em"
-                                        >
-                                          <path
-                                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                          />
-                                        </svg>
-                                      </button>
-                                    </div>
-                                  </nav>
+                                  <span
+                                    class="pf-u-screen-reader"
+                                  />
                                 </div>
                               </div>
                             </div>
@@ -1912,6 +1776,18 @@ exports[`CveModal.js Should match the snapshots 1`] = `
                             </tr>
                           </tbody>
                         </table>
+                        <div
+                          class="pf-c-pagination pf-m-bottom"
+                        >
+                          <div
+                            class="pf-c-skeleton pf-m-text-xl"
+                            style="--pf-c-skeleton--Width: 350px; margin: 10px;"
+                          >
+                            <span
+                              class="pf-u-screen-reader"
+                            />
+                          </div>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -2369,16 +2245,15 @@ exports[`CveModal.js Should match the snapshots 1`] = `
                                       }
                                     }
                                     pagination={
-                                      Object {
-                                        "isCompact": true,
-                                        "isDisabled": false,
-                                        "itemCount": 12,
-                                        "onPerPageSelect": [Function],
-                                        "onSetPage": [Function],
-                                        "ouiaId": "top-cves-pagination",
-                                        "page": 1,
-                                        "perPage": 10,
-                                      }
+                                      <Skeleton
+                                        fontSize="xl"
+                                        style={
+                                          Object {
+                                            "margin": 10,
+                                          }
+                                        }
+                                        width="200px"
+                                      />
                                     }
                                   >
                                     <Toolbar
@@ -2747,690 +2622,30 @@ exports[`CveModal.js Should match the snapshots 1`] = `
                                                 <div
                                                   className="pf-c-toolbar__item ins-c-primary-toolbar__pagination"
                                                 >
-                                                  <Pagination
-                                                    className=""
-                                                    defaultToFullPage={false}
-                                                    firstPage={1}
-                                                    isCompact={true}
-                                                    isDisabled={false}
-                                                    isSticky={false}
-                                                    itemCount={12}
-                                                    itemsEnd={null}
-                                                    itemsStart={null}
-                                                    offset={0}
-                                                    onFirstClick={[Function]}
-                                                    onLastClick={[Function]}
-                                                    onNextClick={[Function]}
-                                                    onPageInput={[Function]}
-                                                    onPerPageSelect={[Function]}
-                                                    onPreviousClick={[Function]}
-                                                    onSetPage={[Function]}
-                                                    ouiaId="top-cves-pagination"
-                                                    ouiaSafe={true}
-                                                    page={1}
-                                                    perPage={10}
-                                                    perPageComponent="div"
-                                                    perPageOptions={
-                                                      Array [
-                                                        Object {
-                                                          "title": "10",
-                                                          "value": 10,
-                                                        },
-                                                        Object {
-                                                          "title": "20",
-                                                          "value": 20,
-                                                        },
-                                                        Object {
-                                                          "title": "50",
-                                                          "value": 50,
-                                                        },
-                                                        Object {
-                                                          "title": "100",
-                                                          "value": 100,
-                                                        },
-                                                      ]
-                                                    }
-                                                    titles={
+                                                  <Skeleton
+                                                    fontSize="xl"
+                                                    style={
                                                       Object {
-                                                        "currPage": "Current page",
-                                                        "items": "",
-                                                        "itemsPerPage": "Items per page",
-                                                        "ofWord": "of",
-                                                        "optionsToggle": "",
-                                                        "page": "",
-                                                        "pages": "",
-                                                        "paginationTitle": "Pagination",
-                                                        "perPageSuffix": "per page",
-                                                        "toFirstPage": "Go to first page",
-                                                        "toLastPage": "Go to last page",
-                                                        "toNextPage": "Go to next page",
-                                                        "toPreviousPage": "Go to previous page",
+                                                        "margin": 10,
                                                       }
                                                     }
-                                                    variant="top"
-                                                    widgetId="options-menu"
+                                                    width="200px"
                                                   >
                                                     <div
-                                                      className="pf-c-pagination pf-m-compact"
-                                                      data-ouia-component-id="top-cves-pagination"
-                                                      data-ouia-component-type="PF4/Pagination"
-                                                      data-ouia-safe={true}
-                                                      id="options-menu-top-pagination"
-                                                    >
-                                                      <div
-                                                        className="pf-c-pagination__total-items"
-                                                      >
-                                                        <ToggleTemplate
-                                                          firstIndex={1}
-                                                          itemCount={12}
-                                                          itemsTitle=""
-                                                          lastIndex={10}
-                                                          ofWord="of"
-                                                        >
-                                                          <b>
-                                                            1
-                                                             - 
-                                                            10
-                                                          </b>
-                                                           
-                                                          of
-                                                           
-                                                          <b>
-                                                            12
-                                                          </b>
-                                                           
-                                                        </ToggleTemplate>
-                                                      </div>
-                                                      <PaginationOptionsMenu
-                                                        className=""
-                                                        defaultToFullPage={false}
-                                                        dropDirection="down"
-                                                        firstIndex={1}
-                                                        isDisabled={false}
-                                                        itemCount={12}
-                                                        itemsPerPageTitle="Items per page"
-                                                        itemsTitle=""
-                                                        lastIndex={10}
-                                                        lastPage={2}
-                                                        ofWord="of"
-                                                        onPerPageSelect={[Function]}
-                                                        optionsToggle=""
-                                                        page={1}
-                                                        perPage={10}
-                                                        perPageComponent="div"
-                                                        perPageOptions={
-                                                          Array [
-                                                            Object {
-                                                              "title": "10",
-                                                              "value": 10,
-                                                            },
-                                                            Object {
-                                                              "title": "20",
-                                                              "value": 20,
-                                                            },
-                                                            Object {
-                                                              "title": "50",
-                                                              "value": 50,
-                                                            },
-                                                            Object {
-                                                              "title": "100",
-                                                              "value": 100,
-                                                            },
-                                                          ]
+                                                      className="pf-c-skeleton pf-m-text-xl"
+                                                      style={
+                                                        Object {
+                                                          "--pf-c-skeleton--Height": undefined,
+                                                          "--pf-c-skeleton--Width": "200px",
+                                                          "margin": 10,
                                                         }
-                                                        perPageSuffix="per page"
-                                                        toggleTemplate={[Function]}
-                                                        widgetId="options-menu-top"
-                                                      >
-                                                        <DropdownWithContext
-                                                          autoFocus={true}
-                                                          className=""
-                                                          direction="down"
-                                                          dropdownItems={
-                                                            Array [
-                                                              <DropdownItem
-                                                                className="pf-m-selected"
-                                                                component="button"
-                                                                data-action="per-page-10"
-                                                                onClick={[Function]}
-                                                              >
-                                                                10
-                                                                 per page
-                                                                <div
-                                                                  className="pf-c-options-menu__menu-item-icon"
-                                                                >
-                                                                  <CheckIcon
-                                                                    color="currentColor"
-                                                                    noVerticalAlign={false}
-                                                                    size="sm"
-                                                                  />
-                                                                </div>
-                                                              </DropdownItem>,
-                                                              <DropdownItem
-                                                                className=""
-                                                                component="button"
-                                                                data-action="per-page-20"
-                                                                onClick={[Function]}
-                                                              >
-                                                                20
-                                                                 per page
-                                                              </DropdownItem>,
-                                                              <DropdownItem
-                                                                className=""
-                                                                component="button"
-                                                                data-action="per-page-50"
-                                                                onClick={[Function]}
-                                                              >
-                                                                50
-                                                                 per page
-                                                              </DropdownItem>,
-                                                              <DropdownItem
-                                                                className=""
-                                                                component="button"
-                                                                data-action="per-page-100"
-                                                                onClick={[Function]}
-                                                              >
-                                                                100
-                                                                 per page
-                                                              </DropdownItem>,
-                                                            ]
-                                                          }
-                                                          isFlipEnabled={true}
-                                                          isGrouped={false}
-                                                          isOpen={false}
-                                                          isPlain={true}
-                                                          isText={false}
-                                                          menuAppendTo="inline"
-                                                          onSelect={[Function]}
-                                                          position="left"
-                                                          toggle={
-                                                            <OptionsToggle
-                                                              firstIndex={1}
-                                                              isDisabled={false}
-                                                              isOpen={false}
-                                                              itemCount={12}
-                                                              itemsPerPageTitle="Items per page"
-                                                              itemsTitle=""
-                                                              lastIndex={10}
-                                                              ofWord="of"
-                                                              onToggle={[Function]}
-                                                              optionsToggle=""
-                                                              parentRef={null}
-                                                              perPageComponent="div"
-                                                              showToggle={true}
-                                                              toggleTemplate={[Function]}
-                                                              widgetId="options-menu-top"
-                                                            />
-                                                          }
-                                                        >
-                                                          <div
-                                                            className="pf-c-options-menu"
-                                                            data-ouia-component-type="PF4/PaginationOptionsMenu"
-                                                            data-ouia-safe={true}
-                                                          >
-                                                            <OptionsToggle
-                                                              aria-haspopup={true}
-                                                              firstIndex={1}
-                                                              getMenuRef={[Function]}
-                                                              id="pf-dropdown-toggle-id-1"
-                                                              isDisabled={false}
-                                                              isOpen={false}
-                                                              isPlain={true}
-                                                              isText={false}
-                                                              itemCount={12}
-                                                              itemsPerPageTitle="Items per page"
-                                                              itemsTitle=""
-                                                              key=".0"
-                                                              lastIndex={10}
-                                                              ofWord="of"
-                                                              onEnter={[Function]}
-                                                              onToggle={[Function]}
-                                                              optionsToggle=""
-                                                              parentRef={
-                                                                Object {
-                                                                  "current": <div
-                                                                    class="pf-c-options-menu"
-                                                                    data-ouia-component-type="PF4/PaginationOptionsMenu"
-                                                                    data-ouia-safe="true"
-                                                                  >
-                                                                    <div
-                                                                      class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
-                                                                    >
-                                                                      <span
-                                                                        class="pf-c-options-menu__toggle-text"
-                                                                      >
-                                                                        <b>
-                                                                          1
-                                                                           - 
-                                                                          10
-                                                                        </b>
-                                                                         
-                                                                        of
-                                                                         
-                                                                        <b>
-                                                                          12
-                                                                        </b>
-                                                                         
-                                                                        
-                                                                      </span>
-                                                                      <button
-                                                                        aria-expanded="false"
-                                                                        aria-haspopup="listbox"
-                                                                        aria-label="Items per page"
-                                                                        class="  pf-c-options-menu__toggle-button"
-                                                                        data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
-                                                                        data-ouia-component-type="PF4/DropdownToggle"
-                                                                        data-ouia-safe="true"
-                                                                        id="options-menu-top-toggle"
-                                                                        type="button"
-                                                                      >
-                                                                        <span
-                                                                          class="pf-c-options-menu__toggle-button-icon"
-                                                                        >
-                                                                          <svg
-                                                                            aria-hidden="true"
-                                                                            fill="currentColor"
-                                                                            height="1em"
-                                                                            role="img"
-                                                                            style="vertical-align: -0.125em;"
-                                                                            viewBox="0 0 320 512"
-                                                                            width="1em"
-                                                                          >
-                                                                            <path
-                                                                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                                                            />
-                                                                          </svg>
-                                                                        </span>
-                                                                      </button>
-                                                                    </div>
-                                                                  </div>,
-                                                                }
-                                                              }
-                                                              perPageComponent="div"
-                                                              showToggle={true}
-                                                              toggleTemplate={[Function]}
-                                                              widgetId="options-menu-top"
-                                                            >
-                                                              <div
-                                                                className="pf-c-options-menu__toggle pf-m-plain pf-m-text"
-                                                              >
-                                                                <span
-                                                                  className="pf-c-options-menu__toggle-text"
-                                                                >
-                                                                  <ToggleTemplate
-                                                                    firstIndex={1}
-                                                                    itemCount={12}
-                                                                    itemsTitle=""
-                                                                    lastIndex={10}
-                                                                    ofWord="of"
-                                                                  >
-                                                                    <b>
-                                                                      1
-                                                                       - 
-                                                                      10
-                                                                    </b>
-                                                                     
-                                                                    of
-                                                                     
-                                                                    <b>
-                                                                      12
-                                                                    </b>
-                                                                     
-                                                                  </ToggleTemplate>
-                                                                </span>
-                                                                <DropdownToggle
-                                                                  aria-haspopup="listbox"
-                                                                  aria-label="Items per page"
-                                                                  className="pf-c-options-menu__toggle-button"
-                                                                  id="options-menu-top-toggle"
-                                                                  isDisabled={false}
-                                                                  isOpen={false}
-                                                                  onEnter={[Function]}
-                                                                  onToggle={[Function]}
-                                                                  parentRef={
-                                                                    Object {
-                                                                      "current": <div
-                                                                        class="pf-c-options-menu"
-                                                                        data-ouia-component-type="PF4/PaginationOptionsMenu"
-                                                                        data-ouia-safe="true"
-                                                                      >
-                                                                        <div
-                                                                          class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
-                                                                        >
-                                                                          <span
-                                                                            class="pf-c-options-menu__toggle-text"
-                                                                          >
-                                                                            <b>
-                                                                              1
-                                                                               - 
-                                                                              10
-                                                                            </b>
-                                                                             
-                                                                            of
-                                                                             
-                                                                            <b>
-                                                                              12
-                                                                            </b>
-                                                                             
-                                                                            
-                                                                          </span>
-                                                                          <button
-                                                                            aria-expanded="false"
-                                                                            aria-haspopup="listbox"
-                                                                            aria-label="Items per page"
-                                                                            class="  pf-c-options-menu__toggle-button"
-                                                                            data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
-                                                                            data-ouia-component-type="PF4/DropdownToggle"
-                                                                            data-ouia-safe="true"
-                                                                            id="options-menu-top-toggle"
-                                                                            type="button"
-                                                                          >
-                                                                            <span
-                                                                              class="pf-c-options-menu__toggle-button-icon"
-                                                                            >
-                                                                              <svg
-                                                                                aria-hidden="true"
-                                                                                fill="currentColor"
-                                                                                height="1em"
-                                                                                role="img"
-                                                                                style="vertical-align: -0.125em;"
-                                                                                viewBox="0 0 320 512"
-                                                                                width="1em"
-                                                                              >
-                                                                                <path
-                                                                                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                                                                />
-                                                                              </svg>
-                                                                            </span>
-                                                                          </button>
-                                                                        </div>
-                                                                      </div>,
-                                                                    }
-                                                                  }
-                                                                >
-                                                                  <Toggle
-                                                                    aria-haspopup="listbox"
-                                                                    aria-label="Items per page"
-                                                                    bubbleEvent={false}
-                                                                    className="pf-c-options-menu__toggle-button"
-                                                                    data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
-                                                                    data-ouia-component-type="PF4/DropdownToggle"
-                                                                    data-ouia-safe={true}
-                                                                    getMenuRef={null}
-                                                                    id="options-menu-top-toggle"
-                                                                    isActive={false}
-                                                                    isDisabled={false}
-                                                                    isOpen={false}
-                                                                    isPlain={false}
-                                                                    isPrimary={false}
-                                                                    isSplitButton={false}
-                                                                    isText={false}
-                                                                    onEnter={[Function]}
-                                                                    onToggle={[Function]}
-                                                                    parentRef={
-                                                                      Object {
-                                                                        "current": <div
-                                                                          class="pf-c-options-menu"
-                                                                          data-ouia-component-type="PF4/PaginationOptionsMenu"
-                                                                          data-ouia-safe="true"
-                                                                        >
-                                                                          <div
-                                                                            class="pf-c-options-menu__toggle pf-m-plain pf-m-text"
-                                                                          >
-                                                                            <span
-                                                                              class="pf-c-options-menu__toggle-text"
-                                                                            >
-                                                                              <b>
-                                                                                1
-                                                                                 - 
-                                                                                10
-                                                                              </b>
-                                                                               
-                                                                              of
-                                                                               
-                                                                              <b>
-                                                                                12
-                                                                              </b>
-                                                                               
-                                                                              
-                                                                            </span>
-                                                                            <button
-                                                                              aria-expanded="false"
-                                                                              aria-haspopup="listbox"
-                                                                              aria-label="Items per page"
-                                                                              class="  pf-c-options-menu__toggle-button"
-                                                                              data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
-                                                                              data-ouia-component-type="PF4/DropdownToggle"
-                                                                              data-ouia-safe="true"
-                                                                              id="options-menu-top-toggle"
-                                                                              type="button"
-                                                                            >
-                                                                              <span
-                                                                                class="pf-c-options-menu__toggle-button-icon"
-                                                                              >
-                                                                                <svg
-                                                                                  aria-hidden="true"
-                                                                                  fill="currentColor"
-                                                                                  height="1em"
-                                                                                  role="img"
-                                                                                  style="vertical-align: -0.125em;"
-                                                                                  viewBox="0 0 320 512"
-                                                                                  width="1em"
-                                                                                >
-                                                                                  <path
-                                                                                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                                                                  />
-                                                                                </svg>
-                                                                              </span>
-                                                                            </button>
-                                                                          </div>
-                                                                        </div>,
-                                                                      }
-                                                                    }
-                                                                    toggleVariant="default"
-                                                                  >
-                                                                    <button
-                                                                      aria-expanded={false}
-                                                                      aria-haspopup="listbox"
-                                                                      aria-label="Items per page"
-                                                                      className="  pf-c-options-menu__toggle-button"
-                                                                      data-ouia-component-id="OUIA-Generated-DropdownToggle-1"
-                                                                      data-ouia-component-type="PF4/DropdownToggle"
-                                                                      data-ouia-safe={true}
-                                                                      disabled={false}
-                                                                      id="options-menu-top-toggle"
-                                                                      onClick={[Function]}
-                                                                      onKeyDown={[Function]}
-                                                                      type="button"
-                                                                    >
-                                                                      <span
-                                                                        className="pf-c-options-menu__toggle-button-icon"
-                                                                      >
-                                                                        <CaretDownIcon
-                                                                          color="currentColor"
-                                                                          noVerticalAlign={false}
-                                                                          size="sm"
-                                                                        >
-                                                                          <svg
-                                                                            aria-hidden={true}
-                                                                            aria-labelledby={null}
-                                                                            fill="currentColor"
-                                                                            height="1em"
-                                                                            role="img"
-                                                                            style={
-                                                                              Object {
-                                                                                "verticalAlign": "-0.125em",
-                                                                              }
-                                                                            }
-                                                                            viewBox="0 0 320 512"
-                                                                            width="1em"
-                                                                          >
-                                                                            <path
-                                                                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                                                            />
-                                                                          </svg>
-                                                                        </CaretDownIcon>
-                                                                      </span>
-                                                                    </button>
-                                                                  </Toggle>
-                                                                </DropdownToggle>
-                                                              </div>
-                                                            </OptionsToggle>
-                                                          </div>
-                                                        </DropdownWithContext>
-                                                      </PaginationOptionsMenu>
-                                                      <Navigation
-                                                        className=""
-                                                        currPage="Current page"
-                                                        firstPage={1}
-                                                        isCompact={true}
-                                                        isDisabled={false}
-                                                        itemCount={12}
-                                                        lastPage={2}
-                                                        ofWord="of"
-                                                        onFirstClick={[Function]}
-                                                        onLastClick={[Function]}
-                                                        onNextClick={[Function]}
-                                                        onPageInput={[Function]}
-                                                        onPreviousClick={[Function]}
-                                                        onSetPage={[Function]}
-                                                        page={1}
-                                                        pagesTitle=""
-                                                        pagesTitlePlural=""
-                                                        paginationTitle="Pagination"
-                                                        perPage={10}
-                                                        toFirstPage="Go to first page"
-                                                        toLastPage="Go to last page"
-                                                        toNextPage="Go to next page"
-                                                        toPreviousPage="Go to previous page"
-                                                      >
-                                                        <nav
-                                                          aria-label="Pagination"
-                                                          className="pf-c-pagination__nav"
-                                                        >
-                                                          <div
-                                                            className="pf-c-pagination__nav-control"
-                                                          >
-                                                            <Button
-                                                              aria-label="Go to previous page"
-                                                              data-action="previous"
-                                                              isDisabled={true}
-                                                              onClick={[Function]}
-                                                              variant="plain"
-                                                            >
-                                                              <ButtonBase
-                                                                aria-label="Go to previous page"
-                                                                data-action="previous"
-                                                                innerRef={null}
-                                                                isDisabled={true}
-                                                                onClick={[Function]}
-                                                                variant="plain"
-                                                              >
-                                                                <button
-                                                                  aria-disabled={true}
-                                                                  aria-label="Go to previous page"
-                                                                  className="pf-c-button pf-m-plain pf-m-disabled"
-                                                                  data-action="previous"
-                                                                  data-ouia-component-id="OUIA-Generated-Button-plain-2"
-                                                                  data-ouia-component-type="PF4/Button"
-                                                                  data-ouia-safe={true}
-                                                                  disabled={true}
-                                                                  onClick={[Function]}
-                                                                  role={null}
-                                                                  tabIndex={null}
-                                                                  type="button"
-                                                                >
-                                                                  <AngleLeftIcon
-                                                                    color="currentColor"
-                                                                    noVerticalAlign={false}
-                                                                    size="sm"
-                                                                  >
-                                                                    <svg
-                                                                      aria-hidden={true}
-                                                                      aria-labelledby={null}
-                                                                      fill="currentColor"
-                                                                      height="1em"
-                                                                      role="img"
-                                                                      style={
-                                                                        Object {
-                                                                          "verticalAlign": "-0.125em",
-                                                                        }
-                                                                      }
-                                                                      viewBox="0 0 256 512"
-                                                                      width="1em"
-                                                                    >
-                                                                      <path
-                                                                        d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                                                                      />
-                                                                    </svg>
-                                                                  </AngleLeftIcon>
-                                                                </button>
-                                                              </ButtonBase>
-                                                            </Button>
-                                                          </div>
-                                                          <div
-                                                            className="pf-c-pagination__nav-control"
-                                                          >
-                                                            <Button
-                                                              aria-label="Go to next page"
-                                                              data-action="next"
-                                                              isDisabled={false}
-                                                              onClick={[Function]}
-                                                              variant="plain"
-                                                            >
-                                                              <ButtonBase
-                                                                aria-label="Go to next page"
-                                                                data-action="next"
-                                                                innerRef={null}
-                                                                isDisabled={false}
-                                                                onClick={[Function]}
-                                                                variant="plain"
-                                                              >
-                                                                <button
-                                                                  aria-disabled={false}
-                                                                  aria-label="Go to next page"
-                                                                  className="pf-c-button pf-m-plain"
-                                                                  data-action="next"
-                                                                  data-ouia-component-id="OUIA-Generated-Button-plain-3"
-                                                                  data-ouia-component-type="PF4/Button"
-                                                                  data-ouia-safe={true}
-                                                                  disabled={false}
-                                                                  onClick={[Function]}
-                                                                  role={null}
-                                                                  type="button"
-                                                                >
-                                                                  <AngleRightIcon
-                                                                    color="currentColor"
-                                                                    noVerticalAlign={false}
-                                                                    size="sm"
-                                                                  >
-                                                                    <svg
-                                                                      aria-hidden={true}
-                                                                      aria-labelledby={null}
-                                                                      fill="currentColor"
-                                                                      height="1em"
-                                                                      role="img"
-                                                                      style={
-                                                                        Object {
-                                                                          "verticalAlign": "-0.125em",
-                                                                        }
-                                                                      }
-                                                                      viewBox="0 0 256 512"
-                                                                      width="1em"
-                                                                    >
-                                                                      <path
-                                                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                                                      />
-                                                                    </svg>
-                                                                  </AngleRightIcon>
-                                                                </button>
-                                                              </ButtonBase>
-                                                            </Button>
-                                                          </div>
-                                                        </nav>
-                                                      </Navigation>
+                                                      }
+                                                    >
+                                                      <span
+                                                        className="pf-u-screen-reader"
+                                                      />
                                                     </div>
-                                                  </Pagination>
+                                                  </Skeleton>
                                                 </div>
                                               </ToolbarItem>
                                             </div>
@@ -31178,6 +30393,44 @@ exports[`CveModal.js Should match the snapshots 1`] = `
                                       </Provider>
                                     </Table>
                                   </SkeletonTable>
+                                  <TableFooter
+                                    isLoading={true}
+                                    onPerPageSelect={[Function]}
+                                    onSetPage={[Function]}
+                                    page={1}
+                                    paginationOUIA="bottom-cves-pagination"
+                                    perPage={10}
+                                    totalItems={12}
+                                  >
+                                    <div
+                                      className="pf-c-pagination pf-m-bottom"
+                                    >
+                                      <Skeleton
+                                        fontSize="xl"
+                                        style={
+                                          Object {
+                                            "margin": 10,
+                                          }
+                                        }
+                                        width="350px"
+                                      >
+                                        <div
+                                          className="pf-c-skeleton pf-m-text-xl"
+                                          style={
+                                            Object {
+                                              "--pf-c-skeleton--Height": undefined,
+                                              "--pf-c-skeleton--Width": "350px",
+                                              "margin": 10,
+                                            }
+                                          }
+                                        >
+                                          <span
+                                            className="pf-u-screen-reader"
+                                          />
+                                        </div>
+                                      </Skeleton>
+                                    </div>
+                                  </TableFooter>
                                 </TableView>
                               </div>
                             </ModalBoxBody>

--- a/src/SmartComponents/Packages/__snapshots__/Packages.test.js.snap
+++ b/src/SmartComponents/Packages/__snapshots__/Packages.test.js.snap
@@ -5685,6 +5685,7 @@ exports[`Packages.js should match the snapshot 1`] = `
                   </Provider>
                 </Table>
                 <TableFooter
+                  isLoading={false}
                   onPerPageSelect={[Function]}
                   onSetPage={[Function]}
                   page={1}
@@ -5692,307 +5693,326 @@ exports[`Packages.js should match the snapshot 1`] = `
                   perPage={25}
                   totalItems={0}
                 >
-                  <TableToolbar>
-                    <Toolbar
-                      className="ins-c-table__toolbar"
-                      data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-1"
-                      data-ouia-component-type="RHI/TableToolbar"
+                  <Pagination
+                    className=""
+                    defaultToFullPage={false}
+                    firstPage={1}
+                    isCompact={false}
+                    isDisabled={true}
+                    isSticky={false}
+                    itemCount={0}
+                    itemsEnd={null}
+                    itemsStart={null}
+                    offset={0}
+                    onFirstClick={[Function]}
+                    onLastClick={[Function]}
+                    onNextClick={[Function]}
+                    onPageInput={[Function]}
+                    onPerPageSelect={[Function]}
+                    onPreviousClick={[Function]}
+                    onSetPage={[Function]}
+                    ouiaId="bottom-package-details-pagination"
+                    ouiaSafe={true}
+                    page={1}
+                    perPage={25}
+                    perPageComponent="div"
+                    perPageOptions={
+                      Array [
+                        Object {
+                          "title": "10",
+                          "value": 10,
+                        },
+                        Object {
+                          "title": "20",
+                          "value": 20,
+                        },
+                        Object {
+                          "title": "50",
+                          "value": 50,
+                        },
+                        Object {
+                          "title": "100",
+                          "value": 100,
+                        },
+                      ]
+                    }
+                    titles={
+                      Object {
+                        "currPage": "Current page",
+                        "items": "",
+                        "itemsPerPage": "Items per page",
+                        "ofWord": "of",
+                        "optionsToggle": "",
+                        "page": "",
+                        "pages": "",
+                        "paginationTitle": "Pagination",
+                        "perPageSuffix": "per page",
+                        "toFirstPage": "Go to first page",
+                        "toLastPage": "Go to last page",
+                        "toNextPage": "Go to next page",
+                        "toPreviousPage": "Go to previous page",
+                      }
+                    }
+                    variant="bottom"
+                    widgetId="pagination-options-menu-bottom"
+                  >
+                    <div
+                      className="pf-c-pagination pf-m-bottom"
+                      data-ouia-component-id="bottom-package-details-pagination"
+                      data-ouia-component-type="PF4/Pagination"
                       data-ouia-safe={true}
+                      id="pagination-options-menu-bottom-bottom-pagination"
                     >
-                      <GenerateId
-                        prefix="pf-random-id-"
+                      <PaginationOptionsMenu
+                        className=""
+                        defaultToFullPage={false}
+                        dropDirection="up"
+                        firstIndex={0}
+                        isDisabled={true}
+                        itemCount={0}
+                        itemsPerPageTitle="Items per page"
+                        itemsTitle=""
+                        lastIndex={0}
+                        lastPage={0}
+                        ofWord="of"
+                        onPerPageSelect={[Function]}
+                        optionsToggle=""
+                        page={0}
+                        perPage={25}
+                        perPageComponent="div"
+                        perPageOptions={
+                          Array [
+                            Object {
+                              "title": "10",
+                              "value": 10,
+                            },
+                            Object {
+                              "title": "20",
+                              "value": 20,
+                            },
+                            Object {
+                              "title": "50",
+                              "value": 50,
+                            },
+                            Object {
+                              "title": "100",
+                              "value": 100,
+                            },
+                          ]
+                        }
+                        perPageSuffix="per page"
+                        toggleTemplate={[Function]}
+                        widgetId="pagination-options-menu-bottom-bottom"
                       >
-                        <div
-                          className="pf-c-toolbar ins-c-table__toolbar"
-                          data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-1"
-                          data-ouia-component-type="RHI/TableToolbar"
-                          data-ouia-safe={true}
-                          id="pf-random-id-0"
-                        >
-                          <Pagination
-                            className=""
-                            defaultToFullPage={false}
-                            firstPage={1}
-                            isCompact={false}
-                            isDisabled={true}
-                            isSticky={false}
-                            itemCount={0}
-                            itemsEnd={null}
-                            itemsStart={null}
-                            offset={0}
-                            onFirstClick={[Function]}
-                            onLastClick={[Function]}
-                            onNextClick={[Function]}
-                            onPageInput={[Function]}
-                            onPerPageSelect={[Function]}
-                            onPreviousClick={[Function]}
-                            onSetPage={[Function]}
-                            ouiaId="bottom-package-details-pagination"
-                            ouiaSafe={true}
-                            page={1}
-                            perPage={25}
-                            perPageComponent="div"
-                            perPageOptions={
-                              Array [
-                                Object {
-                                  "title": "10",
-                                  "value": 10,
-                                },
-                                Object {
-                                  "title": "20",
-                                  "value": 20,
-                                },
-                                Object {
-                                  "title": "50",
-                                  "value": 50,
-                                },
-                                Object {
-                                  "title": "100",
-                                  "value": 100,
-                                },
-                              ]
-                            }
-                            titles={
-                              Object {
-                                "currPage": "Current page",
-                                "items": "",
-                                "itemsPerPage": "Items per page",
-                                "ofWord": "of",
-                                "optionsToggle": "",
-                                "page": "",
-                                "pages": "",
-                                "paginationTitle": "Pagination",
-                                "perPageSuffix": "per page",
-                                "toFirstPage": "Go to first page",
-                                "toLastPage": "Go to last page",
-                                "toNextPage": "Go to next page",
-                                "toPreviousPage": "Go to previous page",
-                              }
-                            }
-                            variant="bottom"
-                            widgetId="pagination-options-menu-bottom"
-                          >
-                            <div
-                              className="pf-c-pagination pf-m-bottom"
-                              data-ouia-component-id="bottom-package-details-pagination"
-                              data-ouia-component-type="PF4/Pagination"
-                              data-ouia-safe={true}
-                              id="pagination-options-menu-bottom-bottom-pagination"
-                            >
-                              <PaginationOptionsMenu
+                        <DropdownWithContext
+                          autoFocus={true}
+                          className=""
+                          direction="up"
+                          dropdownItems={
+                            Array [
+                              <DropdownItem
                                 className=""
-                                defaultToFullPage={false}
-                                dropDirection="up"
-                                firstIndex={0}
-                                isDisabled={true}
-                                itemCount={0}
-                                itemsPerPageTitle="Items per page"
-                                itemsTitle=""
-                                lastIndex={0}
-                                lastPage={0}
-                                ofWord="of"
-                                onPerPageSelect={[Function]}
-                                optionsToggle=""
-                                page={0}
-                                perPage={25}
-                                perPageComponent="div"
-                                perPageOptions={
-                                  Array [
-                                    Object {
-                                      "title": "10",
-                                      "value": 10,
-                                    },
-                                    Object {
-                                      "title": "20",
-                                      "value": 20,
-                                    },
-                                    Object {
-                                      "title": "50",
-                                      "value": 50,
-                                    },
-                                    Object {
-                                      "title": "100",
-                                      "value": 100,
-                                    },
-                                  ]
-                                }
-                                perPageSuffix="per page"
-                                toggleTemplate={[Function]}
-                                widgetId="pagination-options-menu-bottom-bottom"
+                                component="button"
+                                data-action="per-page-10"
+                                onClick={[Function]}
                               >
-                                <DropdownWithContext
-                                  autoFocus={true}
-                                  className=""
-                                  direction="up"
-                                  dropdownItems={
-                                    Array [
-                                      <DropdownItem
-                                        className=""
-                                        component="button"
-                                        data-action="per-page-10"
-                                        onClick={[Function]}
-                                      >
-                                        10
-                                         per page
-                                      </DropdownItem>,
-                                      <DropdownItem
-                                        className=""
-                                        component="button"
-                                        data-action="per-page-20"
-                                        onClick={[Function]}
-                                      >
-                                        20
-                                         per page
-                                      </DropdownItem>,
-                                      <DropdownItem
-                                        className=""
-                                        component="button"
-                                        data-action="per-page-50"
-                                        onClick={[Function]}
-                                      >
-                                        50
-                                         per page
-                                      </DropdownItem>,
-                                      <DropdownItem
-                                        className=""
-                                        component="button"
-                                        data-action="per-page-100"
-                                        onClick={[Function]}
-                                      >
-                                        100
-                                         per page
-                                      </DropdownItem>,
-                                    ]
-                                  }
-                                  isFlipEnabled={true}
-                                  isGrouped={false}
-                                  isOpen={false}
-                                  isPlain={true}
-                                  isText={false}
-                                  menuAppendTo="inline"
-                                  onSelect={[Function]}
-                                  position="left"
-                                  toggle={
-                                    <OptionsToggle
-                                      firstIndex={0}
-                                      isDisabled={true}
-                                      isOpen={false}
-                                      itemCount={0}
-                                      itemsPerPageTitle="Items per page"
-                                      itemsTitle=""
-                                      lastIndex={0}
-                                      ofWord="of"
-                                      onToggle={[Function]}
-                                      optionsToggle=""
-                                      parentRef={null}
-                                      perPageComponent="div"
-                                      showToggle={true}
-                                      toggleTemplate={[Function]}
-                                      widgetId="pagination-options-menu-bottom-bottom"
-                                    />
-                                  }
-                                >
-                                  <div
-                                    className="pf-c-options-menu pf-m-top"
+                                10
+                                 per page
+                              </DropdownItem>,
+                              <DropdownItem
+                                className=""
+                                component="button"
+                                data-action="per-page-20"
+                                onClick={[Function]}
+                              >
+                                20
+                                 per page
+                              </DropdownItem>,
+                              <DropdownItem
+                                className=""
+                                component="button"
+                                data-action="per-page-50"
+                                onClick={[Function]}
+                              >
+                                50
+                                 per page
+                              </DropdownItem>,
+                              <DropdownItem
+                                className=""
+                                component="button"
+                                data-action="per-page-100"
+                                onClick={[Function]}
+                              >
+                                100
+                                 per page
+                              </DropdownItem>,
+                            ]
+                          }
+                          isFlipEnabled={true}
+                          isGrouped={false}
+                          isOpen={false}
+                          isPlain={true}
+                          isText={false}
+                          menuAppendTo="inline"
+                          onSelect={[Function]}
+                          position="left"
+                          toggle={
+                            <OptionsToggle
+                              firstIndex={0}
+                              isDisabled={true}
+                              isOpen={false}
+                              itemCount={0}
+                              itemsPerPageTitle="Items per page"
+                              itemsTitle=""
+                              lastIndex={0}
+                              ofWord="of"
+                              onToggle={[Function]}
+                              optionsToggle=""
+                              parentRef={null}
+                              perPageComponent="div"
+                              showToggle={true}
+                              toggleTemplate={[Function]}
+                              widgetId="pagination-options-menu-bottom-bottom"
+                            />
+                          }
+                        >
+                          <div
+                            className="pf-c-options-menu pf-m-top"
+                            data-ouia-component-type="PF4/PaginationOptionsMenu"
+                            data-ouia-safe={true}
+                          >
+                            <OptionsToggle
+                              aria-haspopup={true}
+                              firstIndex={0}
+                              getMenuRef={[Function]}
+                              id="pf-dropdown-toggle-id-9"
+                              isDisabled={true}
+                              isOpen={false}
+                              isPlain={true}
+                              isText={false}
+                              itemCount={0}
+                              itemsPerPageTitle="Items per page"
+                              itemsTitle=""
+                              key=".0"
+                              lastIndex={0}
+                              ofWord="of"
+                              onEnter={[Function]}
+                              onToggle={[Function]}
+                              optionsToggle=""
+                              parentRef={
+                                Object {
+                                  "current": <div
+                                    class="pf-c-options-menu pf-m-top"
                                     data-ouia-component-type="PF4/PaginationOptionsMenu"
-                                    data-ouia-safe={true}
+                                    data-ouia-safe="true"
                                   >
-                                    <OptionsToggle
-                                      aria-haspopup={true}
-                                      firstIndex={0}
-                                      getMenuRef={[Function]}
-                                      id="pf-dropdown-toggle-id-9"
-                                      isDisabled={true}
-                                      isOpen={false}
-                                      isPlain={true}
-                                      isText={false}
-                                      itemCount={0}
-                                      itemsPerPageTitle="Items per page"
-                                      itemsTitle=""
-                                      key=".0"
-                                      lastIndex={0}
-                                      ofWord="of"
-                                      onEnter={[Function]}
-                                      onToggle={[Function]}
-                                      optionsToggle=""
-                                      parentRef={
-                                        Object {
-                                          "current": <div
-                                            class="pf-c-options-menu pf-m-top"
-                                            data-ouia-component-type="PF4/PaginationOptionsMenu"
-                                            data-ouia-safe="true"
-                                          >
-                                            <div
-                                              class="pf-c-options-menu__toggle pf-m-disabled pf-m-plain pf-m-text"
-                                            >
-                                              <span
-                                                class="pf-c-options-menu__toggle-text"
-                                              >
-                                                <b>
-                                                  0
-                                                   - 
-                                                  0
-                                                </b>
-                                                 
-                                                of
-                                                 
-                                                <b>
-                                                  0
-                                                </b>
-                                                 
-                                                
-                                              </span>
-                                              <button
-                                                aria-expanded="false"
-                                                aria-haspopup="listbox"
-                                                aria-label="Items per page"
-                                                class="  pf-c-options-menu__toggle-button"
-                                                data-ouia-component-id="OUIA-Generated-DropdownToggle-4"
-                                                data-ouia-component-type="PF4/DropdownToggle"
-                                                data-ouia-safe="true"
-                                                disabled=""
-                                                id="pagination-options-menu-bottom-bottom-toggle"
-                                                type="button"
-                                              >
-                                                <span
-                                                  class="pf-c-options-menu__toggle-button-icon"
-                                                >
-                                                  <svg
-                                                    aria-hidden="true"
-                                                    fill="currentColor"
-                                                    height="1em"
-                                                    role="img"
-                                                    style="vertical-align: -0.125em;"
-                                                    viewBox="0 0 320 512"
-                                                    width="1em"
-                                                  >
-                                                    <path
-                                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                                    />
-                                                  </svg>
-                                                </span>
-                                              </button>
-                                            </div>
-                                          </div>,
-                                        }
-                                      }
-                                      perPageComponent="div"
-                                      showToggle={true}
-                                      toggleTemplate={[Function]}
-                                      widgetId="pagination-options-menu-bottom-bottom"
+                                    <div
+                                      class="pf-c-options-menu__toggle pf-m-disabled pf-m-plain pf-m-text"
                                     >
-                                      <div
-                                        className="pf-c-options-menu__toggle pf-m-disabled pf-m-plain pf-m-text"
+                                      <span
+                                        class="pf-c-options-menu__toggle-text"
+                                      >
+                                        <b>
+                                          0
+                                           - 
+                                          0
+                                        </b>
+                                         
+                                        of
+                                         
+                                        <b>
+                                          0
+                                        </b>
+                                         
+                                        
+                                      </span>
+                                      <button
+                                        aria-expanded="false"
+                                        aria-haspopup="listbox"
+                                        aria-label="Items per page"
+                                        class="  pf-c-options-menu__toggle-button"
+                                        data-ouia-component-id="OUIA-Generated-DropdownToggle-4"
+                                        data-ouia-component-type="PF4/DropdownToggle"
+                                        data-ouia-safe="true"
+                                        disabled=""
+                                        id="pagination-options-menu-bottom-bottom-toggle"
+                                        type="button"
                                       >
                                         <span
-                                          className="pf-c-options-menu__toggle-text"
+                                          class="pf-c-options-menu__toggle-button-icon"
                                         >
-                                          <ToggleTemplate
-                                            firstIndex={0}
-                                            itemCount={0}
-                                            itemsTitle=""
-                                            lastIndex={0}
-                                            ofWord="of"
+                                          <svg
+                                            aria-hidden="true"
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            style="vertical-align: -0.125em;"
+                                            viewBox="0 0 320 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                            />
+                                          </svg>
+                                        </span>
+                                      </button>
+                                    </div>
+                                  </div>,
+                                }
+                              }
+                              perPageComponent="div"
+                              showToggle={true}
+                              toggleTemplate={[Function]}
+                              widgetId="pagination-options-menu-bottom-bottom"
+                            >
+                              <div
+                                className="pf-c-options-menu__toggle pf-m-disabled pf-m-plain pf-m-text"
+                              >
+                                <span
+                                  className="pf-c-options-menu__toggle-text"
+                                >
+                                  <ToggleTemplate
+                                    firstIndex={0}
+                                    itemCount={0}
+                                    itemsTitle=""
+                                    lastIndex={0}
+                                    ofWord="of"
+                                  >
+                                    <b>
+                                      0
+                                       - 
+                                      0
+                                    </b>
+                                     
+                                    of
+                                     
+                                    <b>
+                                      0
+                                    </b>
+                                     
+                                  </ToggleTemplate>
+                                </span>
+                                <DropdownToggle
+                                  aria-haspopup="listbox"
+                                  aria-label="Items per page"
+                                  className="pf-c-options-menu__toggle-button"
+                                  id="pagination-options-menu-bottom-bottom-toggle"
+                                  isDisabled={true}
+                                  isOpen={false}
+                                  onEnter={[Function]}
+                                  onToggle={[Function]}
+                                  parentRef={
+                                    Object {
+                                      "current": <div
+                                        class="pf-c-options-menu pf-m-top"
+                                        data-ouia-component-type="PF4/PaginationOptionsMenu"
+                                        data-ouia-safe="true"
+                                      >
+                                        <div
+                                          class="pf-c-options-menu__toggle pf-m-disabled pf-m-plain pf-m-text"
+                                        >
+                                          <span
+                                            class="pf-c-options-menu__toggle-text"
                                           >
                                             <b>
                                               0
@@ -6006,548 +6026,470 @@ exports[`Packages.js should match the snapshot 1`] = `
                                               0
                                             </b>
                                              
-                                          </ToggleTemplate>
-                                        </span>
-                                        <DropdownToggle
-                                          aria-haspopup="listbox"
-                                          aria-label="Items per page"
-                                          className="pf-c-options-menu__toggle-button"
-                                          id="pagination-options-menu-bottom-bottom-toggle"
-                                          isDisabled={true}
-                                          isOpen={false}
-                                          onEnter={[Function]}
-                                          onToggle={[Function]}
-                                          parentRef={
-                                            Object {
-                                              "current": <div
-                                                class="pf-c-options-menu pf-m-top"
-                                                data-ouia-component-type="PF4/PaginationOptionsMenu"
-                                                data-ouia-safe="true"
-                                              >
-                                                <div
-                                                  class="pf-c-options-menu__toggle pf-m-disabled pf-m-plain pf-m-text"
-                                                >
-                                                  <span
-                                                    class="pf-c-options-menu__toggle-text"
-                                                  >
-                                                    <b>
-                                                      0
-                                                       - 
-                                                      0
-                                                    </b>
-                                                     
-                                                    of
-                                                     
-                                                    <b>
-                                                      0
-                                                    </b>
-                                                     
-                                                    
-                                                  </span>
-                                                  <button
-                                                    aria-expanded="false"
-                                                    aria-haspopup="listbox"
-                                                    aria-label="Items per page"
-                                                    class="  pf-c-options-menu__toggle-button"
-                                                    data-ouia-component-id="OUIA-Generated-DropdownToggle-4"
-                                                    data-ouia-component-type="PF4/DropdownToggle"
-                                                    data-ouia-safe="true"
-                                                    disabled=""
-                                                    id="pagination-options-menu-bottom-bottom-toggle"
-                                                    type="button"
-                                                  >
-                                                    <span
-                                                      class="pf-c-options-menu__toggle-button-icon"
-                                                    >
-                                                      <svg
-                                                        aria-hidden="true"
-                                                        fill="currentColor"
-                                                        height="1em"
-                                                        role="img"
-                                                        style="vertical-align: -0.125em;"
-                                                        viewBox="0 0 320 512"
-                                                        width="1em"
-                                                      >
-                                                        <path
-                                                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                                        />
-                                                      </svg>
-                                                    </span>
-                                                  </button>
-                                                </div>
-                                              </div>,
-                                            }
-                                          }
-                                        >
-                                          <Toggle
+                                            
+                                          </span>
+                                          <button
+                                            aria-expanded="false"
                                             aria-haspopup="listbox"
                                             aria-label="Items per page"
-                                            bubbleEvent={false}
-                                            className="pf-c-options-menu__toggle-button"
+                                            class="  pf-c-options-menu__toggle-button"
                                             data-ouia-component-id="OUIA-Generated-DropdownToggle-4"
                                             data-ouia-component-type="PF4/DropdownToggle"
-                                            data-ouia-safe={true}
-                                            getMenuRef={null}
+                                            data-ouia-safe="true"
+                                            disabled=""
                                             id="pagination-options-menu-bottom-bottom-toggle"
-                                            isActive={false}
-                                            isDisabled={true}
-                                            isOpen={false}
-                                            isPlain={false}
-                                            isPrimary={false}
-                                            isSplitButton={false}
-                                            isText={false}
-                                            onEnter={[Function]}
-                                            onToggle={[Function]}
-                                            parentRef={
-                                              Object {
-                                                "current": <div
-                                                  class="pf-c-options-menu pf-m-top"
-                                                  data-ouia-component-type="PF4/PaginationOptionsMenu"
-                                                  data-ouia-safe="true"
-                                                >
-                                                  <div
-                                                    class="pf-c-options-menu__toggle pf-m-disabled pf-m-plain pf-m-text"
-                                                  >
-                                                    <span
-                                                      class="pf-c-options-menu__toggle-text"
-                                                    >
-                                                      <b>
-                                                        0
-                                                         - 
-                                                        0
-                                                      </b>
-                                                       
-                                                      of
-                                                       
-                                                      <b>
-                                                        0
-                                                      </b>
-                                                       
-                                                      
-                                                    </span>
-                                                    <button
-                                                      aria-expanded="false"
-                                                      aria-haspopup="listbox"
-                                                      aria-label="Items per page"
-                                                      class="  pf-c-options-menu__toggle-button"
-                                                      data-ouia-component-id="OUIA-Generated-DropdownToggle-4"
-                                                      data-ouia-component-type="PF4/DropdownToggle"
-                                                      data-ouia-safe="true"
-                                                      disabled=""
-                                                      id="pagination-options-menu-bottom-bottom-toggle"
-                                                      type="button"
-                                                    >
-                                                      <span
-                                                        class="pf-c-options-menu__toggle-button-icon"
-                                                      >
-                                                        <svg
-                                                          aria-hidden="true"
-                                                          fill="currentColor"
-                                                          height="1em"
-                                                          role="img"
-                                                          style="vertical-align: -0.125em;"
-                                                          viewBox="0 0 320 512"
-                                                          width="1em"
-                                                        >
-                                                          <path
-                                                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                                          />
-                                                        </svg>
-                                                      </span>
-                                                    </button>
-                                                  </div>
-                                                </div>,
-                                              }
-                                            }
-                                            toggleVariant="default"
+                                            type="button"
                                           >
+                                            <span
+                                              class="pf-c-options-menu__toggle-button-icon"
+                                            >
+                                              <svg
+                                                aria-hidden="true"
+                                                fill="currentColor"
+                                                height="1em"
+                                                role="img"
+                                                style="vertical-align: -0.125em;"
+                                                viewBox="0 0 320 512"
+                                                width="1em"
+                                              >
+                                                <path
+                                                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                                />
+                                              </svg>
+                                            </span>
+                                          </button>
+                                        </div>
+                                      </div>,
+                                    }
+                                  }
+                                >
+                                  <Toggle
+                                    aria-haspopup="listbox"
+                                    aria-label="Items per page"
+                                    bubbleEvent={false}
+                                    className="pf-c-options-menu__toggle-button"
+                                    data-ouia-component-id="OUIA-Generated-DropdownToggle-4"
+                                    data-ouia-component-type="PF4/DropdownToggle"
+                                    data-ouia-safe={true}
+                                    getMenuRef={null}
+                                    id="pagination-options-menu-bottom-bottom-toggle"
+                                    isActive={false}
+                                    isDisabled={true}
+                                    isOpen={false}
+                                    isPlain={false}
+                                    isPrimary={false}
+                                    isSplitButton={false}
+                                    isText={false}
+                                    onEnter={[Function]}
+                                    onToggle={[Function]}
+                                    parentRef={
+                                      Object {
+                                        "current": <div
+                                          class="pf-c-options-menu pf-m-top"
+                                          data-ouia-component-type="PF4/PaginationOptionsMenu"
+                                          data-ouia-safe="true"
+                                        >
+                                          <div
+                                            class="pf-c-options-menu__toggle pf-m-disabled pf-m-plain pf-m-text"
+                                          >
+                                            <span
+                                              class="pf-c-options-menu__toggle-text"
+                                            >
+                                              <b>
+                                                0
+                                                 - 
+                                                0
+                                              </b>
+                                               
+                                              of
+                                               
+                                              <b>
+                                                0
+                                              </b>
+                                               
+                                              
+                                            </span>
                                             <button
-                                              aria-expanded={false}
+                                              aria-expanded="false"
                                               aria-haspopup="listbox"
                                               aria-label="Items per page"
-                                              className="  pf-c-options-menu__toggle-button"
+                                              class="  pf-c-options-menu__toggle-button"
                                               data-ouia-component-id="OUIA-Generated-DropdownToggle-4"
                                               data-ouia-component-type="PF4/DropdownToggle"
-                                              data-ouia-safe={true}
-                                              disabled={true}
+                                              data-ouia-safe="true"
+                                              disabled=""
                                               id="pagination-options-menu-bottom-bottom-toggle"
-                                              onClick={[Function]}
-                                              onKeyDown={[Function]}
                                               type="button"
                                             >
                                               <span
-                                                className="pf-c-options-menu__toggle-button-icon"
+                                                class="pf-c-options-menu__toggle-button-icon"
                                               >
-                                                <CaretDownIcon
-                                                  color="currentColor"
-                                                  noVerticalAlign={false}
-                                                  size="sm"
+                                                <svg
+                                                  aria-hidden="true"
+                                                  fill="currentColor"
+                                                  height="1em"
+                                                  role="img"
+                                                  style="vertical-align: -0.125em;"
+                                                  viewBox="0 0 320 512"
+                                                  width="1em"
                                                 >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    aria-labelledby={null}
-                                                    fill="currentColor"
-                                                    height="1em"
-                                                    role="img"
-                                                    style={
-                                                      Object {
-                                                        "verticalAlign": "-0.125em",
-                                                      }
-                                                    }
-                                                    viewBox="0 0 320 512"
-                                                    width="1em"
-                                                  >
-                                                    <path
-                                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                                    />
-                                                  </svg>
-                                                </CaretDownIcon>
+                                                  <path
+                                                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                                  />
+                                                </svg>
                                               </span>
                                             </button>
-                                          </Toggle>
-                                        </DropdownToggle>
-                                      </div>
-                                    </OptionsToggle>
-                                  </div>
-                                </DropdownWithContext>
-                              </PaginationOptionsMenu>
-                              <Navigation
-                                className=""
-                                currPage="Current page"
-                                firstPage={1}
-                                isCompact={false}
-                                isDisabled={true}
-                                itemCount={0}
-                                lastPage={0}
-                                ofWord="of"
-                                onFirstClick={[Function]}
-                                onLastClick={[Function]}
-                                onNextClick={[Function]}
-                                onPageInput={[Function]}
-                                onPreviousClick={[Function]}
-                                onSetPage={[Function]}
-                                page={0}
-                                pagesTitle=""
-                                pagesTitlePlural=""
-                                paginationTitle="Pagination"
-                                perPage={25}
-                                toFirstPage="Go to first page"
-                                toLastPage="Go to last page"
-                                toNextPage="Go to next page"
-                                toPreviousPage="Go to previous page"
-                              >
-                                <nav
-                                  aria-label="Pagination"
-                                  className="pf-c-pagination__nav"
-                                >
-                                  <div
-                                    className="pf-c-pagination__nav-control pf-m-first"
+                                          </div>
+                                        </div>,
+                                      }
+                                    }
+                                    toggleVariant="default"
                                   >
-                                    <Button
-                                      aria-label="Go to first page"
-                                      data-action="first"
-                                      isDisabled={true}
-                                      onClick={[Function]}
-                                      variant="plain"
-                                    >
-                                      <ButtonBase
-                                        aria-label="Go to first page"
-                                        data-action="first"
-                                        innerRef={null}
-                                        isDisabled={true}
-                                        onClick={[Function]}
-                                        variant="plain"
-                                      >
-                                        <button
-                                          aria-disabled={true}
-                                          aria-label="Go to first page"
-                                          className="pf-c-button pf-m-plain pf-m-disabled"
-                                          data-action="first"
-                                          data-ouia-component-id="OUIA-Generated-Button-plain-3"
-                                          data-ouia-component-type="PF4/Button"
-                                          data-ouia-safe={true}
-                                          disabled={true}
-                                          onClick={[Function]}
-                                          role={null}
-                                          tabIndex={null}
-                                          type="button"
-                                        >
-                                          <AngleDoubleLeftIcon
-                                            color="currentColor"
-                                            noVerticalAlign={false}
-                                            size="sm"
-                                          >
-                                            <svg
-                                              aria-hidden={true}
-                                              aria-labelledby={null}
-                                              fill="currentColor"
-                                              height="1em"
-                                              role="img"
-                                              style={
-                                                Object {
-                                                  "verticalAlign": "-0.125em",
-                                                }
-                                              }
-                                              viewBox="0 0 448 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                                              />
-                                            </svg>
-                                          </AngleDoubleLeftIcon>
-                                        </button>
-                                      </ButtonBase>
-                                    </Button>
-                                  </div>
-                                  <div
-                                    className="pf-c-pagination__nav-control"
-                                  >
-                                    <Button
-                                      aria-label="Go to previous page"
-                                      data-action="previous"
-                                      isDisabled={true}
-                                      onClick={[Function]}
-                                      variant="plain"
-                                    >
-                                      <ButtonBase
-                                        aria-label="Go to previous page"
-                                        data-action="previous"
-                                        innerRef={null}
-                                        isDisabled={true}
-                                        onClick={[Function]}
-                                        variant="plain"
-                                      >
-                                        <button
-                                          aria-disabled={true}
-                                          aria-label="Go to previous page"
-                                          className="pf-c-button pf-m-plain pf-m-disabled"
-                                          data-action="previous"
-                                          data-ouia-component-id="OUIA-Generated-Button-plain-4"
-                                          data-ouia-component-type="PF4/Button"
-                                          data-ouia-safe={true}
-                                          disabled={true}
-                                          onClick={[Function]}
-                                          role={null}
-                                          tabIndex={null}
-                                          type="button"
-                                        >
-                                          <AngleLeftIcon
-                                            color="currentColor"
-                                            noVerticalAlign={false}
-                                            size="sm"
-                                          >
-                                            <svg
-                                              aria-hidden={true}
-                                              aria-labelledby={null}
-                                              fill="currentColor"
-                                              height="1em"
-                                              role="img"
-                                              style={
-                                                Object {
-                                                  "verticalAlign": "-0.125em",
-                                                }
-                                              }
-                                              viewBox="0 0 256 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                                              />
-                                            </svg>
-                                          </AngleLeftIcon>
-                                        </button>
-                                      </ButtonBase>
-                                    </Button>
-                                  </div>
-                                  <div
-                                    className="pf-c-pagination__nav-page-select"
-                                  >
-                                    <input
-                                      aria-label="Current page"
-                                      className="pf-c-form-control"
+                                    <button
+                                      aria-expanded={false}
+                                      aria-haspopup="listbox"
+                                      aria-label="Items per page"
+                                      className="  pf-c-options-menu__toggle-button"
+                                      data-ouia-component-id="OUIA-Generated-DropdownToggle-4"
+                                      data-ouia-component-type="PF4/DropdownToggle"
+                                      data-ouia-safe={true}
                                       disabled={true}
-                                      max={0}
-                                      min={1}
-                                      onChange={[Function]}
+                                      id="pagination-options-menu-bottom-bottom-toggle"
+                                      onClick={[Function]}
                                       onKeyDown={[Function]}
-                                      type="number"
-                                      value={0}
-                                    />
-                                    <span
-                                      aria-hidden="true"
+                                      type="button"
                                     >
-                                      of
-                                       
-                                      0
-                                    </span>
-                                  </div>
-                                  <div
-                                    className="pf-c-pagination__nav-control"
-                                  >
-                                    <Button
-                                      aria-label="Go to next page"
-                                      data-action="next"
-                                      isDisabled={true}
-                                      onClick={[Function]}
-                                      variant="plain"
-                                    >
-                                      <ButtonBase
-                                        aria-label="Go to next page"
-                                        data-action="next"
-                                        innerRef={null}
-                                        isDisabled={true}
-                                        onClick={[Function]}
-                                        variant="plain"
+                                      <span
+                                        className="pf-c-options-menu__toggle-button-icon"
                                       >
-                                        <button
-                                          aria-disabled={true}
-                                          aria-label="Go to next page"
-                                          className="pf-c-button pf-m-plain pf-m-disabled"
-                                          data-action="next"
-                                          data-ouia-component-id="OUIA-Generated-Button-plain-5"
-                                          data-ouia-component-type="PF4/Button"
-                                          data-ouia-safe={true}
-                                          disabled={true}
-                                          onClick={[Function]}
-                                          role={null}
-                                          tabIndex={null}
-                                          type="button"
+                                        <CaretDownIcon
+                                          color="currentColor"
+                                          noVerticalAlign={false}
+                                          size="sm"
                                         >
-                                          <AngleRightIcon
-                                            color="currentColor"
-                                            noVerticalAlign={false}
-                                            size="sm"
-                                          >
-                                            <svg
-                                              aria-hidden={true}
-                                              aria-labelledby={null}
-                                              fill="currentColor"
-                                              height="1em"
-                                              role="img"
-                                              style={
-                                                Object {
-                                                  "verticalAlign": "-0.125em",
-                                                }
+                                          <svg
+                                            aria-hidden={true}
+                                            aria-labelledby={null}
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            style={
+                                              Object {
+                                                "verticalAlign": "-0.125em",
                                               }
-                                              viewBox="0 0 256 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                              />
-                                            </svg>
-                                          </AngleRightIcon>
-                                        </button>
-                                      </ButtonBase>
-                                    </Button>
-                                  </div>
-                                  <div
-                                    className="pf-c-pagination__nav-control pf-m-last"
-                                  >
-                                    <Button
-                                      aria-label="Go to last page"
-                                      data-action="last"
-                                      isDisabled={true}
-                                      onClick={[Function]}
-                                      variant="plain"
-                                    >
-                                      <ButtonBase
-                                        aria-label="Go to last page"
-                                        data-action="last"
-                                        innerRef={null}
-                                        isDisabled={true}
-                                        onClick={[Function]}
-                                        variant="plain"
-                                      >
-                                        <button
-                                          aria-disabled={true}
-                                          aria-label="Go to last page"
-                                          className="pf-c-button pf-m-plain pf-m-disabled"
-                                          data-action="last"
-                                          data-ouia-component-id="OUIA-Generated-Button-plain-6"
-                                          data-ouia-component-type="PF4/Button"
-                                          data-ouia-safe={true}
-                                          disabled={true}
-                                          onClick={[Function]}
-                                          role={null}
-                                          tabIndex={null}
-                                          type="button"
-                                        >
-                                          <AngleDoubleRightIcon
-                                            color="currentColor"
-                                            noVerticalAlign={false}
-                                            size="sm"
+                                            }
+                                            viewBox="0 0 320 512"
+                                            width="1em"
                                           >
-                                            <svg
-                                              aria-hidden={true}
-                                              aria-labelledby={null}
-                                              fill="currentColor"
-                                              height="1em"
-                                              role="img"
-                                              style={
-                                                Object {
-                                                  "verticalAlign": "-0.125em",
-                                                }
-                                              }
-                                              viewBox="0 0 448 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                                              />
-                                            </svg>
-                                          </AngleDoubleRightIcon>
-                                        </button>
-                                      </ButtonBase>
-                                    </Button>
-                                  </div>
-                                </nav>
-                              </Navigation>
-                            </div>
-                          </Pagination>
-                          <ToolbarChipGroupContent
-                            chipGroupContentRef={
-                              Object {
-                                "current": <div
-                                  class="pf-c-toolbar__content pf-m-hidden"
-                                  hidden=""
-                                >
-                                  <div
-                                    class="pf-c-toolbar__group"
-                                  />
-                                </div>,
-                              }
-                            }
-                            clearFiltersButtonText="Clear all filters"
-                            collapseListedFiltersBreakpoint="lg"
-                            isExpanded={false}
-                            numberOfFilters={0}
-                            numberOfFiltersText={[Function]}
-                            showClearFiltersButton={false}
+                                            <path
+                                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                            />
+                                          </svg>
+                                        </CaretDownIcon>
+                                      </span>
+                                    </button>
+                                  </Toggle>
+                                </DropdownToggle>
+                              </div>
+                            </OptionsToggle>
+                          </div>
+                        </DropdownWithContext>
+                      </PaginationOptionsMenu>
+                      <Navigation
+                        className=""
+                        currPage="Current page"
+                        firstPage={1}
+                        isCompact={false}
+                        isDisabled={true}
+                        itemCount={0}
+                        lastPage={0}
+                        ofWord="of"
+                        onFirstClick={[Function]}
+                        onLastClick={[Function]}
+                        onNextClick={[Function]}
+                        onPageInput={[Function]}
+                        onPreviousClick={[Function]}
+                        onSetPage={[Function]}
+                        page={0}
+                        pagesTitle=""
+                        pagesTitlePlural=""
+                        paginationTitle="Pagination"
+                        perPage={25}
+                        toFirstPage="Go to first page"
+                        toLastPage="Go to last page"
+                        toNextPage="Go to next page"
+                        toPreviousPage="Go to previous page"
+                      >
+                        <nav
+                          aria-label="Pagination"
+                          className="pf-c-pagination__nav"
+                        >
+                          <div
+                            className="pf-c-pagination__nav-control pf-m-first"
                           >
-                            <div
-                              className="pf-c-toolbar__content pf-m-hidden"
-                              hidden={true}
+                            <Button
+                              aria-label="Go to first page"
+                              data-action="first"
+                              isDisabled={true}
+                              onClick={[Function]}
+                              variant="plain"
                             >
-                              <ForwardRef
-                                className=""
+                              <ButtonBase
+                                aria-label="Go to first page"
+                                data-action="first"
+                                innerRef={null}
+                                isDisabled={true}
+                                onClick={[Function]}
+                                variant="plain"
                               >
-                                <ToolbarGroupWithRef
-                                  className=""
-                                  innerRef={null}
+                                <button
+                                  aria-disabled={true}
+                                  aria-label="Go to first page"
+                                  className="pf-c-button pf-m-plain pf-m-disabled"
+                                  data-action="first"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-3"
+                                  data-ouia-component-type="PF4/Button"
+                                  data-ouia-safe={true}
+                                  disabled={true}
+                                  onClick={[Function]}
+                                  role={null}
+                                  tabIndex={null}
+                                  type="button"
                                 >
-                                  <div
-                                    className="pf-c-toolbar__group"
-                                  />
-                                </ToolbarGroupWithRef>
-                              </ForwardRef>
-                            </div>
-                          </ToolbarChipGroupContent>
-                        </div>
-                      </GenerateId>
-                    </Toolbar>
-                  </TableToolbar>
+                                  <AngleDoubleLeftIcon
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 448 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                                      />
+                                    </svg>
+                                  </AngleDoubleLeftIcon>
+                                </button>
+                              </ButtonBase>
+                            </Button>
+                          </div>
+                          <div
+                            className="pf-c-pagination__nav-control"
+                          >
+                            <Button
+                              aria-label="Go to previous page"
+                              data-action="previous"
+                              isDisabled={true}
+                              onClick={[Function]}
+                              variant="plain"
+                            >
+                              <ButtonBase
+                                aria-label="Go to previous page"
+                                data-action="previous"
+                                innerRef={null}
+                                isDisabled={true}
+                                onClick={[Function]}
+                                variant="plain"
+                              >
+                                <button
+                                  aria-disabled={true}
+                                  aria-label="Go to previous page"
+                                  className="pf-c-button pf-m-plain pf-m-disabled"
+                                  data-action="previous"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-4"
+                                  data-ouia-component-type="PF4/Button"
+                                  data-ouia-safe={true}
+                                  disabled={true}
+                                  onClick={[Function]}
+                                  role={null}
+                                  tabIndex={null}
+                                  type="button"
+                                >
+                                  <AngleLeftIcon
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                                      />
+                                    </svg>
+                                  </AngleLeftIcon>
+                                </button>
+                              </ButtonBase>
+                            </Button>
+                          </div>
+                          <div
+                            className="pf-c-pagination__nav-page-select"
+                          >
+                            <input
+                              aria-label="Current page"
+                              className="pf-c-form-control"
+                              disabled={true}
+                              max={0}
+                              min={1}
+                              onChange={[Function]}
+                              onKeyDown={[Function]}
+                              type="number"
+                              value={0}
+                            />
+                            <span
+                              aria-hidden="true"
+                            >
+                              of
+                               
+                              0
+                            </span>
+                          </div>
+                          <div
+                            className="pf-c-pagination__nav-control"
+                          >
+                            <Button
+                              aria-label="Go to next page"
+                              data-action="next"
+                              isDisabled={true}
+                              onClick={[Function]}
+                              variant="plain"
+                            >
+                              <ButtonBase
+                                aria-label="Go to next page"
+                                data-action="next"
+                                innerRef={null}
+                                isDisabled={true}
+                                onClick={[Function]}
+                                variant="plain"
+                              >
+                                <button
+                                  aria-disabled={true}
+                                  aria-label="Go to next page"
+                                  className="pf-c-button pf-m-plain pf-m-disabled"
+                                  data-action="next"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-5"
+                                  data-ouia-component-type="PF4/Button"
+                                  data-ouia-safe={true}
+                                  disabled={true}
+                                  onClick={[Function]}
+                                  role={null}
+                                  tabIndex={null}
+                                  type="button"
+                                >
+                                  <AngleRightIcon
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                      />
+                                    </svg>
+                                  </AngleRightIcon>
+                                </button>
+                              </ButtonBase>
+                            </Button>
+                          </div>
+                          <div
+                            className="pf-c-pagination__nav-control pf-m-last"
+                          >
+                            <Button
+                              aria-label="Go to last page"
+                              data-action="last"
+                              isDisabled={true}
+                              onClick={[Function]}
+                              variant="plain"
+                            >
+                              <ButtonBase
+                                aria-label="Go to last page"
+                                data-action="last"
+                                innerRef={null}
+                                isDisabled={true}
+                                onClick={[Function]}
+                                variant="plain"
+                              >
+                                <button
+                                  aria-disabled={true}
+                                  aria-label="Go to last page"
+                                  className="pf-c-button pf-m-plain pf-m-disabled"
+                                  data-action="last"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-6"
+                                  data-ouia-component-type="PF4/Button"
+                                  data-ouia-safe={true}
+                                  disabled={true}
+                                  onClick={[Function]}
+                                  role={null}
+                                  tabIndex={null}
+                                  type="button"
+                                >
+                                  <AngleDoubleRightIcon
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 448 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                                      />
+                                    </svg>
+                                  </AngleDoubleRightIcon>
+                                </button>
+                              </ButtonBase>
+                            </Button>
+                          </div>
+                        </nav>
+                      </Navigation>
+                    </div>
+                  </Pagination>
                 </TableFooter>
               </TableView>
             </section>

--- a/src/SmartComponents/PatchSet/__snapshots__/PatchSet.test.js.snap
+++ b/src/SmartComponents/PatchSet/__snapshots__/PatchSet.test.js.snap
@@ -8175,6 +8175,7 @@ exports[`HeaderBreadcrumbs Should render correctly 1`] = `
                   </Provider>
                 </Table>
                 <TableFooter
+                  isLoading={false}
                   onPerPageSelect={[Function]}
                   onSetPage={[Function]}
                   page={1}
@@ -8182,687 +8183,635 @@ exports[`HeaderBreadcrumbs Should render correctly 1`] = `
                   perPage={25}
                   totalItems={10}
                 >
-                  <TableToolbar>
-                    <Toolbar
-                      className="ins-c-table__toolbar"
-                      data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-1"
-                      data-ouia-component-type="RHI/TableToolbar"
+                  <Pagination
+                    className=""
+                    defaultToFullPage={false}
+                    firstPage={1}
+                    isCompact={false}
+                    isDisabled={false}
+                    isSticky={false}
+                    itemCount={10}
+                    itemsEnd={null}
+                    itemsStart={null}
+                    offset={0}
+                    onFirstClick={[Function]}
+                    onLastClick={[Function]}
+                    onNextClick={[Function]}
+                    onPageInput={[Function]}
+                    onPerPageSelect={[Function]}
+                    onPreviousClick={[Function]}
+                    onSetPage={[Function]}
+                    ouiaId="bottom-patch-set-pagination"
+                    ouiaSafe={true}
+                    page={1}
+                    perPage={25}
+                    perPageComponent="div"
+                    perPageOptions={
+                      Array [
+                        Object {
+                          "title": "10",
+                          "value": 10,
+                        },
+                        Object {
+                          "title": "20",
+                          "value": 20,
+                        },
+                        Object {
+                          "title": "50",
+                          "value": 50,
+                        },
+                        Object {
+                          "title": "100",
+                          "value": 100,
+                        },
+                      ]
+                    }
+                    titles={
+                      Object {
+                        "currPage": "Current page",
+                        "items": "",
+                        "itemsPerPage": "Items per page",
+                        "ofWord": "of",
+                        "optionsToggle": "",
+                        "page": "",
+                        "pages": "",
+                        "paginationTitle": "Pagination",
+                        "perPageSuffix": "per page",
+                        "toFirstPage": "Go to first page",
+                        "toLastPage": "Go to last page",
+                        "toNextPage": "Go to next page",
+                        "toPreviousPage": "Go to previous page",
+                      }
+                    }
+                    variant="bottom"
+                    widgetId="pagination-options-menu-bottom"
+                  >
+                    <div
+                      className="pf-c-pagination pf-m-bottom"
+                      data-ouia-component-id="bottom-patch-set-pagination"
+                      data-ouia-component-type="PF4/Pagination"
                       data-ouia-safe={true}
+                      id="pagination-options-menu-bottom-bottom-pagination"
                     >
-                      <GenerateId
-                        prefix="pf-random-id-"
+                      <PaginationOptionsMenu
+                        className=""
+                        defaultToFullPage={false}
+                        dropDirection="up"
+                        firstIndex={1}
+                        isDisabled={false}
+                        itemCount={10}
+                        itemsPerPageTitle="Items per page"
+                        itemsTitle=""
+                        lastIndex={10}
+                        lastPage={1}
+                        ofWord="of"
+                        onPerPageSelect={[Function]}
+                        optionsToggle=""
+                        page={1}
+                        perPage={25}
+                        perPageComponent="div"
+                        perPageOptions={
+                          Array [
+                            Object {
+                              "title": "10",
+                              "value": 10,
+                            },
+                            Object {
+                              "title": "20",
+                              "value": 20,
+                            },
+                            Object {
+                              "title": "50",
+                              "value": 50,
+                            },
+                            Object {
+                              "title": "100",
+                              "value": 100,
+                            },
+                          ]
+                        }
+                        perPageSuffix="per page"
+                        toggleTemplate={[Function]}
+                        widgetId="pagination-options-menu-bottom-bottom"
                       >
-                        <div
-                          className="pf-c-toolbar ins-c-table__toolbar"
-                          data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-1"
-                          data-ouia-component-type="RHI/TableToolbar"
-                          data-ouia-safe={true}
-                          id="pf-random-id-0"
-                        >
-                          <Pagination
-                            className=""
-                            defaultToFullPage={false}
-                            firstPage={1}
-                            isCompact={false}
-                            isDisabled={false}
-                            isSticky={false}
-                            itemCount={10}
-                            itemsEnd={null}
-                            itemsStart={null}
-                            offset={0}
-                            onFirstClick={[Function]}
-                            onLastClick={[Function]}
-                            onNextClick={[Function]}
-                            onPageInput={[Function]}
-                            onPerPageSelect={[Function]}
-                            onPreviousClick={[Function]}
-                            onSetPage={[Function]}
-                            ouiaId="bottom-patch-set-pagination"
-                            ouiaSafe={true}
-                            page={1}
-                            perPage={25}
-                            perPageComponent="div"
-                            perPageOptions={
-                              Array [
-                                Object {
-                                  "title": "10",
-                                  "value": 10,
-                                },
-                                Object {
-                                  "title": "20",
-                                  "value": 20,
-                                },
-                                Object {
-                                  "title": "50",
-                                  "value": 50,
-                                },
-                                Object {
-                                  "title": "100",
-                                  "value": 100,
-                                },
-                              ]
-                            }
-                            titles={
-                              Object {
-                                "currPage": "Current page",
-                                "items": "",
-                                "itemsPerPage": "Items per page",
-                                "ofWord": "of",
-                                "optionsToggle": "",
-                                "page": "",
-                                "pages": "",
-                                "paginationTitle": "Pagination",
-                                "perPageSuffix": "per page",
-                                "toFirstPage": "Go to first page",
-                                "toLastPage": "Go to last page",
-                                "toNextPage": "Go to next page",
-                                "toPreviousPage": "Go to previous page",
-                              }
-                            }
-                            variant="bottom"
-                            widgetId="pagination-options-menu-bottom"
-                          >
-                            <div
-                              className="pf-c-pagination pf-m-bottom"
-                              data-ouia-component-id="bottom-patch-set-pagination"
-                              data-ouia-component-type="PF4/Pagination"
-                              data-ouia-safe={true}
-                              id="pagination-options-menu-bottom-bottom-pagination"
-                            >
-                              <PaginationOptionsMenu
+                        <DropdownWithContext
+                          autoFocus={true}
+                          className=""
+                          direction="up"
+                          dropdownItems={
+                            Array [
+                              <DropdownItem
                                 className=""
-                                defaultToFullPage={false}
-                                dropDirection="up"
-                                firstIndex={1}
-                                isDisabled={false}
-                                itemCount={10}
-                                itemsPerPageTitle="Items per page"
-                                itemsTitle=""
-                                lastIndex={10}
-                                lastPage={1}
-                                ofWord="of"
-                                onPerPageSelect={[Function]}
-                                optionsToggle=""
-                                page={1}
-                                perPage={25}
-                                perPageComponent="div"
-                                perPageOptions={
-                                  Array [
-                                    Object {
-                                      "title": "10",
-                                      "value": 10,
-                                    },
-                                    Object {
-                                      "title": "20",
-                                      "value": 20,
-                                    },
-                                    Object {
-                                      "title": "50",
-                                      "value": 50,
-                                    },
-                                    Object {
-                                      "title": "100",
-                                      "value": 100,
-                                    },
-                                  ]
-                                }
-                                perPageSuffix="per page"
-                                toggleTemplate={[Function]}
-                                widgetId="pagination-options-menu-bottom-bottom"
+                                component="button"
+                                data-action="per-page-10"
+                                onClick={[Function]}
                               >
-                                <DropdownWithContext
-                                  autoFocus={true}
-                                  className=""
-                                  direction="up"
-                                  dropdownItems={
-                                    Array [
-                                      <DropdownItem
-                                        className=""
-                                        component="button"
-                                        data-action="per-page-10"
-                                        onClick={[Function]}
-                                      >
-                                        10
-                                         per page
-                                      </DropdownItem>,
-                                      <DropdownItem
-                                        className=""
-                                        component="button"
-                                        data-action="per-page-20"
-                                        onClick={[Function]}
-                                      >
-                                        20
-                                         per page
-                                      </DropdownItem>,
-                                      <DropdownItem
-                                        className=""
-                                        component="button"
-                                        data-action="per-page-50"
-                                        onClick={[Function]}
-                                      >
-                                        50
-                                         per page
-                                      </DropdownItem>,
-                                      <DropdownItem
-                                        className=""
-                                        component="button"
-                                        data-action="per-page-100"
-                                        onClick={[Function]}
-                                      >
-                                        100
-                                         per page
-                                      </DropdownItem>,
-                                    ]
-                                  }
-                                  isFlipEnabled={true}
-                                  isGrouped={false}
+                                10
+                                 per page
+                              </DropdownItem>,
+                              <DropdownItem
+                                className=""
+                                component="button"
+                                data-action="per-page-20"
+                                onClick={[Function]}
+                              >
+                                20
+                                 per page
+                              </DropdownItem>,
+                              <DropdownItem
+                                className=""
+                                component="button"
+                                data-action="per-page-50"
+                                onClick={[Function]}
+                              >
+                                50
+                                 per page
+                              </DropdownItem>,
+                              <DropdownItem
+                                className=""
+                                component="button"
+                                data-action="per-page-100"
+                                onClick={[Function]}
+                              >
+                                100
+                                 per page
+                              </DropdownItem>,
+                            ]
+                          }
+                          isFlipEnabled={true}
+                          isGrouped={false}
+                          isOpen={false}
+                          isPlain={true}
+                          isText={false}
+                          menuAppendTo="inline"
+                          onSelect={[Function]}
+                          position="left"
+                          toggle={
+                            <OptionsToggle
+                              firstIndex={1}
+                              isDisabled={false}
+                              isOpen={false}
+                              itemCount={10}
+                              itemsPerPageTitle="Items per page"
+                              itemsTitle=""
+                              lastIndex={10}
+                              ofWord="of"
+                              onToggle={[Function]}
+                              optionsToggle=""
+                              parentRef={null}
+                              perPageComponent="div"
+                              showToggle={true}
+                              toggleTemplate={[Function]}
+                              widgetId="pagination-options-menu-bottom-bottom"
+                            />
+                          }
+                        >
+                          <div
+                            className="pf-c-options-menu pf-m-top"
+                            data-ouia-component-type="PF4/PaginationOptionsMenu"
+                            data-ouia-safe={true}
+                          >
+                            <OptionsToggle
+                              aria-haspopup={true}
+                              firstIndex={1}
+                              getMenuRef={[Function]}
+                              id="pf-dropdown-toggle-id-15"
+                              isDisabled={false}
+                              isOpen={false}
+                              isPlain={true}
+                              isText={false}
+                              itemCount={10}
+                              itemsPerPageTitle="Items per page"
+                              itemsTitle=""
+                              key=".0"
+                              lastIndex={10}
+                              ofWord="of"
+                              onEnter={[Function]}
+                              onToggle={[Function]}
+                              optionsToggle=""
+                              parentRef={
+                                Object {
+                                  "current": null,
+                                }
+                              }
+                              perPageComponent="div"
+                              showToggle={true}
+                              toggleTemplate={[Function]}
+                              widgetId="pagination-options-menu-bottom-bottom"
+                            >
+                              <div
+                                className="pf-c-options-menu__toggle pf-m-plain pf-m-text"
+                              >
+                                <span
+                                  className="pf-c-options-menu__toggle-text"
+                                >
+                                  <ToggleTemplate
+                                    firstIndex={1}
+                                    itemCount={10}
+                                    itemsTitle=""
+                                    lastIndex={10}
+                                    ofWord="of"
+                                  >
+                                    <b>
+                                      1
+                                       - 
+                                      10
+                                    </b>
+                                     
+                                    of
+                                     
+                                    <b>
+                                      10
+                                    </b>
+                                     
+                                  </ToggleTemplate>
+                                </span>
+                                <DropdownToggle
+                                  aria-haspopup="listbox"
+                                  aria-label="Items per page"
+                                  className="pf-c-options-menu__toggle-button"
+                                  id="pagination-options-menu-bottom-bottom-toggle"
+                                  isDisabled={false}
                                   isOpen={false}
-                                  isPlain={true}
-                                  isText={false}
-                                  menuAppendTo="inline"
-                                  onSelect={[Function]}
-                                  position="left"
-                                  toggle={
-                                    <OptionsToggle
-                                      firstIndex={1}
-                                      isDisabled={false}
-                                      isOpen={false}
-                                      itemCount={10}
-                                      itemsPerPageTitle="Items per page"
-                                      itemsTitle=""
-                                      lastIndex={10}
-                                      ofWord="of"
-                                      onToggle={[Function]}
-                                      optionsToggle=""
-                                      parentRef={null}
-                                      perPageComponent="div"
-                                      showToggle={true}
-                                      toggleTemplate={[Function]}
-                                      widgetId="pagination-options-menu-bottom-bottom"
-                                    />
+                                  onEnter={[Function]}
+                                  onToggle={[Function]}
+                                  parentRef={
+                                    Object {
+                                      "current": null,
+                                    }
                                   }
                                 >
-                                  <div
-                                    className="pf-c-options-menu pf-m-top"
-                                    data-ouia-component-type="PF4/PaginationOptionsMenu"
+                                  <Toggle
+                                    aria-haspopup="listbox"
+                                    aria-label="Items per page"
+                                    bubbleEvent={false}
+                                    className="pf-c-options-menu__toggle-button"
+                                    data-ouia-component-id="OUIA-Generated-DropdownToggle-2"
+                                    data-ouia-component-type="PF4/DropdownToggle"
                                     data-ouia-safe={true}
+                                    getMenuRef={null}
+                                    id="pagination-options-menu-bottom-bottom-toggle"
+                                    isActive={false}
+                                    isDisabled={false}
+                                    isOpen={false}
+                                    isPlain={false}
+                                    isPrimary={false}
+                                    isSplitButton={false}
+                                    isText={false}
+                                    onEnter={[Function]}
+                                    onToggle={[Function]}
+                                    parentRef={
+                                      Object {
+                                        "current": null,
+                                      }
+                                    }
+                                    toggleVariant="default"
                                   >
-                                    <OptionsToggle
-                                      aria-haspopup={true}
-                                      firstIndex={1}
-                                      getMenuRef={[Function]}
-                                      id="pf-dropdown-toggle-id-15"
-                                      isDisabled={false}
-                                      isOpen={false}
-                                      isPlain={true}
-                                      isText={false}
-                                      itemCount={10}
-                                      itemsPerPageTitle="Items per page"
-                                      itemsTitle=""
-                                      key=".0"
-                                      lastIndex={10}
-                                      ofWord="of"
-                                      onEnter={[Function]}
-                                      onToggle={[Function]}
-                                      optionsToggle=""
-                                      parentRef={
+                                    <button
+                                      aria-expanded={false}
+                                      aria-haspopup="listbox"
+                                      aria-label="Items per page"
+                                      className="  pf-c-options-menu__toggle-button"
+                                      data-ouia-component-id="OUIA-Generated-DropdownToggle-2"
+                                      data-ouia-component-type="PF4/DropdownToggle"
+                                      data-ouia-safe={true}
+                                      disabled={false}
+                                      id="pagination-options-menu-bottom-bottom-toggle"
+                                      onClick={[Function]}
+                                      onKeyDown={[Function]}
+                                      type="button"
+                                    >
+                                      <span
+                                        className="pf-c-options-menu__toggle-button-icon"
+                                      >
+                                        <CaretDownIcon
+                                          color="currentColor"
+                                          noVerticalAlign={false}
+                                          size="sm"
+                                        >
+                                          <svg
+                                            aria-hidden={true}
+                                            aria-labelledby={null}
+                                            fill="currentColor"
+                                            height="1em"
+                                            role="img"
+                                            style={
+                                              Object {
+                                                "verticalAlign": "-0.125em",
+                                              }
+                                            }
+                                            viewBox="0 0 320 512"
+                                            width="1em"
+                                          >
+                                            <path
+                                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                                            />
+                                          </svg>
+                                        </CaretDownIcon>
+                                      </span>
+                                    </button>
+                                  </Toggle>
+                                </DropdownToggle>
+                              </div>
+                            </OptionsToggle>
+                          </div>
+                        </DropdownWithContext>
+                      </PaginationOptionsMenu>
+                      <Navigation
+                        className=""
+                        currPage="Current page"
+                        firstPage={1}
+                        isCompact={false}
+                        isDisabled={false}
+                        itemCount={10}
+                        lastPage={1}
+                        ofWord="of"
+                        onFirstClick={[Function]}
+                        onLastClick={[Function]}
+                        onNextClick={[Function]}
+                        onPageInput={[Function]}
+                        onPreviousClick={[Function]}
+                        onSetPage={[Function]}
+                        page={1}
+                        pagesTitle=""
+                        pagesTitlePlural=""
+                        paginationTitle="Pagination"
+                        perPage={25}
+                        toFirstPage="Go to first page"
+                        toLastPage="Go to last page"
+                        toNextPage="Go to next page"
+                        toPreviousPage="Go to previous page"
+                      >
+                        <nav
+                          aria-label="Pagination"
+                          className="pf-c-pagination__nav"
+                        >
+                          <div
+                            className="pf-c-pagination__nav-control pf-m-first"
+                          >
+                            <Button
+                              aria-label="Go to first page"
+                              data-action="first"
+                              isDisabled={true}
+                              onClick={[Function]}
+                              variant="plain"
+                            >
+                              <ButtonBase
+                                aria-label="Go to first page"
+                                data-action="first"
+                                innerRef={null}
+                                isDisabled={true}
+                                onClick={[Function]}
+                                variant="plain"
+                              >
+                                <button
+                                  aria-disabled={true}
+                                  aria-label="Go to first page"
+                                  className="pf-c-button pf-m-plain pf-m-disabled"
+                                  data-action="first"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-8"
+                                  data-ouia-component-type="PF4/Button"
+                                  data-ouia-safe={true}
+                                  disabled={true}
+                                  onClick={[Function]}
+                                  role={null}
+                                  tabIndex={null}
+                                  type="button"
+                                >
+                                  <AngleDoubleLeftIcon
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
                                         Object {
-                                          "current": null,
+                                          "verticalAlign": "-0.125em",
                                         }
                                       }
-                                      perPageComponent="div"
-                                      showToggle={true}
-                                      toggleTemplate={[Function]}
-                                      widgetId="pagination-options-menu-bottom-bottom"
+                                      viewBox="0 0 448 512"
+                                      width="1em"
                                     >
-                                      <div
-                                        className="pf-c-options-menu__toggle pf-m-plain pf-m-text"
-                                      >
-                                        <span
-                                          className="pf-c-options-menu__toggle-text"
-                                        >
-                                          <ToggleTemplate
-                                            firstIndex={1}
-                                            itemCount={10}
-                                            itemsTitle=""
-                                            lastIndex={10}
-                                            ofWord="of"
-                                          >
-                                            <b>
-                                              1
-                                               - 
-                                              10
-                                            </b>
-                                             
-                                            of
-                                             
-                                            <b>
-                                              10
-                                            </b>
-                                             
-                                          </ToggleTemplate>
-                                        </span>
-                                        <DropdownToggle
-                                          aria-haspopup="listbox"
-                                          aria-label="Items per page"
-                                          className="pf-c-options-menu__toggle-button"
-                                          id="pagination-options-menu-bottom-bottom-toggle"
-                                          isDisabled={false}
-                                          isOpen={false}
-                                          onEnter={[Function]}
-                                          onToggle={[Function]}
-                                          parentRef={
-                                            Object {
-                                              "current": null,
-                                            }
-                                          }
-                                        >
-                                          <Toggle
-                                            aria-haspopup="listbox"
-                                            aria-label="Items per page"
-                                            bubbleEvent={false}
-                                            className="pf-c-options-menu__toggle-button"
-                                            data-ouia-component-id="OUIA-Generated-DropdownToggle-2"
-                                            data-ouia-component-type="PF4/DropdownToggle"
-                                            data-ouia-safe={true}
-                                            getMenuRef={null}
-                                            id="pagination-options-menu-bottom-bottom-toggle"
-                                            isActive={false}
-                                            isDisabled={false}
-                                            isOpen={false}
-                                            isPlain={false}
-                                            isPrimary={false}
-                                            isSplitButton={false}
-                                            isText={false}
-                                            onEnter={[Function]}
-                                            onToggle={[Function]}
-                                            parentRef={
-                                              Object {
-                                                "current": null,
-                                              }
-                                            }
-                                            toggleVariant="default"
-                                          >
-                                            <button
-                                              aria-expanded={false}
-                                              aria-haspopup="listbox"
-                                              aria-label="Items per page"
-                                              className="  pf-c-options-menu__toggle-button"
-                                              data-ouia-component-id="OUIA-Generated-DropdownToggle-2"
-                                              data-ouia-component-type="PF4/DropdownToggle"
-                                              data-ouia-safe={true}
-                                              disabled={false}
-                                              id="pagination-options-menu-bottom-bottom-toggle"
-                                              onClick={[Function]}
-                                              onKeyDown={[Function]}
-                                              type="button"
-                                            >
-                                              <span
-                                                className="pf-c-options-menu__toggle-button-icon"
-                                              >
-                                                <CaretDownIcon
-                                                  color="currentColor"
-                                                  noVerticalAlign={false}
-                                                  size="sm"
-                                                >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    aria-labelledby={null}
-                                                    fill="currentColor"
-                                                    height="1em"
-                                                    role="img"
-                                                    style={
-                                                      Object {
-                                                        "verticalAlign": "-0.125em",
-                                                      }
-                                                    }
-                                                    viewBox="0 0 320 512"
-                                                    width="1em"
-                                                  >
-                                                    <path
-                                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                                    />
-                                                  </svg>
-                                                </CaretDownIcon>
-                                              </span>
-                                            </button>
-                                          </Toggle>
-                                        </DropdownToggle>
-                                      </div>
-                                    </OptionsToggle>
-                                  </div>
-                                </DropdownWithContext>
-                              </PaginationOptionsMenu>
-                              <Navigation
-                                className=""
-                                currPage="Current page"
-                                firstPage={1}
-                                isCompact={false}
-                                isDisabled={false}
-                                itemCount={10}
-                                lastPage={1}
-                                ofWord="of"
-                                onFirstClick={[Function]}
-                                onLastClick={[Function]}
-                                onNextClick={[Function]}
-                                onPageInput={[Function]}
-                                onPreviousClick={[Function]}
-                                onSetPage={[Function]}
-                                page={1}
-                                pagesTitle=""
-                                pagesTitlePlural=""
-                                paginationTitle="Pagination"
-                                perPage={25}
-                                toFirstPage="Go to first page"
-                                toLastPage="Go to last page"
-                                toNextPage="Go to next page"
-                                toPreviousPage="Go to previous page"
-                              >
-                                <nav
-                                  aria-label="Pagination"
-                                  className="pf-c-pagination__nav"
-                                >
-                                  <div
-                                    className="pf-c-pagination__nav-control pf-m-first"
-                                  >
-                                    <Button
-                                      aria-label="Go to first page"
-                                      data-action="first"
-                                      isDisabled={true}
-                                      onClick={[Function]}
-                                      variant="plain"
-                                    >
-                                      <ButtonBase
-                                        aria-label="Go to first page"
-                                        data-action="first"
-                                        innerRef={null}
-                                        isDisabled={true}
-                                        onClick={[Function]}
-                                        variant="plain"
-                                      >
-                                        <button
-                                          aria-disabled={true}
-                                          aria-label="Go to first page"
-                                          className="pf-c-button pf-m-plain pf-m-disabled"
-                                          data-action="first"
-                                          data-ouia-component-id="OUIA-Generated-Button-plain-8"
-                                          data-ouia-component-type="PF4/Button"
-                                          data-ouia-safe={true}
-                                          disabled={true}
-                                          onClick={[Function]}
-                                          role={null}
-                                          tabIndex={null}
-                                          type="button"
-                                        >
-                                          <AngleDoubleLeftIcon
-                                            color="currentColor"
-                                            noVerticalAlign={false}
-                                            size="sm"
-                                          >
-                                            <svg
-                                              aria-hidden={true}
-                                              aria-labelledby={null}
-                                              fill="currentColor"
-                                              height="1em"
-                                              role="img"
-                                              style={
-                                                Object {
-                                                  "verticalAlign": "-0.125em",
-                                                }
-                                              }
-                                              viewBox="0 0 448 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                                              />
-                                            </svg>
-                                          </AngleDoubleLeftIcon>
-                                        </button>
-                                      </ButtonBase>
-                                    </Button>
-                                  </div>
-                                  <div
-                                    className="pf-c-pagination__nav-control"
-                                  >
-                                    <Button
-                                      aria-label="Go to previous page"
-                                      data-action="previous"
-                                      isDisabled={true}
-                                      onClick={[Function]}
-                                      variant="plain"
-                                    >
-                                      <ButtonBase
-                                        aria-label="Go to previous page"
-                                        data-action="previous"
-                                        innerRef={null}
-                                        isDisabled={true}
-                                        onClick={[Function]}
-                                        variant="plain"
-                                      >
-                                        <button
-                                          aria-disabled={true}
-                                          aria-label="Go to previous page"
-                                          className="pf-c-button pf-m-plain pf-m-disabled"
-                                          data-action="previous"
-                                          data-ouia-component-id="OUIA-Generated-Button-plain-9"
-                                          data-ouia-component-type="PF4/Button"
-                                          data-ouia-safe={true}
-                                          disabled={true}
-                                          onClick={[Function]}
-                                          role={null}
-                                          tabIndex={null}
-                                          type="button"
-                                        >
-                                          <AngleLeftIcon
-                                            color="currentColor"
-                                            noVerticalAlign={false}
-                                            size="sm"
-                                          >
-                                            <svg
-                                              aria-hidden={true}
-                                              aria-labelledby={null}
-                                              fill="currentColor"
-                                              height="1em"
-                                              role="img"
-                                              style={
-                                                Object {
-                                                  "verticalAlign": "-0.125em",
-                                                }
-                                              }
-                                              viewBox="0 0 256 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                                              />
-                                            </svg>
-                                          </AngleLeftIcon>
-                                        </button>
-                                      </ButtonBase>
-                                    </Button>
-                                  </div>
-                                  <div
-                                    className="pf-c-pagination__nav-page-select"
-                                  >
-                                    <input
-                                      aria-label="Current page"
-                                      className="pf-c-form-control"
-                                      disabled={true}
-                                      max={1}
-                                      min={1}
-                                      onChange={[Function]}
-                                      onKeyDown={[Function]}
-                                      type="number"
-                                      value={1}
-                                    />
-                                    <span
-                                      aria-hidden="true"
-                                    >
-                                      of
-                                       
-                                      1
-                                    </span>
-                                  </div>
-                                  <div
-                                    className="pf-c-pagination__nav-control"
-                                  >
-                                    <Button
-                                      aria-label="Go to next page"
-                                      data-action="next"
-                                      isDisabled={true}
-                                      onClick={[Function]}
-                                      variant="plain"
-                                    >
-                                      <ButtonBase
-                                        aria-label="Go to next page"
-                                        data-action="next"
-                                        innerRef={null}
-                                        isDisabled={true}
-                                        onClick={[Function]}
-                                        variant="plain"
-                                      >
-                                        <button
-                                          aria-disabled={true}
-                                          aria-label="Go to next page"
-                                          className="pf-c-button pf-m-plain pf-m-disabled"
-                                          data-action="next"
-                                          data-ouia-component-id="OUIA-Generated-Button-plain-10"
-                                          data-ouia-component-type="PF4/Button"
-                                          data-ouia-safe={true}
-                                          disabled={true}
-                                          onClick={[Function]}
-                                          role={null}
-                                          tabIndex={null}
-                                          type="button"
-                                        >
-                                          <AngleRightIcon
-                                            color="currentColor"
-                                            noVerticalAlign={false}
-                                            size="sm"
-                                          >
-                                            <svg
-                                              aria-hidden={true}
-                                              aria-labelledby={null}
-                                              fill="currentColor"
-                                              height="1em"
-                                              role="img"
-                                              style={
-                                                Object {
-                                                  "verticalAlign": "-0.125em",
-                                                }
-                                              }
-                                              viewBox="0 0 256 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                              />
-                                            </svg>
-                                          </AngleRightIcon>
-                                        </button>
-                                      </ButtonBase>
-                                    </Button>
-                                  </div>
-                                  <div
-                                    className="pf-c-pagination__nav-control pf-m-last"
-                                  >
-                                    <Button
-                                      aria-label="Go to last page"
-                                      data-action="last"
-                                      isDisabled={true}
-                                      onClick={[Function]}
-                                      variant="plain"
-                                    >
-                                      <ButtonBase
-                                        aria-label="Go to last page"
-                                        data-action="last"
-                                        innerRef={null}
-                                        isDisabled={true}
-                                        onClick={[Function]}
-                                        variant="plain"
-                                      >
-                                        <button
-                                          aria-disabled={true}
-                                          aria-label="Go to last page"
-                                          className="pf-c-button pf-m-plain pf-m-disabled"
-                                          data-action="last"
-                                          data-ouia-component-id="OUIA-Generated-Button-plain-11"
-                                          data-ouia-component-type="PF4/Button"
-                                          data-ouia-safe={true}
-                                          disabled={true}
-                                          onClick={[Function]}
-                                          role={null}
-                                          tabIndex={null}
-                                          type="button"
-                                        >
-                                          <AngleDoubleRightIcon
-                                            color="currentColor"
-                                            noVerticalAlign={false}
-                                            size="sm"
-                                          >
-                                            <svg
-                                              aria-hidden={true}
-                                              aria-labelledby={null}
-                                              fill="currentColor"
-                                              height="1em"
-                                              role="img"
-                                              style={
-                                                Object {
-                                                  "verticalAlign": "-0.125em",
-                                                }
-                                              }
-                                              viewBox="0 0 448 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                                              />
-                                            </svg>
-                                          </AngleDoubleRightIcon>
-                                        </button>
-                                      </ButtonBase>
-                                    </Button>
-                                  </div>
-                                </nav>
-                              </Navigation>
-                            </div>
-                          </Pagination>
-                          <ToolbarChipGroupContent
-                            chipGroupContentRef={
-                              Object {
-                                "current": null,
-                              }
-                            }
-                            clearFiltersButtonText="Clear all filters"
-                            collapseListedFiltersBreakpoint="lg"
-                            isExpanded={false}
-                            numberOfFilters={0}
-                            numberOfFiltersText={[Function]}
-                            showClearFiltersButton={false}
+                                      <path
+                                        d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                                      />
+                                    </svg>
+                                  </AngleDoubleLeftIcon>
+                                </button>
+                              </ButtonBase>
+                            </Button>
+                          </div>
+                          <div
+                            className="pf-c-pagination__nav-control"
                           >
-                            <div
-                              className="pf-c-toolbar__content pf-m-hidden"
-                              hidden={true}
+                            <Button
+                              aria-label="Go to previous page"
+                              data-action="previous"
+                              isDisabled={true}
+                              onClick={[Function]}
+                              variant="plain"
                             >
-                              <ForwardRef
-                                className=""
+                              <ButtonBase
+                                aria-label="Go to previous page"
+                                data-action="previous"
+                                innerRef={null}
+                                isDisabled={true}
+                                onClick={[Function]}
+                                variant="plain"
                               >
-                                <ToolbarGroupWithRef
-                                  className=""
-                                  innerRef={null}
+                                <button
+                                  aria-disabled={true}
+                                  aria-label="Go to previous page"
+                                  className="pf-c-button pf-m-plain pf-m-disabled"
+                                  data-action="previous"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-9"
+                                  data-ouia-component-type="PF4/Button"
+                                  data-ouia-safe={true}
+                                  disabled={true}
+                                  onClick={[Function]}
+                                  role={null}
+                                  tabIndex={null}
+                                  type="button"
                                 >
-                                  <div
-                                    className="pf-c-toolbar__group"
-                                  />
-                                </ToolbarGroupWithRef>
-                              </ForwardRef>
-                            </div>
-                          </ToolbarChipGroupContent>
-                        </div>
-                      </GenerateId>
-                    </Toolbar>
-                  </TableToolbar>
+                                  <AngleLeftIcon
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                                      />
+                                    </svg>
+                                  </AngleLeftIcon>
+                                </button>
+                              </ButtonBase>
+                            </Button>
+                          </div>
+                          <div
+                            className="pf-c-pagination__nav-page-select"
+                          >
+                            <input
+                              aria-label="Current page"
+                              className="pf-c-form-control"
+                              disabled={true}
+                              max={1}
+                              min={1}
+                              onChange={[Function]}
+                              onKeyDown={[Function]}
+                              type="number"
+                              value={1}
+                            />
+                            <span
+                              aria-hidden="true"
+                            >
+                              of
+                               
+                              1
+                            </span>
+                          </div>
+                          <div
+                            className="pf-c-pagination__nav-control"
+                          >
+                            <Button
+                              aria-label="Go to next page"
+                              data-action="next"
+                              isDisabled={true}
+                              onClick={[Function]}
+                              variant="plain"
+                            >
+                              <ButtonBase
+                                aria-label="Go to next page"
+                                data-action="next"
+                                innerRef={null}
+                                isDisabled={true}
+                                onClick={[Function]}
+                                variant="plain"
+                              >
+                                <button
+                                  aria-disabled={true}
+                                  aria-label="Go to next page"
+                                  className="pf-c-button pf-m-plain pf-m-disabled"
+                                  data-action="next"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-10"
+                                  data-ouia-component-type="PF4/Button"
+                                  data-ouia-safe={true}
+                                  disabled={true}
+                                  onClick={[Function]}
+                                  role={null}
+                                  tabIndex={null}
+                                  type="button"
+                                >
+                                  <AngleRightIcon
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 256 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                      />
+                                    </svg>
+                                  </AngleRightIcon>
+                                </button>
+                              </ButtonBase>
+                            </Button>
+                          </div>
+                          <div
+                            className="pf-c-pagination__nav-control pf-m-last"
+                          >
+                            <Button
+                              aria-label="Go to last page"
+                              data-action="last"
+                              isDisabled={true}
+                              onClick={[Function]}
+                              variant="plain"
+                            >
+                              <ButtonBase
+                                aria-label="Go to last page"
+                                data-action="last"
+                                innerRef={null}
+                                isDisabled={true}
+                                onClick={[Function]}
+                                variant="plain"
+                              >
+                                <button
+                                  aria-disabled={true}
+                                  aria-label="Go to last page"
+                                  className="pf-c-button pf-m-plain pf-m-disabled"
+                                  data-action="last"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-11"
+                                  data-ouia-component-type="PF4/Button"
+                                  data-ouia-safe={true}
+                                  disabled={true}
+                                  onClick={[Function]}
+                                  role={null}
+                                  tabIndex={null}
+                                  type="button"
+                                >
+                                  <AngleDoubleRightIcon
+                                    color="currentColor"
+                                    noVerticalAlign={false}
+                                    size="sm"
+                                  >
+                                    <svg
+                                      aria-hidden={true}
+                                      aria-labelledby={null}
+                                      fill="currentColor"
+                                      height="1em"
+                                      role="img"
+                                      style={
+                                        Object {
+                                          "verticalAlign": "-0.125em",
+                                        }
+                                      }
+                                      viewBox="0 0 448 512"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                                      />
+                                    </svg>
+                                  </AngleDoubleRightIcon>
+                                </button>
+                              </ButtonBase>
+                            </Button>
+                          </div>
+                        </nav>
+                      </Navigation>
+                    </div>
+                  </Pagination>
                 </TableFooter>
               </TableView>
             </section>

--- a/src/SmartComponents/SystemPackages/__snapshots__/SystemPackages.test.js.snap
+++ b/src/SmartComponents/SystemPackages/__snapshots__/SystemPackages.test.js.snap
@@ -352,16 +352,15 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
               }
             }
             pagination={
-              Object {
-                "isCompact": true,
-                "isDisabled": true,
-                "itemCount": 0,
-                "onPerPageSelect": [Function],
-                "onSetPage": [Function],
-                "ouiaId": "top-system-packages-pagination",
-                "page": 1,
-                "perPage": 25,
-              }
+              <Skeleton
+                fontSize="xl"
+                style={
+                  Object {
+                    "margin": 10,
+                  }
+                }
+                width="200px"
+              />
             }
           >
             <Toolbar
@@ -1847,685 +1846,30 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                         <div
                           className="pf-c-toolbar__item ins-c-primary-toolbar__pagination"
                         >
-                          <Pagination
-                            className=""
-                            defaultToFullPage={false}
-                            firstPage={1}
-                            isCompact={true}
-                            isDisabled={true}
-                            isSticky={false}
-                            itemCount={0}
-                            itemsEnd={null}
-                            itemsStart={null}
-                            offset={0}
-                            onFirstClick={[Function]}
-                            onLastClick={[Function]}
-                            onNextClick={[Function]}
-                            onPageInput={[Function]}
-                            onPerPageSelect={[Function]}
-                            onPreviousClick={[Function]}
-                            onSetPage={[Function]}
-                            ouiaId="top-system-packages-pagination"
-                            ouiaSafe={true}
-                            page={1}
-                            perPage={25}
-                            perPageComponent="div"
-                            perPageOptions={
-                              Array [
-                                Object {
-                                  "title": "10",
-                                  "value": 10,
-                                },
-                                Object {
-                                  "title": "20",
-                                  "value": 20,
-                                },
-                                Object {
-                                  "title": "50",
-                                  "value": 50,
-                                },
-                                Object {
-                                  "title": "100",
-                                  "value": 100,
-                                },
-                              ]
-                            }
-                            titles={
+                          <Skeleton
+                            fontSize="xl"
+                            style={
                               Object {
-                                "currPage": "Current page",
-                                "items": "",
-                                "itemsPerPage": "Items per page",
-                                "ofWord": "of",
-                                "optionsToggle": "",
-                                "page": "",
-                                "pages": "",
-                                "paginationTitle": "Pagination",
-                                "perPageSuffix": "per page",
-                                "toFirstPage": "Go to first page",
-                                "toLastPage": "Go to last page",
-                                "toNextPage": "Go to next page",
-                                "toPreviousPage": "Go to previous page",
+                                "margin": 10,
                               }
                             }
-                            variant="top"
-                            widgetId="options-menu"
+                            width="200px"
                           >
                             <div
-                              className="pf-c-pagination pf-m-compact"
-                              data-ouia-component-id="top-system-packages-pagination"
-                              data-ouia-component-type="PF4/Pagination"
-                              data-ouia-safe={true}
-                              id="options-menu-top-pagination"
-                            >
-                              <div
-                                className="pf-c-pagination__total-items"
-                              >
-                                <ToggleTemplate
-                                  firstIndex={0}
-                                  itemCount={0}
-                                  itemsTitle=""
-                                  lastIndex={0}
-                                  ofWord="of"
-                                >
-                                  <b>
-                                    0
-                                     - 
-                                    0
-                                  </b>
-                                   
-                                  of
-                                   
-                                  <b>
-                                    0
-                                  </b>
-                                   
-                                </ToggleTemplate>
-                              </div>
-                              <PaginationOptionsMenu
-                                className=""
-                                defaultToFullPage={false}
-                                dropDirection="down"
-                                firstIndex={0}
-                                isDisabled={true}
-                                itemCount={0}
-                                itemsPerPageTitle="Items per page"
-                                itemsTitle=""
-                                lastIndex={0}
-                                lastPage={0}
-                                ofWord="of"
-                                onPerPageSelect={[Function]}
-                                optionsToggle=""
-                                page={0}
-                                perPage={25}
-                                perPageComponent="div"
-                                perPageOptions={
-                                  Array [
-                                    Object {
-                                      "title": "10",
-                                      "value": 10,
-                                    },
-                                    Object {
-                                      "title": "20",
-                                      "value": 20,
-                                    },
-                                    Object {
-                                      "title": "50",
-                                      "value": 50,
-                                    },
-                                    Object {
-                                      "title": "100",
-                                      "value": 100,
-                                    },
-                                  ]
+                              className="pf-c-skeleton pf-m-text-xl"
+                              style={
+                                Object {
+                                  "--pf-c-skeleton--Height": undefined,
+                                  "--pf-c-skeleton--Width": "200px",
+                                  "margin": 10,
                                 }
-                                perPageSuffix="per page"
-                                toggleTemplate={[Function]}
-                                widgetId="options-menu-top"
-                              >
-                                <DropdownWithContext
-                                  autoFocus={true}
-                                  className=""
-                                  direction="down"
-                                  dropdownItems={
-                                    Array [
-                                      <DropdownItem
-                                        className=""
-                                        component="button"
-                                        data-action="per-page-10"
-                                        onClick={[Function]}
-                                      >
-                                        10
-                                         per page
-                                      </DropdownItem>,
-                                      <DropdownItem
-                                        className=""
-                                        component="button"
-                                        data-action="per-page-20"
-                                        onClick={[Function]}
-                                      >
-                                        20
-                                         per page
-                                      </DropdownItem>,
-                                      <DropdownItem
-                                        className=""
-                                        component="button"
-                                        data-action="per-page-50"
-                                        onClick={[Function]}
-                                      >
-                                        50
-                                         per page
-                                      </DropdownItem>,
-                                      <DropdownItem
-                                        className=""
-                                        component="button"
-                                        data-action="per-page-100"
-                                        onClick={[Function]}
-                                      >
-                                        100
-                                         per page
-                                      </DropdownItem>,
-                                    ]
-                                  }
-                                  isFlipEnabled={true}
-                                  isGrouped={false}
-                                  isOpen={false}
-                                  isPlain={true}
-                                  isText={false}
-                                  menuAppendTo="inline"
-                                  onSelect={[Function]}
-                                  position="left"
-                                  toggle={
-                                    <OptionsToggle
-                                      firstIndex={0}
-                                      isDisabled={true}
-                                      isOpen={false}
-                                      itemCount={0}
-                                      itemsPerPageTitle="Items per page"
-                                      itemsTitle=""
-                                      lastIndex={0}
-                                      ofWord="of"
-                                      onToggle={[Function]}
-                                      optionsToggle=""
-                                      parentRef={null}
-                                      perPageComponent="div"
-                                      showToggle={true}
-                                      toggleTemplate={[Function]}
-                                      widgetId="options-menu-top"
-                                    />
-                                  }
-                                >
-                                  <div
-                                    className="pf-c-options-menu"
-                                    data-ouia-component-type="PF4/PaginationOptionsMenu"
-                                    data-ouia-safe={true}
-                                  >
-                                    <OptionsToggle
-                                      aria-haspopup={true}
-                                      firstIndex={0}
-                                      getMenuRef={[Function]}
-                                      id="pf-dropdown-toggle-id-4"
-                                      isDisabled={true}
-                                      isOpen={false}
-                                      isPlain={true}
-                                      isText={false}
-                                      itemCount={0}
-                                      itemsPerPageTitle="Items per page"
-                                      itemsTitle=""
-                                      key=".0"
-                                      lastIndex={0}
-                                      ofWord="of"
-                                      onEnter={[Function]}
-                                      onToggle={[Function]}
-                                      optionsToggle=""
-                                      parentRef={
-                                        Object {
-                                          "current": <div
-                                            class="pf-c-options-menu"
-                                            data-ouia-component-type="PF4/PaginationOptionsMenu"
-                                            data-ouia-safe="true"
-                                          >
-                                            <div
-                                              class="pf-c-options-menu__toggle pf-m-disabled pf-m-plain pf-m-text"
-                                            >
-                                              <span
-                                                class="pf-c-options-menu__toggle-text"
-                                              >
-                                                <b>
-                                                  0
-                                                   - 
-                                                  0
-                                                </b>
-                                                 
-                                                of
-                                                 
-                                                <b>
-                                                  0
-                                                </b>
-                                                 
-                                                
-                                              </span>
-                                              <button
-                                                aria-expanded="false"
-                                                aria-haspopup="listbox"
-                                                aria-label="Items per page"
-                                                class="  pf-c-options-menu__toggle-button"
-                                                data-ouia-component-id="OUIA-Generated-DropdownToggle-4"
-                                                data-ouia-component-type="PF4/DropdownToggle"
-                                                data-ouia-safe="true"
-                                                disabled=""
-                                                id="options-menu-top-toggle"
-                                                type="button"
-                                              >
-                                                <span
-                                                  class="pf-c-options-menu__toggle-button-icon"
-                                                >
-                                                  <svg
-                                                    aria-hidden="true"
-                                                    fill="currentColor"
-                                                    height="1em"
-                                                    role="img"
-                                                    style="vertical-align: -0.125em;"
-                                                    viewBox="0 0 320 512"
-                                                    width="1em"
-                                                  >
-                                                    <path
-                                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                                    />
-                                                  </svg>
-                                                </span>
-                                              </button>
-                                            </div>
-                                          </div>,
-                                        }
-                                      }
-                                      perPageComponent="div"
-                                      showToggle={true}
-                                      toggleTemplate={[Function]}
-                                      widgetId="options-menu-top"
-                                    >
-                                      <div
-                                        className="pf-c-options-menu__toggle pf-m-disabled pf-m-plain pf-m-text"
-                                      >
-                                        <span
-                                          className="pf-c-options-menu__toggle-text"
-                                        >
-                                          <ToggleTemplate
-                                            firstIndex={0}
-                                            itemCount={0}
-                                            itemsTitle=""
-                                            lastIndex={0}
-                                            ofWord="of"
-                                          >
-                                            <b>
-                                              0
-                                               - 
-                                              0
-                                            </b>
-                                             
-                                            of
-                                             
-                                            <b>
-                                              0
-                                            </b>
-                                             
-                                          </ToggleTemplate>
-                                        </span>
-                                        <DropdownToggle
-                                          aria-haspopup="listbox"
-                                          aria-label="Items per page"
-                                          className="pf-c-options-menu__toggle-button"
-                                          id="options-menu-top-toggle"
-                                          isDisabled={true}
-                                          isOpen={false}
-                                          onEnter={[Function]}
-                                          onToggle={[Function]}
-                                          parentRef={
-                                            Object {
-                                              "current": <div
-                                                class="pf-c-options-menu"
-                                                data-ouia-component-type="PF4/PaginationOptionsMenu"
-                                                data-ouia-safe="true"
-                                              >
-                                                <div
-                                                  class="pf-c-options-menu__toggle pf-m-disabled pf-m-plain pf-m-text"
-                                                >
-                                                  <span
-                                                    class="pf-c-options-menu__toggle-text"
-                                                  >
-                                                    <b>
-                                                      0
-                                                       - 
-                                                      0
-                                                    </b>
-                                                     
-                                                    of
-                                                     
-                                                    <b>
-                                                      0
-                                                    </b>
-                                                     
-                                                    
-                                                  </span>
-                                                  <button
-                                                    aria-expanded="false"
-                                                    aria-haspopup="listbox"
-                                                    aria-label="Items per page"
-                                                    class="  pf-c-options-menu__toggle-button"
-                                                    data-ouia-component-id="OUIA-Generated-DropdownToggle-4"
-                                                    data-ouia-component-type="PF4/DropdownToggle"
-                                                    data-ouia-safe="true"
-                                                    disabled=""
-                                                    id="options-menu-top-toggle"
-                                                    type="button"
-                                                  >
-                                                    <span
-                                                      class="pf-c-options-menu__toggle-button-icon"
-                                                    >
-                                                      <svg
-                                                        aria-hidden="true"
-                                                        fill="currentColor"
-                                                        height="1em"
-                                                        role="img"
-                                                        style="vertical-align: -0.125em;"
-                                                        viewBox="0 0 320 512"
-                                                        width="1em"
-                                                      >
-                                                        <path
-                                                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                                        />
-                                                      </svg>
-                                                    </span>
-                                                  </button>
-                                                </div>
-                                              </div>,
-                                            }
-                                          }
-                                        >
-                                          <Toggle
-                                            aria-haspopup="listbox"
-                                            aria-label="Items per page"
-                                            bubbleEvent={false}
-                                            className="pf-c-options-menu__toggle-button"
-                                            data-ouia-component-id="OUIA-Generated-DropdownToggle-4"
-                                            data-ouia-component-type="PF4/DropdownToggle"
-                                            data-ouia-safe={true}
-                                            getMenuRef={null}
-                                            id="options-menu-top-toggle"
-                                            isActive={false}
-                                            isDisabled={true}
-                                            isOpen={false}
-                                            isPlain={false}
-                                            isPrimary={false}
-                                            isSplitButton={false}
-                                            isText={false}
-                                            onEnter={[Function]}
-                                            onToggle={[Function]}
-                                            parentRef={
-                                              Object {
-                                                "current": <div
-                                                  class="pf-c-options-menu"
-                                                  data-ouia-component-type="PF4/PaginationOptionsMenu"
-                                                  data-ouia-safe="true"
-                                                >
-                                                  <div
-                                                    class="pf-c-options-menu__toggle pf-m-disabled pf-m-plain pf-m-text"
-                                                  >
-                                                    <span
-                                                      class="pf-c-options-menu__toggle-text"
-                                                    >
-                                                      <b>
-                                                        0
-                                                         - 
-                                                        0
-                                                      </b>
-                                                       
-                                                      of
-                                                       
-                                                      <b>
-                                                        0
-                                                      </b>
-                                                       
-                                                      
-                                                    </span>
-                                                    <button
-                                                      aria-expanded="false"
-                                                      aria-haspopup="listbox"
-                                                      aria-label="Items per page"
-                                                      class="  pf-c-options-menu__toggle-button"
-                                                      data-ouia-component-id="OUIA-Generated-DropdownToggle-4"
-                                                      data-ouia-component-type="PF4/DropdownToggle"
-                                                      data-ouia-safe="true"
-                                                      disabled=""
-                                                      id="options-menu-top-toggle"
-                                                      type="button"
-                                                    >
-                                                      <span
-                                                        class="pf-c-options-menu__toggle-button-icon"
-                                                      >
-                                                        <svg
-                                                          aria-hidden="true"
-                                                          fill="currentColor"
-                                                          height="1em"
-                                                          role="img"
-                                                          style="vertical-align: -0.125em;"
-                                                          viewBox="0 0 320 512"
-                                                          width="1em"
-                                                        >
-                                                          <path
-                                                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                                          />
-                                                        </svg>
-                                                      </span>
-                                                    </button>
-                                                  </div>
-                                                </div>,
-                                              }
-                                            }
-                                            toggleVariant="default"
-                                          >
-                                            <button
-                                              aria-expanded={false}
-                                              aria-haspopup="listbox"
-                                              aria-label="Items per page"
-                                              className="  pf-c-options-menu__toggle-button"
-                                              data-ouia-component-id="OUIA-Generated-DropdownToggle-4"
-                                              data-ouia-component-type="PF4/DropdownToggle"
-                                              data-ouia-safe={true}
-                                              disabled={true}
-                                              id="options-menu-top-toggle"
-                                              onClick={[Function]}
-                                              onKeyDown={[Function]}
-                                              type="button"
-                                            >
-                                              <span
-                                                className="pf-c-options-menu__toggle-button-icon"
-                                              >
-                                                <CaretDownIcon
-                                                  color="currentColor"
-                                                  noVerticalAlign={false}
-                                                  size="sm"
-                                                >
-                                                  <svg
-                                                    aria-hidden={true}
-                                                    aria-labelledby={null}
-                                                    fill="currentColor"
-                                                    height="1em"
-                                                    role="img"
-                                                    style={
-                                                      Object {
-                                                        "verticalAlign": "-0.125em",
-                                                      }
-                                                    }
-                                                    viewBox="0 0 320 512"
-                                                    width="1em"
-                                                  >
-                                                    <path
-                                                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                                                    />
-                                                  </svg>
-                                                </CaretDownIcon>
-                                              </span>
-                                            </button>
-                                          </Toggle>
-                                        </DropdownToggle>
-                                      </div>
-                                    </OptionsToggle>
-                                  </div>
-                                </DropdownWithContext>
-                              </PaginationOptionsMenu>
-                              <Navigation
-                                className=""
-                                currPage="Current page"
-                                firstPage={1}
-                                isCompact={true}
-                                isDisabled={true}
-                                itemCount={0}
-                                lastPage={0}
-                                ofWord="of"
-                                onFirstClick={[Function]}
-                                onLastClick={[Function]}
-                                onNextClick={[Function]}
-                                onPageInput={[Function]}
-                                onPreviousClick={[Function]}
-                                onSetPage={[Function]}
-                                page={0}
-                                pagesTitle=""
-                                pagesTitlePlural=""
-                                paginationTitle="Pagination"
-                                perPage={25}
-                                toFirstPage="Go to first page"
-                                toLastPage="Go to last page"
-                                toNextPage="Go to next page"
-                                toPreviousPage="Go to previous page"
-                              >
-                                <nav
-                                  aria-label="Pagination"
-                                  className="pf-c-pagination__nav"
-                                >
-                                  <div
-                                    className="pf-c-pagination__nav-control"
-                                  >
-                                    <Button
-                                      aria-label="Go to previous page"
-                                      data-action="previous"
-                                      isDisabled={true}
-                                      onClick={[Function]}
-                                      variant="plain"
-                                    >
-                                      <ButtonBase
-                                        aria-label="Go to previous page"
-                                        data-action="previous"
-                                        innerRef={null}
-                                        isDisabled={true}
-                                        onClick={[Function]}
-                                        variant="plain"
-                                      >
-                                        <button
-                                          aria-disabled={true}
-                                          aria-label="Go to previous page"
-                                          className="pf-c-button pf-m-plain pf-m-disabled"
-                                          data-action="previous"
-                                          data-ouia-component-id="OUIA-Generated-Button-plain-1"
-                                          data-ouia-component-type="PF4/Button"
-                                          data-ouia-safe={true}
-                                          disabled={true}
-                                          onClick={[Function]}
-                                          role={null}
-                                          tabIndex={null}
-                                          type="button"
-                                        >
-                                          <AngleLeftIcon
-                                            color="currentColor"
-                                            noVerticalAlign={false}
-                                            size="sm"
-                                          >
-                                            <svg
-                                              aria-hidden={true}
-                                              aria-labelledby={null}
-                                              fill="currentColor"
-                                              height="1em"
-                                              role="img"
-                                              style={
-                                                Object {
-                                                  "verticalAlign": "-0.125em",
-                                                }
-                                              }
-                                              viewBox="0 0 256 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                                              />
-                                            </svg>
-                                          </AngleLeftIcon>
-                                        </button>
-                                      </ButtonBase>
-                                    </Button>
-                                  </div>
-                                  <div
-                                    className="pf-c-pagination__nav-control"
-                                  >
-                                    <Button
-                                      aria-label="Go to next page"
-                                      data-action="next"
-                                      isDisabled={true}
-                                      onClick={[Function]}
-                                      variant="plain"
-                                    >
-                                      <ButtonBase
-                                        aria-label="Go to next page"
-                                        data-action="next"
-                                        innerRef={null}
-                                        isDisabled={true}
-                                        onClick={[Function]}
-                                        variant="plain"
-                                      >
-                                        <button
-                                          aria-disabled={true}
-                                          aria-label="Go to next page"
-                                          className="pf-c-button pf-m-plain pf-m-disabled"
-                                          data-action="next"
-                                          data-ouia-component-id="OUIA-Generated-Button-plain-2"
-                                          data-ouia-component-type="PF4/Button"
-                                          data-ouia-safe={true}
-                                          disabled={true}
-                                          onClick={[Function]}
-                                          role={null}
-                                          tabIndex={null}
-                                          type="button"
-                                        >
-                                          <AngleRightIcon
-                                            color="currentColor"
-                                            noVerticalAlign={false}
-                                            size="sm"
-                                          >
-                                            <svg
-                                              aria-hidden={true}
-                                              aria-labelledby={null}
-                                              fill="currentColor"
-                                              height="1em"
-                                              role="img"
-                                              style={
-                                                Object {
-                                                  "verticalAlign": "-0.125em",
-                                                }
-                                              }
-                                              viewBox="0 0 256 512"
-                                              width="1em"
-                                            >
-                                              <path
-                                                d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                                              />
-                                            </svg>
-                                          </AngleRightIcon>
-                                        </button>
-                                      </ButtonBase>
-                                    </Button>
-                                  </div>
-                                </nav>
-                              </Navigation>
+                              }
+                            >
+                              <span
+                                className="pf-u-screen-reader"
+                              />
                             </div>
-                          </Pagination>
+                          </Skeleton>
                         </div>
                       </ToolbarItem>
                     </div>
@@ -30274,6 +29618,44 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
               </Provider>
             </Table>
           </SkeletonTable>
+          <TableFooter
+            isLoading={true}
+            onPerPageSelect={[Function]}
+            onSetPage={[Function]}
+            page={1}
+            paginationOUIA="bottom-system-packages-pagination"
+            perPage={25}
+            totalItems={0}
+          >
+            <div
+              className="pf-c-pagination pf-m-bottom"
+            >
+              <Skeleton
+                fontSize="xl"
+                style={
+                  Object {
+                    "margin": 10,
+                  }
+                }
+                width="350px"
+              >
+                <div
+                  className="pf-c-skeleton pf-m-text-xl"
+                  style={
+                    Object {
+                      "--pf-c-skeleton--Height": undefined,
+                      "--pf-c-skeleton--Width": "350px",
+                      "margin": 10,
+                    }
+                  }
+                >
+                  <span
+                    className="pf-u-screen-reader"
+                  />
+                </div>
+              </Skeleton>
+            </div>
+          </TableFooter>
         </TableView>
       </SystemPackages>
     </Router>


### PR DESCRIPTION
# Description

- fix bottom pagination using double padding (32px instead of 16px)

### Before
![Screenshot from 2023-02-15 00-47-04](https://user-images.githubusercontent.com/8426204/218888644-db0cc2a7-b62d-4e52-a5af-630f7cd4546f.png)

### After
![Screenshot from 2023-02-15 00-46-55](https://user-images.githubusercontent.com/8426204/218888650-d50367e2-1292-4dbb-9eb2-dd1a980a6039.png)

- fix paginations not being replaced by loading skeletons when data is loading (this fix applies to all pages except Inventory tables, which will be addressed in a separate PR); top pagination displayed stale data for the duration of the loading, bottom pagination was removed for the duration of the loading

### Before
![Screenshot from 2023-02-15 00-55-45](https://user-images.githubusercontent.com/8426204/218890188-866b0986-7633-4ab8-be91-263303743e18.png)

### After
![Screenshot from 2023-02-15 00-55-22](https://user-images.githubusercontent.com/8426204/218890220-d66e38e4-6c9f-40f9-a9fa-b7be2535d033.png)

# How to test the PR
Bottom pagination should have correct 16px padding. Top and bottom paginations of all tables except Systems (Inventory) tables should be replaced by 200px loading skeleton when table data is loading.

# Checklist:

- [ ] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [x] README.md is updated if necessary
- [ ] Needs additional dependent work
