### PR TITLE
feat: Table links and sorting fix

### DIFF
--- a/src/SmartComponents/AdvisorySystems/AdvisorySystems.js
+++ b/src/SmartComponents/AdvisorySystems/AdvisorySystems.js
@@ -14,13 +14,13 @@ import { changeAffectedSystemsParams, clearAdvisorySystemsReducer,
     clearInventoryReducer, systemSelectAction } from '../../store/Actions/Actions';
 import { inventoryEntitiesReducer, modifyInventory } from '../../store/Reducers/InventoryEntitiesReducer';
 import { exportAdvisorySystemsCSV, exportAdvisorySystemsJSON, fetchAdvisorySystems } from '../../Utilities/api';
-import { remediationIdentifiers } from '../../Utilities/constants';
+import { featureFlags, remediationIdentifiers } from '../../Utilities/constants';
 import {
     arrayFromObj, decodeQueryparams, persistantParams,
     remediationProvider, removeUndefinedObjectKeys
 } from '../../Utilities/Helpers';
 import {
-    useBulkSelectConfig, useGetEntities, useOnExport, useRemoveFilter
+    useBulkSelectConfig, useFeatureFlag, useGetEntities, useOnExport, useRemoveFilter
 } from '../../Utilities/Hooks';
 import { intl } from '../../Utilities/IntlProvider';
 import { systemsListColumns, systemsRowActions } from '../Systems/SystemsListAssets';
@@ -38,6 +38,8 @@ const AdvisorySystems = ({ advisoryName }) => {
         setRemediationModalCmp
     ] = React.useState(() => () => null);
     const history = useHistory();
+
+    const isPatchSetEnabled = useFeatureFlag(featureFlags.patch_set);
 
     const decodedParams = decodeQueryparams(history.location.search);
     const systems = useSelector(({ entities }) => entities?.rows || [], shallowEqual);
@@ -135,7 +137,7 @@ const AdvisorySystems = ({ advisoryName }) => {
                     initialLoading
                     ignoreRefresh
                     hideFilters={{ all: true, tags: false }}
-                    columns={(defaultColumns) => systemsColumnsMerger(defaultColumns, false)}
+                    columns={(defaultColumns) => systemsColumnsMerger(defaultColumns, isPatchSetEnabled)}
                     showTags
                     customFilters={{
                         patchParams: {

--- a/src/SmartComponents/PatchSetDetail/PatchSetDetailAssets.js
+++ b/src/SmartComponents/PatchSetDetail/PatchSetDetailAssets.js
@@ -2,23 +2,20 @@ import { sortable } from '@patternfly/react-table/dist/js';
 
 export const patchSetDetailColumns = [
     {
-        key: 'name',
+        key: 'display_name',
         title: 'Name',
         transforms: [sortable]
     },
     {
         key: 'operating_system',
-        title: 'OS',
-        transforms: [sortable]
+        title: 'OS'
     },
     {
         key: 'tags',
-        title: 'Tags',
-        transforms: [sortable]
+        title: 'Tags'
     },
     {
         key: 'last_seen',
-        title: 'Last seen',
-        transforms: [sortable]
+        title: 'Last seen'
     }
 ];

--- a/src/SmartComponents/Systems/SystemsListAssets.js
+++ b/src/SmartComponents/Systems/SystemsListAssets.js
@@ -1,3 +1,5 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
 import { fetchApplicableSystemAdvisoriesApi } from '../../Utilities/api';
 import { remediationIdentifiers } from '../../Utilities/constants';
 import { createAdvisoriesIcons, createUpgradableColumn,
@@ -8,7 +10,9 @@ export const systemsListColumns = (isPatchSetEnabled = false) => [
     ...(isPatchSetEnabled ? [{
         key: 'baseline_name',
         title: 'Template',
-        renderFunc: value => value || 'No template',
+        renderFunc: (value, _, row) => value
+            ? <Link to={{ pathname: `/templates/${row.baseline_id}` }}>{value}</Link>
+            : 'No template',
         props: {
             width: 5
         }

--- a/src/Utilities/DataMappers.js
+++ b/src/Utilities/DataMappers.js
@@ -396,7 +396,7 @@ export const createPatchSetDetailRows = (rows) => {
                 cells: [
                     {
                         title: (
-                            <Link to={{ pathname: `/systems/${row.id}` }}>
+                            <Link to={{ pathname: `/systems/${row.inventory_id}` }}>
                                 {row.attributes.display_name}
                             </Link>
                         )

--- a/src/Utilities/api.js
+++ b/src/Utilities/api.js
@@ -61,7 +61,7 @@ export const fetchApplicablePackagesApi = params => {
 
 export const fetchAdvisorySystems = params => {
     const { id, ...args } = params;
-    return createApiCall(`/advisories/${id}/systems`, 'v2', 'get', prepareEntitiesParams(args));
+    return createApiCall(`/advisories/${id}/systems`, 'v3', 'get', prepareEntitiesParams(args));
 };
 
 export const fetchPackageSystems = params => {


### PR DESCRIPTION
# Description
- Link from Advisory detail to Template detail page
- Fix sorting on Template detail page
- Link from Template detail to Systems detail page

## Testing instructions
a) Go to Advisory detail page and in the table find a system that has a template. Verify you can navigate to Template detail page by clicking on the system name inside the table.
b) In Template detail page you should be able to correctly sort the table by display name. All other columns should have sorting indicators disabled.
c) Go to Template detail page and click on any system name inside the first column. You should be correctly navigated to Systems detail page of clicked system.

