### PR TITLE
Decouple step title and sidebar name in Template Wizard

### DIFF
--- a/src/Messages.js
+++ b/src/Messages.js
@@ -700,7 +700,7 @@ export default defineMessages({
     textTemplateReviewSystems: {
         id: 'textTemplateReviewSystems',
         description: 'text for patch template wizard',
-        defaultMessage: 'You will be able to adjust your selection anytime. A system can have only one patch template, \n therefore if you assign a new patch template to the system, it will be overwritten. '
+        defaultMessage: 'Select systems to apply your new template to, or skip this step to apply the template later. Note that if you apply a template to a system that already has one, the old template will be overwritten.'
     },
     textTemplateSelectedSystems: {
         id: 'textTemplateSelectedSystems',
@@ -806,6 +806,11 @@ export default defineMessages({
         id: 'titlesTemplateNoDescription',
         description: 'title with capital letters',
         defaultMessage: 'No description available'
+    },
+    titlesTemplateNoDescriptionProvided: {
+        id: 'titlesTemplateNoDescriptionProvided',
+        description: 'title with capital letters',
+        defaultMessage: 'No description provided'
     },
     titlesTemplateRemoveMultipleButton: {
         id: 'titlesTemplateRemoveMultipleButton',

--- a/src/SmartComponents/PatchSetWizard/PatchSetWizard.js
+++ b/src/SmartComponents/PatchSetWizard/PatchSetWizard.js
@@ -69,7 +69,8 @@ export const PatchSetWizard = ({ systemsIDs, setBaselineState, patchSetID }) => 
         configurationStep: {
             component: ConfigurationStepFields,
             systemsIDs: systemsIDs || [],
-            patchSetID
+            patchSetID,
+            wizardType
         },
         reviewSystems: {
             component: ReviewSystems,

--- a/src/SmartComponents/PatchSetWizard/WizardAssets.js
+++ b/src/SmartComponents/PatchSetWizard/WizardAssets.js
@@ -92,7 +92,6 @@ export const schema = (wizardType) => {
                 name: 'patch-set-wizard',
                 isDynamic: true,
                 inModal: true,
-                showTitles: true,
                 title: getWizardTitle(wizardType),
                 description: <Fragment>
                     {intl.formatMessage(messages.templateDescription)}
@@ -131,9 +130,7 @@ export const schema = (wizardType) => {
                             }
                         ]
                     }
-
                 ]
-
             }
         ]
     });

--- a/src/SmartComponents/PatchSetWizard/steps/ConfigurationStepFields.js
+++ b/src/SmartComponents/PatchSetWizard/steps/ConfigurationStepFields.js
@@ -17,7 +17,7 @@ import ConfigurationFields from '../InputFields/ConfigurationFields';
 
 import { convertIsoToDate } from '../../../Utilities/Helpers';
 
