### PR TITLE
Template system unassignment from Template detail page

### DIFF
--- a/src/SmartComponents/Modals/Helpers.js
+++ b/src/SmartComponents/Modals/Helpers.js
@@ -5,7 +5,10 @@ import messages from '../../Messages';
 import { fetchSystems } from '../../Utilities/api';
 
 export const filterSystemsWithoutSets = (systemsIDs) =>  {
-    return fetchSystems({ limit: -1, 'filter[baseline_name]': 'neq:' }).then((allSystemsWithPatchSet) => {
+    return fetchSystems({
+        limit: -1, 'filter[baseline_name]': 'neq:',
+        filter: { stale: [true, false] }
+    }).then((allSystemsWithPatchSet) => {
         return systemsIDs.filter(systemID =>
             allSystemsWithPatchSet?.data.some(system => system.id === systemID)
         );

--- a/src/SmartComponents/Modals/UnassignSystemsModal.js
+++ b/src/SmartComponents/Modals/UnassignSystemsModal.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { Fragment, useEffect, useState } from 'react';
 import propTypes from 'prop-types';
 import { Modal, Button, Grid, Skeleton } from '@patternfly/react-core';
 import { injectIntl } from 'react-intl';
@@ -27,6 +27,8 @@ const UnassignSystemsModal = ({ unassignSystemsModalState = {}, setUnassignSyste
     const handleUnassignment = useUnassignSystemsHook(handleModalToggle, systemsWithPatchSet);
 
     useEffect(() => {
+        setSystemsLoading(true);
+
         filterSystemsWithoutSets(systemsIDs).then(result => {
             setSystemWithPatchSet(result);
             setSystemsLoading(false);
@@ -43,7 +45,12 @@ const UnassignSystemsModal = ({ unassignSystemsModalState = {}, setUnassignSyste
             onClose={handleModalClose}
             titleIconVariant="warning"
             actions={[
-                <Button key="confirm" variant="danger" onClick={handleUnassignment} isDisabled={systemsWithPatchSet.length === 0}>
+                <Button
+                    key="confirm"
+                    variant="danger"
+                    onClick={handleUnassignment}
+                    isDisabled={systemsLoading || systemsWithPatchSet.length === 0}
+                >
                     {intl.formatMessage(messages.labelsRemove)}
                 </Button>,
                 <Button key="cancel" variant="link" onClick={handleModalClose}>
@@ -51,13 +58,17 @@ const UnassignSystemsModal = ({ unassignSystemsModalState = {}, setUnassignSyste
                 </Button>
             ]}
         >
-            <Grid container hasGutter>
-                {systemsLoading && <Skeleton />}
-                {(!systemsLoading && systemsWithPatchSet.length !== 0) &&
-                    renderUnassignModalMessages('textUnassignSystemsStatement', systemsWithPatchSet.length, intl)
-                }
-                {(!systemsLoading && systemsWithoutPatchSetCount > 0) &&
-                    renderUnassignModalMessages('textUnassignSystemsWarning', systemsWithoutPatchSetCount, intl)
+            <Grid hasGutter>
+                {systemsLoading
+                    ? <Skeleton />
+                    : <Fragment>
+                        {systemsWithPatchSet.length > 0 &&
+                            renderUnassignModalMessages('textUnassignSystemsStatement', systemsWithPatchSet.length, intl)
+                        }
+                        {systemsWithoutPatchSetCount > 0 &&
+                            renderUnassignModalMessages('textUnassignSystemsWarning', systemsWithoutPatchSetCount, intl)
+                        }
+                    </Fragment>
                 }
             </Grid>
         </Modal>

--- a/src/SmartComponents/Modals/__snapshots__/UnassignSystemsModal.test.js.snap
+++ b/src/SmartComponents/Modals/__snapshots__/UnassignSystemsModal.test.js.snap
@@ -460,12 +460,10 @@ exports[`UnassignSystemsModal should match the snapshots 1`] = `
                             id="pf-modal-part-2"
                           >
                             <Grid
-                              container={true}
                               hasGutter={true}
                             >
                               <div
                                 className="pf-l-grid pf-m-gutter"
-                                container={true}
                               >
                                 <Skeleton>
                                   <div

--- a/src/Utilities/DataMappers.js
+++ b/src/Utilities/DataMappers.js
@@ -390,9 +390,9 @@ export const createPatchSetDetailRows = (rows) => {
         rows &&
         rows.map(row => {
             return {
-                id: row.id,
+                id: row.inventory_id,
                 displayName: row.display_name,
-                key: row.id,
+                key: row.inventory_id,
                 cells: [
                     {
                         title: (


### PR DESCRIPTION
# Description

Associated Jira ticket: [SPM-1904](https://issues.redhat.com/browse/SPM-1904), [SPM-1907](https://issues.redhat.com/browse/SPM-1907), [SPM-1927](https://issues.redhat.com/browse/SPM-1927)

From System list page:
It was not possible to remove template from stale systems. This is now fixed.

From Template detail page:
Add table row actions accessible with patch:template:write permission, these actions contain action to unassign system from a template.

## Testing instructions

**a) System list page:**
Find a system that has template assigned.

i) Unassign system from template using row actions kebab.
ii) Unassign multiple systems from template using bulk action kebab in the table toolbar. Make sure to try to select some systems that do have template and some that don't - modal should then point out to you that some systems don't have a template and won't be affected.

**b) Template detail page:**
Unassign system from template using row actions kebab.
Bulk action is not currently implemented.