### PR TITLE
Remove template docs links

### DIFF
--- a/src/PresentationalComponents/Snippets/EmptyStates.js
+++ b/src/PresentationalComponents/Snippets/EmptyStates.js
@@ -11,8 +11,7 @@ import LockIcon from '@patternfly/react-icons/dist/js/icons/lock-icon';
 import React from 'react';
 import { intl } from '../../Utilities/IntlProvider';
 import messages from '../../Messages';
-import { ExternalLinkAltIcon, PlusCircleIcon } from '@patternfly/react-icons';
-import { TEMPLATES_DOCS_LINK } from '../../Utilities/constants';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 import PropTypes from 'prop-types';
 
 export const EmptyAdvisoryList = () => (
@@ -83,11 +82,13 @@ export const NoPatchSetList = ({ Button }) => (
             {intl.formatMessage(messages.statesNoTemplateBody)}
             <br />
             <br />
+            {/*
             <a href={TEMPLATES_DOCS_LINK} target="__blank" rel="noopener noreferrer">
                 {intl.formatMessage(messages.statesNoTemplateLink)} <ExternalLinkAltIcon />
             </a>
             <br />
             <br />
+            */}
             <Button />
         </EmptyStateBody>
     </EmptyState>

--- a/src/SmartComponents/PatchSet/PatchSet.js
+++ b/src/SmartComponents/PatchSet/PatchSet.js
@@ -23,11 +23,11 @@ import {
     patchSetRowActions, CustomActionsToggle
 } from './PatchSetAssets';
 import PatchSetWizard from '../PatchSetWizard/PatchSetWizard';
-import { patchSetDeleteNotifications, TEMPLATES_DOCS_LINK } from '../../Utilities/constants';
+import { patchSetDeleteNotifications } from '../../Utilities/constants';
 import usePatchSetState from '../../Utilities/usePatchSetState';
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import { useOnSelect, ID_API_ENDPOINTS } from '../../Utilities/useOnSelect';
-import { ExternalLinkAltIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { Popover } from '@patternfly/react-core';
 import DeleteSetModal from '../Modals/DeleteSetModal';
 import { NoPatchSetList, NoSmartManagement } from '../../PresentationalComponents/Snippets/EmptyStates';
@@ -185,11 +185,13 @@ const PatchSet = () => {
                         bodyContent={
                             intl.formatMessage(messages.templatePopoverBody)
                         }
+                        /*
                         footerContent={
                             <a href={TEMPLATES_DOCS_LINK} target="__blank" rel="noopener noreferrer">
                                 {intl.formatMessage(messages.linksLearnMore)} <ExternalLinkAltIcon />
                             </a>
                         }
+                        */
                     >
                         <OutlinedQuestionCircleIcon
                             color="var(--pf-global--secondary-color--100)"

--- a/src/SmartComponents/PatchSet/__snapshots__/PatchSet.test.js.snap
+++ b/src/SmartComponents/PatchSet/__snapshots__/PatchSet.test.js.snap
@@ -134,21 +134,6 @@ exports[`HeaderBreadcrumbs Should render correctly 1`] = `
                 aria-labelledby="template-header-title-popover"
                 bodyContent="Templates allow you to control the scope of package and advisory updates to be installed on selected systems."
                 enableFlip={true}
-                footerContent={
-                  <a
-                    href="https://access.redhat.com/documentation/en-us/red_hat_insights/2022/html/system_patching_using_ansible_playbooks_via_remediations/index"
-                    rel="noopener noreferrer"
-                    target="__blank"
-                  >
-                    Learn more
-                     
-                    <ExternalLinkAltIcon
-                      color="currentColor"
-                      noVerticalAlign={false}
-                      size="sm"
-                    />
-                  </a>
-                }
                 hasAutoWidth={true}
                 headerContent="About Templates"
                 id="template-header-title-popover"
@@ -197,21 +182,6 @@ exports[`HeaderBreadcrumbs Should render correctly 1`] = `
                               aria-labelledby="template-header-title-popover"
                               bodyContent="Templates allow you to control the scope of package and advisory updates to be installed on selected systems."
                               enableFlip={true}
-                              footerContent={
-                                <a
-                                  href="https://access.redhat.com/documentation/en-us/red_hat_insights/2022/html/system_patching_using_ansible_playbooks_via_remediations/index"
-                                  rel="noopener noreferrer"
-                                  target="__blank"
-                                >
-                                  Learn more
-                                   
-                                  <ExternalLinkAltIcon
-                                    color="currentColor"
-                                    noVerticalAlign={false}
-                                    size="sm"
-                                  />
-                                </a>
-                              }
                               hasAutoWidth={true}
                               headerContent="About Templates"
                               id="template-header-title-popover"
@@ -255,21 +225,6 @@ exports[`HeaderBreadcrumbs Should render correctly 1`] = `
                                 aria-labelledby="template-header-title-popover"
                                 bodyContent="Templates allow you to control the scope of package and advisory updates to be installed on selected systems."
                                 enableFlip={true}
-                                footerContent={
-                                  <a
-                                    href="https://access.redhat.com/documentation/en-us/red_hat_insights/2022/html/system_patching_using_ansible_playbooks_via_remediations/index"
-                                    rel="noopener noreferrer"
-                                    target="__blank"
-                                  >
-                                    Learn more
-                                     
-                                    <ExternalLinkAltIcon
-                                      color="currentColor"
-                                      noVerticalAlign={false}
-                                      size="sm"
-                                    />
-                                  </a>
-                                }
                                 hasAutoWidth={true}
                                 headerContent="About Templates"
                                 id="template-header-title-popover"
@@ -349,23 +304,6 @@ exports[`HeaderBreadcrumbs Should render correctly 1`] = `
                                         >
                                           Templates allow you to control the scope of package and advisory updates to be installed on selected systems.
                                         </PopoverBody>
-                                        <PopoverFooter
-                                          id="popover-template-header-title-popover-footer"
-                                        >
-                                          <a
-                                            href="https://access.redhat.com/documentation/en-us/red_hat_insights/2022/html/system_patching_using_ansible_playbooks_via_remediations/index"
-                                            rel="noopener noreferrer"
-                                            target="__blank"
-                                          >
-                                            Learn more
-                                             
-                                            <ExternalLinkAltIcon
-                                              color="currentColor"
-                                              noVerticalAlign={false}
-                                              size="sm"
-                                            />
-                                          </a>
-                                        </PopoverFooter>
                                       </PopoverContent>
                                     </ForwardRef>
                                   }

--- a/src/SmartComponents/PatchSetWizard/PatchSetWizard.js
+++ b/src/SmartComponents/PatchSetWizard/PatchSetWizard.js
@@ -22,8 +22,6 @@ import { usePatchSetApi } from '../../Utilities/Hooks';
 import { intl } from '../../Utilities/IntlProvider';
 import messages from '../../Messages';
 import { fetchPatchSetAction, clearPatchSetAction, fetchPatchSetSystemsAction } from '../../store/Actions/Actions';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-import { TEMPLATES_DOCS_LINK } from '../../Utilities/constants';
 
 export const PatchSetWizard = ({ systemsIDs, setBaselineState, patchSetID }) => {
     //if system ids exist, those are being assigned. Likewise if patchSetID exists, it is being edited
@@ -119,10 +117,11 @@ export const PatchSetWizard = ({ systemsIDs, setBaselineState, patchSetID }) => 
                         description={
                             <Fragment>
                                 {intl.formatMessage(messages.templateDescription)}
-                                <a href={TEMPLATES_DOCS_LINK} target="__blank" rel="noopener noreferrer" className="pf-u-ml-sm">
+                                {/*<a href={TEMPLATES_DOCS_LINK} target="__blank" rel="noopener noreferrer"
+                                    className="pf-u-ml-sm">
                                     {intl.formatMessage(messages.labelsDocumentation)}
                                     <ExternalLinkAltIcon className="pf-u-ml-xs"/>
-                                </a>
+                                </a>*/}
                             </Fragment>
                         }
                         steps={[

--- a/src/SmartComponents/PatchSetWizard/WizardAssets.js
+++ b/src/SmartComponents/PatchSetWizard/WizardAssets.js
@@ -6,8 +6,6 @@ import { filterSelectedActiveSystemIDs } from '../../Utilities/Helpers';
 import dateValidator from '../../Utilities/dateValidator';
 import { sortable } from '@patternfly/react-table/dist/js';
 import React, { Fragment } from 'react';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-import { TEMPLATES_DOCS_LINK } from '../../Utilities/constants';
 
 export const reviewSystemColumns = [{
     key: 'display_name',
@@ -96,10 +94,11 @@ export const schema = (wizardType) => {
                 title: getWizardTitle(wizardType),
                 description: <Fragment>
                     {intl.formatMessage(messages.templateDescription)}
+                    {/*
                     <a href={TEMPLATES_DOCS_LINK} target="__blank" rel="noopener noreferrer" className="pf-u-ml-sm">
                         {intl.formatMessage(messages.labelsDocumentation)}
                         <ExternalLinkAltIcon className="pf-u-ml-xs"/>
-                    </a>
+                    </a>*/}
                 </Fragment>,
                 fields: [
                     {


### PR DESCRIPTION
As per PM's request (https://redhat-internal.slack.com/archives/CPS5FH07Q/p1678202549907769?thread_ts=1678119878.115079&cid=CPS5FH07Q) we are, for now, removing all documentation link related to templates.

These places include:
- Template list page empty state (displayed when user has 0 templates)
- Template list page title tooltip
- Template creation/editing wizard just below the wizard title