-const ConfigurationStepFields = ({ systemsIDs, patchSetID }) => {
+const ConfigurationStepFields = ({ systemsIDs, patchSetID, wizardType }) => {
 
     const formOptions = useFormApi();
     const shouldShowRadioButtons = (!patchSetID && systemsIDs?.length !== 0) || false;
@@ -45,6 +45,13 @@ const ConfigurationStepFields = ({ systemsIDs, patchSetID }) => {
 
     return (
         <Stack hasGutter>
+            <StackItem>
+                <TextContent>
+                    <Text component="h2">
+                        {intl.formatMessage(wizardType === 'edit' ? messages.templateEdit : messages.templateNew)}
+                    </Text>
+                </TextContent>
+            </StackItem>
             {shouldShowRadioButtons && <TextContent style={{ marginTop: '-15px' }}>
                 <Text component={TextVariants.p}>
                     {intl.formatMessage(
@@ -93,6 +100,7 @@ const ConfigurationStepFields = ({ systemsIDs, patchSetID }) => {
 
 ConfigurationStepFields.propTypes = {
     systemsIDs: propTypes.array,
-    patchSetID: propTypes.string
+    patchSetID: propTypes.string,
+    wizardType: propTypes.string
 };
 export default ConfigurationStepFields;

--- a/src/SmartComponents/PatchSetWizard/steps/ReviewPatchSet.js
+++ b/src/SmartComponents/PatchSetWizard/steps/ReviewPatchSet.js
@@ -35,6 +35,13 @@ const ReviewPatchSet = () => {
     return (
         <Stack hasGutter>
             <StackItem>
+                <TextContent>
+                    <Text component="h2">
+                        {intl.formatMessage(messages.templateReview)}
+                    </Text>
+                </TextContent>
+            </StackItem>
+            <StackItem>
                 <TextContent style={{ marginTop: '-15px' }}>
                     <Text component={TextVariants.p}>
                         {intl.formatMessage(messages.textPatchTemplateReview)}
@@ -59,7 +66,7 @@ const ReviewPatchSet = () => {
                     <TextList component={TextListVariants.dl}>
                         {renderTextListItem('labelsColumnsName', name)}
                         {renderTextListItem('labelsDescription', description
-                            || intl.formatMessage(messages.titlesTemplateNoDescription))}
+                            || intl.formatMessage(messages.titlesTemplateNoDescriptionProvided))}
                     </TextList>
                 </TextContent>
             </StackItem>

--- a/src/SmartComponents/PatchSetWizard/steps/ReviewSystems.js
+++ b/src/SmartComponents/PatchSetWizard/steps/ReviewSystems.js
@@ -119,6 +119,13 @@ export const ReviewSystems = ({ systemsIDs = [], ...props }) => {
     return (
         <Stack hasGutter>
             <StackItem>
+                <TextContent>
+                    <Text component="h2">
+                        {intl.formatMessage(messages.templateSelectSystems)}
+                    </Text>
+                </TextContent>
+            </StackItem>
+            <StackItem>
                 <TextContent style={{ marginTop: '-15px' }}>
                     <Text component={TextVariants.p}>
                         {intl.formatMessage(messages.textTemplateReviewSystems)}

--- a/src/SmartComponents/PatchSetWizard/steps/__snapshots__/ReviewPatchSet.test.js.snap
+++ b/src/SmartComponents/PatchSetWizard/steps/__snapshots__/ReviewPatchSet.test.js.snap
@@ -12,6 +12,31 @@ exports[`ReviewPatchSet.js Should display all Patch Template configuration 1`] =
         <div
           className="pf-l-stack__item"
         >
+          <TextContent>
+            <div
+              className="pf-c-content"
+            >
+              <Text
+                component="h2"
+              >
+                <h2
+                  className=""
+                  data-ouia-component-id="OUIA-Generated-Text-1"
+                  data-ouia-component-type="PF4/Text"
+                  data-ouia-safe={true}
+                  data-pf-content={true}
+                >
+                  Review 
+                </h2>
+              </Text>
+            </div>
+          </TextContent>
+        </div>
+      </StackItem>
+      <StackItem>
+        <div
+          className="pf-l-stack__item"
+        >
           <TextContent
             style={
               Object {
@@ -32,7 +57,7 @@ exports[`ReviewPatchSet.js Should display all Patch Template configuration 1`] =
               >
                 <p
                   className=""
-                  data-ouia-component-id="OUIA-Generated-Text-1"
+                  data-ouia-component-id="OUIA-Generated-Text-2"
                   data-ouia-component-type="PF4/Text"
                   data-ouia-safe={true}
                   data-pf-content={true}
@@ -58,7 +83,7 @@ exports[`ReviewPatchSet.js Should display all Patch Template configuration 1`] =
               >
                 <h2
                   className="pf-u-mt-md pf-u-mb-sm"
-                  data-ouia-component-id="OUIA-Generated-Text-2"
+                  data-ouia-component-id="OUIA-Generated-Text-3"
                   data-ouia-component-type="PF4/Text"
                   data-ouia-safe={true}
                   data-pf-content={true}
@@ -120,7 +145,7 @@ exports[`ReviewPatchSet.js Should display all Patch Template configuration 1`] =
               >
                 <h2
                   className="pf-u-mt-md pf-u-mb-sm"
-                  data-ouia-component-id="OUIA-Generated-Text-3"
+                  data-ouia-component-id="OUIA-Generated-Text-4"
                   data-ouia-component-type="PF4/Text"
                   data-ouia-safe={true}
                   data-pf-content={true}
@@ -210,7 +235,7 @@ exports[`ReviewPatchSet.js Should display all Patch Template configuration 1`] =
               >
                 <h2
                   className="pf-u-mt-md pf-u-mb-sm"
-                  data-ouia-component-id="OUIA-Generated-Text-4"
+                  data-ouia-component-id="OUIA-Generated-Text-5"
                   data-ouia-component-type="PF4/Text"
                   data-ouia-safe={true}
                   data-pf-content={true}
@@ -275,6 +300,31 @@ exports[`ReviewPatchSet.js Should display available configuration fields only 1`
         <div
           className="pf-l-stack__item"
         >
+          <TextContent>
+            <div
+              className="pf-c-content"
+            >
+              <Text
+                component="h2"
+              >
+                <h2
+                  className=""
+                  data-ouia-component-id="OUIA-Generated-Text-6"
+                  data-ouia-component-type="PF4/Text"
+                  data-ouia-safe={true}
+                  data-pf-content={true}
+                >
+                  Review 
+                </h2>
+              </Text>
+            </div>
+          </TextContent>
+        </div>
+      </StackItem>
+      <StackItem>
+        <div
+          className="pf-l-stack__item"
+        >
           <TextContent
             style={
               Object {
@@ -295,7 +345,7 @@ exports[`ReviewPatchSet.js Should display available configuration fields only 1`
               >
                 <p
                   className=""
-                  data-ouia-component-id="OUIA-Generated-Text-5"
+                  data-ouia-component-id="OUIA-Generated-Text-7"
                   data-ouia-component-type="PF4/Text"
                   data-ouia-safe={true}
                   data-pf-content={true}
@@ -321,7 +371,7 @@ exports[`ReviewPatchSet.js Should display available configuration fields only 1`
               >
                 <h2
                   className="pf-u-mt-md pf-u-mb-sm"
-                  data-ouia-component-id="OUIA-Generated-Text-6"
+                  data-ouia-component-id="OUIA-Generated-Text-8"
                   data-ouia-component-type="PF4/Text"
                   data-ouia-safe={true}
                   data-pf-content={true}
@@ -383,7 +433,7 @@ exports[`ReviewPatchSet.js Should display available configuration fields only 1`
               >
                 <h2
                   className="pf-u-mt-md pf-u-mb-sm"
-                  data-ouia-component-id="OUIA-Generated-Text-7"
+                  data-ouia-component-id="OUIA-Generated-Text-9"
                   data-ouia-component-type="PF4/Text"
                   data-ouia-safe={true}
                   data-pf-content={true}
@@ -450,7 +500,7 @@ exports[`ReviewPatchSet.js Should display available configuration fields only 1`
                     <dd
                       className=""
                     >
-                      No description available
+                      No description provided
                     </dd>
                   </TextListItem>
                 </dl>
@@ -473,7 +523,7 @@ exports[`ReviewPatchSet.js Should display available configuration fields only 1`
               >
                 <h2
                   className="pf-u-mt-md pf-u-mb-sm"
-                  data-ouia-component-id="OUIA-Generated-Text-8"
+                  data-ouia-component-id="OUIA-Generated-Text-10"
                   data-ouia-component-type="PF4/Text"
                   data-ouia-safe={true}
                   data-pf-content={true}


### PR DESCRIPTION
# Description

Associated Jira ticket: [SPM-1893](https://issues.redhat.com/browse/SPM-1893)

- until now the title of the step had to be the same for header label and sidebar label, but in the future we will need them to be different so I decoupled these strings by removing `showTitles: true` and manually adding header to each step
- update System selection step text to the [latest mockups](https://www.sketch.com/s/598ac9a1-16ce-47b1-8515-e79928a2b2fb/a/eKRw04p)
- if user leaves description field empty, review step will state 'No description provided' instead of 'No description available'
