### PR TITLE
Template detail empty state button launches wizard

### DIFF
--- a/src/SmartComponents/PatchSetDetail/PatchSetDetail.js
+++ b/src/SmartComponents/PatchSetDetail/PatchSetDetail.js
@@ -188,11 +188,11 @@ const PatchSetDetail = () => {
                     onConfirm={deleteSet}
                 />
                 {patchSetState.isPatchSetWizardOpen &&
-                <PatchSetWizard
-                    systemsIDs={patchSetState.systemsIDs}
-                    setBaselineState={setPatchSetState}
-                    patchSetID={patchSetId}
-                />}
+                    <PatchSetWizard
+                        systemsIDs={patchSetState.systemsIDs}
+                        setBaselineState={setPatchSetState}
+                        patchSetID={patchSetId}
+                    />}
                 <UnassignSystemsModal
                     unassignSystemsModalState={patchSetState}
                     setUnassignSystemsModalOpen={setPatchSetState}
@@ -285,21 +285,25 @@ const PatchSetDetail = () => {
                             {intl.formatMessage(messages.templateDetailTableTitle)}
                         </Text>
                     </TextContent>
-                    {hasSmartManagement ? (rows.length === 0 && !status.isLoading) ? <NoAppliedSystems /> : <TableView
-                        columns={patchSetDetailColumns}
-                        compact
-                        onSetPage={onSetPage}
-                        onPerPageSelect={onPerPageSelect}
-                        onSort={onSort}
-                        sortBy={sortBy}
-                        apply={apply}
-                        tableOUIA={'patch-set-detail-table'}
-                        paginationOUIA={'patch-set-detail-pagination'}
-                        store={{ rows, metadata, status, queryParams }}
-                        actionsConfig={actionsConfig}
-                        actionsToggle={!hasAccess ? CustomActionsToggle : null}
-                        searchChipLabel={intl.formatMessage(messages.labelsFiltersSearchTemplateTitle)}
-                    /> : <NoSmartManagement />}
+                    {hasSmartManagement
+                        ? (rows.length === 0 && !status.isLoading)
+                            ? <NoAppliedSystems onButtonClick={() => openPatchSetAssignWizard()} />
+                            : <TableView
+                                columns={patchSetDetailColumns}
+                                compact
+                                onSetPage={onSetPage}
+                                onPerPageSelect={onPerPageSelect}
+                                onSort={onSort}
+                                sortBy={sortBy}
+                                apply={apply}
+                                tableOUIA={'patch-set-detail-table'}
+                                paginationOUIA={'patch-set-detail-pagination'}
+                                store={{ rows, metadata, status, queryParams }}
+                                actionsConfig={actionsConfig}
+                                actionsToggle={!hasAccess ? CustomActionsToggle : null}
+                                searchChipLabel={intl.formatMessage(messages.labelsFiltersSearchTemplateTitle)}
+                            />
+                        : <NoSmartManagement />}
                 </Main>
             </Fragment >);
 };

--- a/src/SmartComponents/PatchSetWizard/PatchSetWizard.js
+++ b/src/SmartComponents/PatchSetWizard/PatchSetWizard.js
@@ -25,7 +25,7 @@ import { fetchPatchSetAction, clearPatchSetAction, fetchPatchSetSystemsAction } 
 
 export const PatchSetWizard = ({ systemsIDs, setBaselineState, patchSetID }) => {
     //if system ids exist, those are being assigned. Likewise if patchSetID exists, it is being edited
-    const wizardType = systemsIDs ? 'assign' : (patchSetID ? 'edit' : 'create');
+    const wizardType = patchSetID ? 'edit' : 'create';
     const [wizardState, setWizardState] = useState({
         submitted: false,
         formValues: {},

--- a/src/SmartComponents/PatchSetWizard/WizardAssets.js
+++ b/src/SmartComponents/PatchSetWizard/WizardAssets.js
@@ -66,20 +66,9 @@ export const toDateComponent = [{
 }];
 
 export const getWizardTitle = (wizardType) => {
-    let wizardTitle = '';
-
-    switch (wizardType) {
-        case 'assign':
-            wizardTitle = intl.formatMessage(messages.templateTitleAssignSystem);
-            break;
-        case 'edit':
-            wizardTitle = intl.formatMessage(messages.templateEdit);
-            break;
-        default:
-            wizardTitle = intl.formatMessage(messages.templateTitle);
-    }
-
-    return wizardTitle;
+    return (wizardType === 'edit')
+        ? intl.formatMessage(messages.templateEdit)
+        : intl.formatMessage(messages.templateTitle);
 };
 
 export const schema = (wizardType) => {


### PR DESCRIPTION
# Description

Associated Jira ticket: [SPM-1893](https://issues.redhat.com/browse/SPM-1893)

- if template has 0 systems it shows an empty state on template detail page, the button in the empty state now correctly opens wizard; previously it didn't do anything
- removed unused 'assign' template wizard type
- editing a template from template detail page now has correct "edit" verb instead of "create" in the titles