### PR TITLE
Link from System detail header to template detail

### DIFF
--- a/src/SmartComponents/SystemDetail/InventoryDetail.js
+++ b/src/SmartComponents/SystemDetail/InventoryDetail.js
@@ -15,16 +15,17 @@ import { clearNotifications } from '@redhat-cloud-services/frontend-components-n
 import PatchSetWrapper from '../../PresentationalComponents/PatchSetWrapper/PatchSetWrapper';
 import usePatchSetState from '../../Utilities/usePatchSetState';
 import { featureFlags } from '../../Utilities/constants';
-import { useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import SystemDetail from './SystemDetail';
 
 const InventoryDetail = () => {
-    const {  inventoryId } = useParams();
+    const { inventoryId } = useParams();
     const store = useStore();
 
     const dispatch = useDispatch();
-    const { hasThirdPartyRepo, patchSetName } = useSelector(
-        ({ entityDetails }) => entityDetails && entityDetails || {}
+
+    const { hasThirdPartyRepo, patchSetName, patchSetId } = useSelector(
+        ({ SystemDetailStore }) => SystemDetailStore
     );
 
     const { display_name: displayName } = useSelector(
@@ -95,26 +96,28 @@ const InventoryDetail = () => {
                     appList={[]}
                 >
                     <Grid>
-                        <GridItem>
-                            {patchSetName && <TextContent>
+                        {patchSetName && <GridItem>
+                            <TextContent>
                                 <Text>
-                                    {`${intl.formatMessage(messages.labelsColumnsTemplate)}: ${patchSetName}`}
+                                    {intl.formatMessage(messages.labelsColumnsTemplate)}:
+                                    <Link to={{ pathname: `/templates/${patchSetId}` }} className="pf-u-ml-xs">
+                                        {patchSetName}
+                                    </Link>
                                 </Text>
                             </TextContent>
-                            }
-                        </GridItem>
+                        </GridItem>}
                         <GridItem>
                             {hasThirdPartyRepo &&
-                    (<Alert className='pf-u-mt-md' isInline variant="info"
-                        title={intl.formatMessage(messages.textThirdPartyInfo)}>
-                    </Alert>)
+                                (<Alert className='pf-u-mt-md' isInline variant="info"
+                                    title={intl.formatMessage(messages.textThirdPartyInfo)}>
+                                </Alert>)
                             }
                         </GridItem>
                     </Grid>
                 </InventoryDetailHead>
             </Header>
             <Main>
-                <SystemDetail inventoryId={inventoryId}/>
+                <SystemDetail inventoryId={inventoryId} />
             </Main>
         </DetailWrapper>);
 };

--- a/src/SmartComponents/SystemDetail/InventoryDetail.test.js
+++ b/src/SmartComponents/SystemDetail/InventoryDetail.test.js
@@ -38,18 +38,18 @@ jest.mock('@redhat-cloud-services/frontend-components/Inventory', () => ({
 }));
 jest.mock('./SystemDetail', () => () => <div>This is system detail</div>);
 
-const mockState = { ...entityDetail };
+const mockState = { ...entityDetail, SystemDetailStore: {} };
 
 const initStore = (state) => {
     const customMiddleWare = () => next => action => {
         useSelector.mockImplementation(callback => {
-            return callback({  entityDetails: state });
+            return callback({ entityDetails: state, SystemDetailStore: state  });
         });
         next(action);
     };
 
     const mockStore = configureStore([customMiddleWare]);
-    return mockStore({  entityDetails: state });
+    return mockStore({ entityDetails: state, SystemDetailStore: state });
 };
 
 let wrapper;
@@ -60,7 +60,7 @@ beforeEach(() => {
 
     store.clearActions();
     useSelector.mockImplementation(callback => {
-        return callback({ entityDetails: mockState });
+        return callback({ entityDetails: mockState, SystemDetailStore: {} });
     });
     wrapper = mountWithIntl(<Provider store={store}>
         <Router><InventoryDetail /></Router>
@@ -88,7 +88,10 @@ describe('InventoryPage.js', () => {
 
     it('Should display "Remove from a template" action in enabled state', () => {
         useSelector.mockImplementation(callback => {
-            return callback({ entityDetails: { ...mockState, patchSetName: 'test-name' } });
+            return callback({
+                entityDetails: { ...mockState, patchSetName: 'test-name' },
+                SystemDetailStore: { patchSetName: 'template-name' }
+            });
         });
         const tempWrapper = mount(<Provider store={store}>
             <Router><InventoryDetail /></Router>
@@ -104,7 +107,7 @@ describe('InventoryPage.js', () => {
     it('Should open UnassignSystemsModal when "Remove from a template" action is called', () => {
         const testID = 'test-system-id';
         useSelector.mockImplementation(callback => {
-            return callback({ entityDetails: { ...mockState, patchSetName: 'test-name' } });
+            return callback({ entityDetails: { ...mockState, patchSetName: 'test-name' }, SystemDetailStore: {} });
         });
         const tempWrapper = mountWithIntl(<Provider store={store}>
             <Router><InventoryDetail  /></Router>

--- a/src/Utilities/api.js
+++ b/src/Utilities/api.js
@@ -43,7 +43,7 @@ export const fetchSystems = params => {
 };
 
 export const fetchSystemDetails = id => {
-    return createApiCall(`/systems/${id}`, 'v2', 'get');
+    return createApiCall(`/systems/${id}`, 'v3', 'get');
 };
 
 export const fetchAdvisoryDetailsApi = params => {

--- a/src/store/Reducers/SystemDetailStore.js
+++ b/src/store/Reducers/SystemDetailStore.js
@@ -8,6 +8,7 @@ export const SystemDetailStore = (state = initialState, { type, payload }) => {
         case 'FETCH_SYSTEM_DETAIL_FULFILLED':
             state.hasThirdPartyRepo = payload.data?.attributes.third_party;
             state.patchSetName = payload.data?.attributes.baseline_name;
+            state.patchSetId = payload.data?.attributes.baseline_id;
             return state;
         case 'LOAD_ENTITY_PENDING':
             return {


### PR DESCRIPTION
# Description

Associated Jira ticket: [SPM-1945](https://issues.redhat.com/browse/SPM-1945)

In System detail header
- update template name to link to Template detail page
- fix race condition where Inventory API response could overwrite `hasThirdPartyRepo` and `patchSetName` parameters and header would show up as having no template and no third party repo
- fix tags not displaying

