### PR TITLE
feat(Templates): Update templates page header

### DIFF
--- a/deploy/frontend.yml
+++ b/deploy/frontend.yml
@@ -35,8 +35,8 @@ objects:
               title: 'Packages'
               href: '/insights/patch/packages'
             - appId: 'patch'
-              title: 'Patch Template'
-              href: '/insights/patch/patch-template'
+              title: 'Templates'
+              href: '/insights/patch/templates'
       module:
         manifestLocation: "/apps/patch/fed-mods.json"
         modules:

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -507,6 +507,16 @@ export default defineMessages({
         description: 'validation text of the patch template wizard',
         defaultMessage: 'At least one system must be selected. Actions must be associated to a system to be added to a playbook.'
     },
+    templatePopoverBody: {
+        id: 'templatePopoverBody',
+        description: 'Template page header popover body',
+        defaultMessage: 'Templates allow you to control the scope of package and advisory updates to be installed on selected systems.'
+    },
+    templatePopoverHeader: {
+        id: 'templatePopoverHeader',
+        description: 'Template page header popover title',
+        defaultMessage: 'About Templates'
+    },
     templateReview: {
         id: 'templateReview',
         description: 'step name of the patch template wizard',
@@ -670,7 +680,7 @@ export default defineMessages({
     titlesTemplate: {
         id: 'titlesTemplate',
         description: 'page title with capital letter',
-        defaultMessage: 'Patch template'
+        defaultMessage: 'Templates'
     },
     titlesTemplateAssign: {
         id: 'titlesTemplateAssign',

--- a/src/SmartComponents/PatchSet/PatchSet.js
+++ b/src/SmartComponents/PatchSet/PatchSet.js
@@ -6,8 +6,10 @@ import messages from '../../Messages';
 import Header from '../../PresentationalComponents/Header/Header';
 import searchFilter from '../../PresentationalComponents/Filters/SearchFilter';
 import TableView from '../../PresentationalComponents/TableView/TableView';
-import { fetchPatchSetsAction, changePatchSetsParams,
-    selectPatchSetRow, clearPatchSetsAction } from '../../store/Actions/Actions';
+import {
+    fetchPatchSetsAction, changePatchSetsParams,
+    selectPatchSetRow, clearPatchSetsAction
+} from '../../store/Actions/Actions';
 import { deletePatchSet } from '../../Utilities/api';
 import { createPatchSetRows } from '../../Utilities/DataMappers';
 import { createSortBy, decodeQueryparams, encodeURLParams } from '../../Utilities/Helpers';
@@ -16,14 +18,18 @@ import {
 } from '../../Utilities/Hooks';
 import { intl } from '../../Utilities/IntlProvider';
 import { clearNotifications, addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
-import { patchSetColumns, CreatePatchSetButton as createPatchSetButton,
-    patchSetRowActions, CustomActionsToggle } from './PatchSetAssets';
+import {
+    patchSetColumns, CreatePatchSetButton as createPatchSetButton,
+    patchSetRowActions, CustomActionsToggle
+} from './PatchSetAssets';
 import PatchSetWizard from '../PatchSetWizard/PatchSetWizard';
-import { patchSetDeleteNotifications } from '../../Utilities/constants';
+import { patchSetDeleteNotifications, TEMPLATES_DOCS_LINK } from '../../Utilities/constants';
 import usePatchSetState from '../../Utilities/usePatchSetState';
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import { useOnSelect, ID_API_ENDPOINTS } from '../../Utilities/useOnSelect';
 import { NoSmartManagement } from '../../PresentationalComponents/Snippets/EmptyStates';
+import { ExternalLinkAltIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { Popover } from '@patternfly/react-core';
 
 const PatchSet = () => {
     const pageTitle = intl.formatMessage(messages.titlesTemplate);
@@ -146,7 +152,38 @@ const PatchSet = () => {
 
     return (
         <React.Fragment>
-            <Header title={intl.formatMessage(messages.titlesTemplate)} headerOUIA={'advisories'} />
+            <Header
+                headerOUIA={'advisories'}
+                title={<span>
+                    {intl.formatMessage(messages.titlesTemplate)}
+                    <Popover
+                        id="template-header-title-popover"
+                        aria-describedby="template-header-title-popover"
+                        aria-labelledby="template-header-title-popover"
+                        hasAutoWidth
+                        maxWidth="320px"
+                        position="right"
+                        enableFlip
+                        headerContent={
+                            intl.formatMessage(messages.templatePopoverHeader)
+                        }
+                        bodyContent={
+                            intl.formatMessage(messages.templatePopoverBody)
+                        }
+                        footerContent={
+                            <a href={TEMPLATES_DOCS_LINK} target="__blank" rel="noopener noreferrer">
+                                {intl.formatMessage(messages.linksReadMore)} <ExternalLinkAltIcon />
+                            </a>
+                        }
+                    >
+                        <OutlinedQuestionCircleIcon
+                            color="var(--pf-global--secondary-color--100)"
+                            className="pf-u-ml-sm"
+                            style={{ verticalAlign: '0', fontSize: 16, cursor: 'pointer' }}
+                        />
+                    </Popover>
+                </span>}
+            />
             {patchSetState.isPatchSetWizardOpen &&
                 <PatchSetWizard
                     systemsIDs={patchSetState.systemsIDs}

--- a/src/SmartComponents/PatchSet/__snapshots__/PatchSet.test.js.snap
+++ b/src/SmartComponents/PatchSet/__snapshots__/PatchSet.test.js.snap
@@ -46,7 +46,53 @@ exports[`HeaderBreadcrumbs Should render correctly 1`] = `
       >
         <Header
           headerOUIA="advisories"
-          title="Patch template"
+          title={
+            <span>
+              Templates
+              <Popover
+                aria-describedby="template-header-title-popover"
+                aria-labelledby="template-header-title-popover"
+                bodyContent="Templates allow you to control the scope of package and advisory updates to be installed on selected systems."
+                enableFlip={true}
+                footerContent={
+                  <a
+                    href="https://access.redhat.com/documentation/en-us/red_hat_insights/2022/html/system_patching_using_ansible_playbooks_via_remediations/index"
+                    rel="noopener noreferrer"
+                    target="__blank"
+                  >
+                    Read more
+                     
+                    <ExternalLinkAltIcon
+                      color="currentColor"
+                      noVerticalAlign={false}
+                      size="sm"
+                    />
+                  </a>
+                }
+                hasAutoWidth={true}
+                headerContent="About Templates"
+                id="template-header-title-popover"
+                maxWidth="320px"
+                position="right"
+              >
+                <span>
+                  <OutlinedQuestionCircleIcon
+                    className="pf-u-ml-sm pointer cves-header-questionmark"
+                    color="var(--pf-global--secondary-color--100)"
+                    noVerticalAlign={false}
+                    size="sm"
+                    style={
+                      Object {
+                        "cursor": "pointer",
+                        "fontSize": 16,
+                        "verticalAlign": "0",
+                      }
+                    }
+                  />
+                </span>
+              </Popover>
+            </span>
+          }
         >
           <PageHeader
             data-ouia-component-type="advisories-page-header"
@@ -57,7 +103,53 @@ exports[`HeaderBreadcrumbs Should render correctly 1`] = `
               widget-type="InsightsPageHeader"
             >
               <PageHeaderTitle
-                title="Patch template"
+                title={
+                  <span>
+                    Templates
+                    <Popover
+                      aria-describedby="template-header-title-popover"
+                      aria-labelledby="template-header-title-popover"
+                      bodyContent="Templates allow you to control the scope of package and advisory updates to be installed on selected systems."
+                      enableFlip={true}
+                      footerContent={
+                        <a
+                          href="https://access.redhat.com/documentation/en-us/red_hat_insights/2022/html/system_patching_using_ansible_playbooks_via_remediations/index"
+                          rel="noopener noreferrer"
+                          target="__blank"
+                        >
+                          Read more
+                           
+                          <ExternalLinkAltIcon
+                            color="currentColor"
+                            noVerticalAlign={false}
+                            size="sm"
+                          />
+                        </a>
+                      }
+                      hasAutoWidth={true}
+                      headerContent="About Templates"
+                      id="template-header-title-popover"
+                      maxWidth="320px"
+                      position="right"
+                    >
+                      <span>
+                        <OutlinedQuestionCircleIcon
+                          className="pf-u-ml-sm pointer cves-header-questionmark"
+                          color="var(--pf-global--secondary-color--100)"
+                          noVerticalAlign={false}
+                          size="sm"
+                          style={
+                            Object {
+                              "cursor": "pointer",
+                              "fontSize": 16,
+                              "verticalAlign": "0",
+                            }
+                          }
+                        />
+                      </span>
+                    </Popover>
+                  </span>
+                }
               >
                 <Title
                   className=""
@@ -72,7 +164,208 @@ exports[`HeaderBreadcrumbs Should render correctly 1`] = `
                     data-ouia-safe={true}
                     widget-type="InsightsPageHeaderTitle"
                   >
-                    Patch template
+                    <span>
+                      Templates
+                      <Popover
+                        aria-describedby="template-header-title-popover"
+                        aria-labelledby="template-header-title-popover"
+                        bodyContent="Templates allow you to control the scope of package and advisory updates to be installed on selected systems."
+                        enableFlip={true}
+                        footerContent={
+                          <a
+                            href="https://access.redhat.com/documentation/en-us/red_hat_insights/2022/html/system_patching_using_ansible_playbooks_via_remediations/index"
+                            rel="noopener noreferrer"
+                            target="__blank"
+                          >
+                            Read more
+                             
+                            <ExternalLinkAltIcon
+                              color="currentColor"
+                              noVerticalAlign={false}
+                              size="sm"
+                            />
+                          </a>
+                        }
+                        hasAutoWidth={true}
+                        headerContent="About Templates"
+                        id="template-header-title-popover"
+                        maxWidth="320px"
+                        position="right"
+                      >
+                        <Popper
+                          appendTo={[Function]}
+                          distance={25}
+                          enableFlip={true}
+                          flipBehavior={
+                            Array [
+                              "top",
+                              "bottom",
+                              "left",
+                              "right",
+                              "top-start",
+                              "top-end",
+                              "bottom-start",
+                              "bottom-end",
+                              "left-start",
+                              "left-end",
+                              "right-start",
+                              "right-end",
+                            ]
+                          }
+                          isVisible={false}
+                          onDocumentClick={[Function]}
+                          onDocumentKeyDown={[Function]}
+                          onTriggerClick={[Function]}
+                          placement="right"
+                          popper={
+                            <ForwardRef
+                              active={false}
+                              aria-describedby="template-header-title-popover"
+                              aria-labelledby="template-header-title-popover"
+                              aria-modal="true"
+                              className="pf-c-popover pf-m-width-auto"
+                              focusTrapOptions={
+                                Object {
+                                  "clickOutsideDeactivates": true,
+                                  "fallbackFocus": [Function],
+                                  "returnFocusOnDeactivate": true,
+                                  "tabbableOptions": Object {
+                                    "displayCheck": "none",
+                                  },
+                                }
+                              }
+                              onMouseDown={[Function]}
+                              preventScrollOnDeactivate={true}
+                              role="dialog"
+                              style={
+                                Object {
+                                  "maxWidth": "320px",
+                                  "minWidth": null,
+                                  "opacity": 0,
+                                  "transition": "opacity 300ms cubic-bezier(.54, 1.5, .38, 1.11)",
+                                }
+                              }
+                            >
+                              <PopoverArrow />
+                              <PopoverContent>
+                                <PopoverCloseButton
+                                  aria-label="Close"
+                                  onClose={[Function]}
+                                />
+                                <PopoverHeader
+                                  alertSeverityScreenReaderText="undefined alert:"
+                                  icon={null}
+                                  id="popover-template-header-title-popover-header"
+                                  titleHeadingLevel="h6"
+                                >
+                                  About Templates
+                                </PopoverHeader>
+                                <PopoverBody
+                                  id="popover-template-header-title-popover-body"
+                                >
+                                  Templates allow you to control the scope of package and advisory updates to be installed on selected systems.
+                                </PopoverBody>
+                                <PopoverFooter
+                                  id="popover-template-header-title-popover-footer"
+                                >
+                                  <a
+                                    href="https://access.redhat.com/documentation/en-us/red_hat_insights/2022/html/system_patching_using_ansible_playbooks_via_remediations/index"
+                                    rel="noopener noreferrer"
+                                    target="__blank"
+                                  >
+                                    Read more
+                                     
+                                    <ExternalLinkAltIcon
+                                      color="currentColor"
+                                      noVerticalAlign={false}
+                                      size="sm"
+                                    />
+                                  </a>
+                                </PopoverFooter>
+                              </PopoverContent>
+                            </ForwardRef>
+                          }
+                          popperMatchesTriggerWidth={false}
+                          positionModifiers={
+                            Object {
+                              "bottom": "pf-m-bottom",
+                              "bottom-end": "pf-m-bottom-right",
+                              "bottom-start": "pf-m-bottom-left",
+                              "left": "pf-m-left",
+                              "left-end": "pf-m-left-bottom",
+                              "left-start": "pf-m-left-top",
+                              "right": "pf-m-right",
+                              "right-end": "pf-m-right-bottom",
+                              "right-start": "pf-m-right-top",
+                              "top": "pf-m-top",
+                              "top-end": "pf-m-top-right",
+                              "top-start": "pf-m-top-left",
+                            }
+                          }
+                          removeFindDomNode={false}
+                          trigger={
+                            <span>
+                              <OutlinedQuestionCircleIcon
+                                className="pf-u-ml-sm pointer cves-header-questionmark"
+                                color="var(--pf-global--secondary-color--100)"
+                                noVerticalAlign={false}
+                                size="sm"
+                                style={
+                                  Object {
+                                    "cursor": "pointer",
+                                    "fontSize": 16,
+                                    "verticalAlign": "0",
+                                  }
+                                }
+                              />
+                            </span>
+                          }
+                          zIndex={9999}
+                        >
+                          <FindRefWrapper
+                            onFoundRef={[Function]}
+                          >
+                            <span>
+                              <OutlinedQuestionCircleIcon
+                                className="pf-u-ml-sm pointer cves-header-questionmark"
+                                color="var(--pf-global--secondary-color--100)"
+                                noVerticalAlign={false}
+                                size="sm"
+                                style={
+                                  Object {
+                                    "cursor": "pointer",
+                                    "fontSize": 16,
+                                    "verticalAlign": "0",
+                                  }
+                                }
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  aria-labelledby={null}
+                                  className="pf-u-ml-sm pointer cves-header-questionmark"
+                                  fill="var(--pf-global--secondary-color--100)"
+                                  height="1em"
+                                  role="img"
+                                  style={
+                                    Object {
+                                      "cursor": "pointer",
+                                      "fontSize": 16,
+                                      "verticalAlign": "0",
+                                    }
+                                  }
+                                  viewBox="0 0 512 512"
+                                  width="1em"
+                                >
+                                  <path
+                                    d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                                  />
+                                </svg>
+                              </OutlinedQuestionCircleIcon>
+                            </span>
+                          </FindRefWrapper>
+                        </Popper>
+                      </Popover>
+                    </span>
                   </h1>
                 </Title>
               </PageHeaderTitle>

--- a/src/SmartComponents/PatchSet/__snapshots__/PatchSet.test.js.snap
+++ b/src/SmartComponents/PatchSet/__snapshots__/PatchSet.test.js.snap
@@ -75,21 +75,19 @@ exports[`HeaderBreadcrumbs Should render correctly 1`] = `
                 maxWidth="320px"
                 position="right"
               >
-                <span>
-                  <OutlinedQuestionCircleIcon
-                    className="pf-u-ml-sm pointer cves-header-questionmark"
-                    color="var(--pf-global--secondary-color--100)"
-                    noVerticalAlign={false}
-                    size="sm"
-                    style={
-                      Object {
-                        "cursor": "pointer",
-                        "fontSize": 16,
-                        "verticalAlign": "0",
-                      }
+                <OutlinedQuestionCircleIcon
+                  className="pf-u-ml-sm"
+                  color="var(--pf-global--secondary-color--100)"
+                  noVerticalAlign={false}
+                  size="sm"
+                  style={
+                    Object {
+                      "cursor": "pointer",
+                      "fontSize": 16,
+                      "verticalAlign": "0",
                     }
-                  />
-                </span>
+                  }
+                />
               </Popover>
             </span>
           }
@@ -132,21 +130,19 @@ exports[`HeaderBreadcrumbs Should render correctly 1`] = `
                       maxWidth="320px"
                       position="right"
                     >
-                      <span>
-                        <OutlinedQuestionCircleIcon
-                          className="pf-u-ml-sm pointer cves-header-questionmark"
-                          color="var(--pf-global--secondary-color--100)"
-                          noVerticalAlign={false}
-                          size="sm"
-                          style={
-                            Object {
-                              "cursor": "pointer",
-                              "fontSize": 16,
-                              "verticalAlign": "0",
-                            }
+                      <OutlinedQuestionCircleIcon
+                        className="pf-u-ml-sm"
+                        color="var(--pf-global--secondary-color--100)"
+                        noVerticalAlign={false}
+                        size="sm"
+                        style={
+                          Object {
+                            "cursor": "pointer",
+                            "fontSize": 16,
+                            "verticalAlign": "0",
                           }
-                        />
-                      </span>
+                        }
+                      />
                     </Popover>
                   </span>
                 }
@@ -304,33 +300,45 @@ exports[`HeaderBreadcrumbs Should render correctly 1`] = `
                           }
                           removeFindDomNode={false}
                           trigger={
-                            <span>
-                              <OutlinedQuestionCircleIcon
-                                className="pf-u-ml-sm pointer cves-header-questionmark"
-                                color="var(--pf-global--secondary-color--100)"
-                                noVerticalAlign={false}
-                                size="sm"
-                                style={
-                                  Object {
-                                    "cursor": "pointer",
-                                    "fontSize": 16,
-                                    "verticalAlign": "0",
-                                  }
+                            <OutlinedQuestionCircleIcon
+                              className="pf-u-ml-sm"
+                              color="var(--pf-global--secondary-color--100)"
+                              noVerticalAlign={false}
+                              size="sm"
+                              style={
+                                Object {
+                                  "cursor": "pointer",
+                                  "fontSize": 16,
+                                  "verticalAlign": "0",
                                 }
-                              />
-                            </span>
+                              }
+                            />
                           }
                           zIndex={9999}
                         >
                           <FindRefWrapper
                             onFoundRef={[Function]}
                           >
-                            <span>
-                              <OutlinedQuestionCircleIcon
-                                className="pf-u-ml-sm pointer cves-header-questionmark"
-                                color="var(--pf-global--secondary-color--100)"
-                                noVerticalAlign={false}
-                                size="sm"
+                            <OutlinedQuestionCircleIcon
+                              className="pf-u-ml-sm"
+                              color="var(--pf-global--secondary-color--100)"
+                              noVerticalAlign={false}
+                              size="sm"
+                              style={
+                                Object {
+                                  "cursor": "pointer",
+                                  "fontSize": 16,
+                                  "verticalAlign": "0",
+                                }
+                              }
+                            >
+                              <svg
+                                aria-hidden={true}
+                                aria-labelledby={null}
+                                className="pf-u-ml-sm"
+                                fill="var(--pf-global--secondary-color--100)"
+                                height="1em"
+                                role="img"
                                 style={
                                   Object {
                                     "cursor": "pointer",
@@ -338,30 +346,14 @@ exports[`HeaderBreadcrumbs Should render correctly 1`] = `
                                     "verticalAlign": "0",
                                   }
                                 }
+                                viewBox="0 0 512 512"
+                                width="1em"
                               >
-                                <svg
-                                  aria-hidden={true}
-                                  aria-labelledby={null}
-                                  className="pf-u-ml-sm pointer cves-header-questionmark"
-                                  fill="var(--pf-global--secondary-color--100)"
-                                  height="1em"
-                                  role="img"
-                                  style={
-                                    Object {
-                                      "cursor": "pointer",
-                                      "fontSize": 16,
-                                      "verticalAlign": "0",
-                                    }
-                                  }
-                                  viewBox="0 0 512 512"
-                                  width="1em"
-                                >
-                                  <path
-                                    d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
-                                  />
-                                </svg>
-                              </OutlinedQuestionCircleIcon>
-                            </span>
+                                <path
+                                  d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                                />
+                              </svg>
+                            </OutlinedQuestionCircleIcon>
                           </FindRefWrapper>
                         </Popper>
                       </Popover>

--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -284,3 +284,6 @@ export const patchSetUnassignSystemsNotifications = (systemsCount) => ({
         variant: 'success'
     }
 });
+
+export const TEMPLATES_DOCS_LINK = 'https://access.redhat.com/documentation/en-us/red_hat_insights/2022/html/'
+    + 'system_patching_using_ansible_playbooks_via_remediations/index';


### PR DESCRIPTION
# Description

Associated Jira ticket: [SPM-1548](https://issues.redhat.com/browse/SPM-1548)
Associated mockup: https://www.sketch.com/s/598ac9a1-16ce-47b1-8515-e79928a2b2fb/a/ELywAxO

- update header title in Patch Templates page from 'Patch template' to 'Templates'.
- add popover next to header title
- update `frontend.yml` with current information

# How to test the PR

Verify correspondence of Template list page header with the [mockup](https://www.sketch.com/s/598ac9a1-16ce-47b1-8515-e79928a2b2fb/a/ELywAxO).

# Mockup
![Screenshot from 2023-02-15 21-14-58](https://user-images.githubusercontent.com/8426204/219152444-d09f36ba-1038-47bb-862c-8688297ec427.png)

# Before the change
![Screenshot from 2023-02-15 21-13-32](https://user-images.githubusercontent.com/8426204/219152494-10b8d857-bbc6-47a2-a8f5-175da255dfe1.png)

# After the change
![Screenshot from 2023-02-15 21-07-51](https://user-images.githubusercontent.com/8426204/219152520-54f55a6e-7bc2-497a-848e-d23110628f1e.png)

# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [x] README.md is updated if necessary
- [ ] Needs additional dependent work
