### PR TITLE
fix(SPM-1885): pass auth token to webworker

### DIFF
--- a/src/Utilities/useRemediationDataProvider.js
+++ b/src/Utilities/useRemediationDataProvider.js
@@ -56,11 +56,15 @@ const useRemediationDataProvider = (selectedRows, setRemediationLoading, remedia
     const remediationDataProvider = async () => {
         setRemediationLoading(true);
 
+        //Auth token must be added to webworker request as webworker does not have access
+        //to default token by platform
+        const authToken = await window.insights.chrome.auth.getToken();
         const remediationPairs = await prepareRemediationPairs(
             {
                 payload: removeUndefinedObjectKeys(selectedRows),
                 remediationType,
-                areAllSelected
+                areAllSelected,
+                authToken
             },
             dispatch
         );


### PR DESCRIPTION
# Description

Associated Jira ticket: https://issues.redhat.com/browse/SPM-1885

Fixes failing remediation by passing auth token explicitly. After platform decomissioned auth cooki, we have to pass it to webworker.

# How to test the PR

Please make sure remediation works as expected, the remediation gets indeed created.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
