### PR TITLE
Draft: investigate bundle size

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -138,7 +138,7 @@ module.exports = {
         },
         production: {
             plugins: [
-                patternflyTransformImports('js'),
+                patternflyTransformImports('esm'),
                 fecTransformImports('cjs')
             ]
         },

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -1,28 +1,65 @@
 /* global require, module, __dirname */
-const { resolve } = require('path');
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
-const config = require('@redhat-cloud-services/frontend-components-config');
+const { resolve } = require("path");
+const BundleAnalyzerPlugin =
+    require("webpack-bundle-analyzer").BundleAnalyzerPlugin;
+const config = require("@redhat-cloud-services/frontend-components-config");
 const { config: webpackConfig, plugins } = config({
-    rootFolder: resolve(__dirname, '../')
+    rootFolder: resolve(__dirname, "../"),
 });
 
 plugins.push(
-    require('@redhat-cloud-services/frontend-components-config/federated-modules')({
-        root: resolve(__dirname, '../'),
-        exposes: {
-            './RootApp': resolve(__dirname, '../src/AppEntry'),
-            './SystemDetail': resolve(__dirname, '../src/index.js')
+    require("@redhat-cloud-services/frontend-components-config/federated-modules")(
+        {
+            root: resolve(__dirname, "../"),
+            exposes: {
+                "./RootApp": resolve(__dirname, "../src/AppEntry"),
+                "./SystemDetail": resolve(__dirname, "../src/index.js"),
+            },
         }
-    })
+    )
 );
 
-module.exports = function(env) {
-    if (env && env.analyze === 'true') {
+module.exports = function (env) {
+    if (env && env.analyze === "true") {
         plugins.push(new BundleAnalyzerPlugin());
     }
 
-    return {
+    webpackConfig.optimization = {
+        ...webpackConfig.optimization,
+        splitChunks: {
+            cacheGroups: {
+                vendor: {
+                    test: /\/node_modules\//,
+                    name: 'vendor',
+                    chunks: 'all'
+                },
+                main: {
+                    test: /\/src\//,
+                    name: 'main',
+                    chunks: 'all'
+                }
+            }
+        }
+    };
+
+    // webpackConfig.resolve.alias = {
+    //     ...webpackConfig.resolve.alias,
+    //     // '@patternfly/react-icons': false,
+    //     // '@patternfly/react-table': false,
+    //     '@data-driven-forms/react-form-renderer': false,
+    //     '@redhat-cloud-services/frontend-components': false,
+    //     '@data-driven-forms/pf4-component-mapper': false,
+    //     '@redhat-cloud-services/frontend-components-notifications': false,
+    //     '@redhat-cloud-services/frontend-components-remediations': false,
+    //     '@redhat-cloud-services/frontend-components-utilities': false
+    // };
+
+    const asd = {
         ...webpackConfig,
         plugins
+    };
+
+    return {
+        ...asd
     };
 };

--- a/src/PresentationalComponents/Snippets/EmptyStates.js
+++ b/src/PresentationalComponents/Snippets/EmptyStates.js
@@ -5,8 +5,8 @@ import {
     EmptyStateVariant,
     Title
 } from '@patternfly/react-core';
-import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon';
-import LockIcon from '@patternfly/react-icons/dist/js/icons/lock-icon';
+import { SearchIcon } from '@patternfly/react-icons';
+import { LockIcon } from '@patternfly/react-icons';
 import React from 'react';
 import { intl } from '../../Utilities/IntlProvider';
 import messages from '../../Messages';

--- a/src/PresentationalComponents/Snippets/Error.js
+++ b/src/PresentationalComponents/Snippets/Error.js
@@ -1,5 +1,5 @@
 import { Card, EmptyState, EmptyStateBody, EmptyStateIcon, EmptyStateVariant, Title } from '@patternfly/react-core';
-import FrownOpenIcon from '@patternfly/react-icons/dist/js/icons/frown-open-icon';
+import { FrownOpenIcon } from '@patternfly/react-icons';
 import propTypes from 'prop-types';
 import React from 'react';
 import { intl } from '../../Utilities/IntlProvider';

--- a/src/PresentationalComponents/Snippets/ExternalLink.js
+++ b/src/PresentationalComponents/Snippets/ExternalLink.js
@@ -1,5 +1,5 @@
 import { Flex, FlexItem } from '@patternfly/react-core';
-import ExternalLinkSquareAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-square-alt-icon';
+import { ExternalLinkSquareAltIcon } from '@patternfly/react-icons';
 import propTypes from 'prop-types';
 import React from 'react';
 

--- a/src/PresentationalComponents/TableView/TableViewAssets.js
+++ b/src/PresentationalComponents/TableView/TableViewAssets.js
@@ -1,4 +1,4 @@
-import { cellWidth, expandable, sortable } from '@patternfly/react-table/dist/js';
+import { cellWidth, expandable, sortable } from '@patternfly/react-table';
 import messages from '../../Messages';
 import { intl } from '../../Utilities/IntlProvider';
 

--- a/src/SmartComponents/PatchSet/PatchSetAssets.js
+++ b/src/SmartComponents/PatchSet/PatchSetAssets.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button, Tooltip } from '@patternfly/react-core';
-import { sortable } from '@patternfly/react-table/dist/js';
+import { sortable } from '@patternfly/react-table';
 import {
     EllipsisVIcon
 } from '@patternfly/react-icons';

--- a/src/SmartComponents/Remediation/AsyncRemediationButton.js
+++ b/src/SmartComponents/Remediation/AsyncRemediationButton.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { useDispatch } from 'react-redux';
 import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 import { Spinner } from '@patternfly/react-core';
-import { spinnerSize } from '@patternfly/react-core/dist/js/components/Spinner/Spinner';
+// import { spinnerSize } from '@patternfly/react-core/dist/js/components/Spinner/Spinner';
 import { intl } from '../../Utilities/IntlProvider';
 import messages from '../../Messages';
 
@@ -19,7 +19,7 @@ const AsyncRemediationButton = ({ remediationProvider, isDisabled, isLoading }) 
         <AsyncComponent
             appName="remediations"
             module="./RemediationButton"
-            fallback={<Spinner size={spinnerSize.lg} />}
+            fallback={<Spinner size="lg" />}
             dataProvider={remediationProvider}
             onRemediationCreated={handleRemediationSuccess}
             isDisabled={isDisabled}

--- a/src/Utilities/Helpers.js
+++ b/src/Utilities/Helpers.js
@@ -5,7 +5,7 @@ import {
     EnhancementIcon, InfoCircleIcon, LongArrowAltUpIcon,
     SecurityIcon
 } from '@patternfly/react-icons';
-import { SortByDirection } from '@patternfly/react-table/dist/js';
+import { SortByDirection } from '@patternfly/react-table';
 import flatten from 'lodash/flatten';
 import findIndex from 'lodash/findIndex';
 import pickBy from 'lodash/pickBy';

--- a/src/Utilities/Helpers.test.js
+++ b/src/Utilities/Helpers.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { SortByDirection } from '@patternfly/react-table/dist/js';
+import { SortByDirection } from '@patternfly/react-table';
 import toJson from 'enzyme-to-json';
 import { publicDateOptions, remediationIdentifiers } from '../Utilities/constants';
 import { addOrRemoveItemFromSet, arrayFromObj, buildFilterChips, changeListParams, convertLimitOffset, 

--- a/src/Utilities/Hooks.js
+++ b/src/Utilities/Hooks.js
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import { useLocation, useHistory } from 'react-router-dom';
-import { SortByDirection } from '@patternfly/react-table/dist/js';
+import { SortByDirection } from '@patternfly/react-table';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux/actions/notifications';
 import { downloadFile } from '@redhat-cloud-services/frontend-components-utilities/helpers';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';

--- a/src/Utilities/Hooks.test.js
+++ b/src/Utilities/Hooks.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { SortByDirection } from '@patternfly/react-table/dist/js';
+import { SortByDirection } from '@patternfly/react-table';
 import { useEntitlements, useHandleRefresh, usePagePerPage, 
     usePerPageSelect, useRemoveFilter, useSetPage, useSortColumn } from './Hooks';
 import { packagesListDefaultFilters } from './constants';

--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -1,7 +1,7 @@
-import BugIcon from '@patternfly/react-icons/dist/js/icons/bug-icon';
-import EnhancementIcon from '@patternfly/react-icons/dist/js/icons/enhancement-icon';
-import SecurityIcon from '@patternfly/react-icons/dist/js/icons/security-icon';
-import FlagIcon from '@patternfly/react-icons/dist/js/icons/flag-icon';
+import { BugIcon } from '@patternfly/react-icons';
+import { EnhancementIcon } from '@patternfly/react-icons';
+import { SecurityIcon } from '@patternfly/react-icons';
+import { FlagIcon } from '@patternfly/react-icons';
 import React from 'react';
 import { subtractDate } from './Helpers';
 


### PR DESCRIPTION
Try to bundle only esm packages. Before there was a mixture of js and esm.

Before with mixed dist/esm imports:
All: 3.56 MB
vendor: 3.36 MB

After only esm imports:
All: 3.18 MB
Vendor: 2.98 MB

However, the largest space offender appears to be when federated modules is used. In testing, after disabling `@redhat-cloud-services/frontend-components-config/federated-modules` plugin in prod.webpack.config.js, it can be seen:

Disable module federation:
All: 1.2 MB
Vendor: 1 MB

The issue appears to be that once module federation is enabled, dependencies are fully bundled (and not just the used imports).

I am not sure yet about a solution for this, but this issue is also being addressed here:
https://github.com/patternfly/patternfly-react/issues/8357