### PR TITLE
Fix template up-to date being off by a day in negative UTC timezones

### DIFF
--- a/src/PresentationalComponents/Header/Header.js
+++ b/src/PresentationalComponents/Header/Header.js
@@ -15,7 +15,7 @@ const Header = ({ title, showTabs, breadcrumbs, children, headerOUIA, actions })
                 data-ouia-component-type={`${headerOUIA}-page-header`}
             >
                 {breadcrumbs && <HeaderBreadcrumbs items={breadcrumbs} headerOUIA={headerOUIA} />}
-                <Split>
+                <Split hasGutter>
                     <SplitItem>
                         <PageHeaderTitle title={title} />
                     </SplitItem>

--- a/src/PresentationalComponents/Header/__snapshots__/Header.test.js.snap
+++ b/src/PresentationalComponents/Header/__snapshots__/Header.test.js.snap
@@ -101,9 +101,11 @@ exports[`Header component should render with 1 breadcrumb item and last is activ
               </nav>
             </Breadcrumb>
           </HeaderBreadcrumbs>
-          <Split>
+          <Split
+            hasGutter={true}
+          >
             <div
-              className="pf-l-split"
+              className="pf-l-split pf-m-gutter"
             >
               <SplitItem>
                 <div
@@ -320,9 +322,11 @@ exports[`Header component should render with 2 breadcrumb items and last is acti
               </nav>
             </Breadcrumb>
           </HeaderBreadcrumbs>
-          <Split>
+          <Split
+            hasGutter={true}
+          >
             <div
-              className="pf-l-split"
+              className="pf-l-split pf-m-gutter"
             >
               <SplitItem>
                 <div
@@ -609,9 +613,11 @@ exports[`Header component should render with 3 breadcrumb items and last is acti
               </nav>
             </Breadcrumb>
           </HeaderBreadcrumbs>
-          <Split>
+          <Split
+            hasGutter={true}
+          >
             <div
-              className="pf-l-split"
+              className="pf-l-split pf-m-gutter"
             >
               <SplitItem>
                 <div
@@ -711,9 +717,11 @@ exports[`Header component should render with empty breadcrumb 1`] = `
               </nav>
             </Breadcrumb>
           </HeaderBreadcrumbs>
-          <Split>
+          <Split
+            hasGutter={true}
+          >
             <div
-              className="pf-l-split"
+              className="pf-l-split pf-m-gutter"
             >
               <SplitItem>
                 <div
@@ -795,9 +803,11 @@ exports[`Header component should render with header Hello world 1`] = `
           data-ouia-component-type="undefined-page-header"
           widget-type="InsightsPageHeader"
         >
-          <Split>
+          <Split
+            hasGutter={true}
+          >
             <div
-              className="pf-l-split"
+              className="pf-l-split pf-m-gutter"
             >
               <SplitItem>
                 <div
@@ -881,9 +891,11 @@ exports[`Header component should render with header as empty string 1`] = `
           data-ouia-component-type="undefined-page-header"
           widget-type="InsightsPageHeader"
         >
-          <Split>
+          <Split
+            hasGutter={true}
+          >
             <div
-              className="pf-l-split"
+              className="pf-l-split pf-m-gutter"
             >
               <SplitItem>
                 <div
@@ -1009,9 +1021,11 @@ exports[`Header component should render without to attribute 1`] = `
               </nav>
             </Breadcrumb>
           </HeaderBreadcrumbs>
-          <Split>
+          <Split
+            hasGutter={true}
+          >
             <div
-              className="pf-l-split"
+              className="pf-l-split pf-m-gutter"
             >
               <SplitItem>
                 <div

--- a/src/SmartComponents/AdvisoryDetail/__snapshots__/AdvisoryDetail.test.js.snap
+++ b/src/SmartComponents/AdvisoryDetail/__snapshots__/AdvisoryDetail.test.js.snap
@@ -199,9 +199,11 @@ exports[`AdvisoryDetail.js Should match the snapshots 1`] = `
                     </nav>
                   </Breadcrumb>
                 </HeaderBreadcrumbs>
-                <Split>
+                <Split
+                  hasGutter={true}
+                >
                   <div
-                    className="pf-l-split"
+                    className="pf-l-split pf-m-gutter"
                   >
                     <SplitItem>
                       <div

--- a/src/SmartComponents/PackageDetail/__snapshots__/PackageDetail.test.js.snap
+++ b/src/SmartComponents/PackageDetail/__snapshots__/PackageDetail.test.js.snap
@@ -199,9 +199,11 @@ exports[`PackageDetail.js should match the snapshot 1`] = `
                     </nav>
                   </Breadcrumb>
                 </HeaderBreadcrumbs>
-                <Split>
+                <Split
+                  hasGutter={true}
+                >
                   <div
-                    className="pf-l-split"
+                    className="pf-l-split pf-m-gutter"
                   >
                     <SplitItem>
                       <div

--- a/src/SmartComponents/Packages/__snapshots__/Packages.test.js.snap
+++ b/src/SmartComponents/Packages/__snapshots__/Packages.test.js.snap
@@ -49,9 +49,11 @@ exports[`Packages.js should match the snapshot 1`] = `
               data-ouia-component-type="packages-page-header"
               widget-type="InsightsPageHeader"
             >
-              <Split>
+              <Split
+                hasGutter={true}
+              >
                 <div
-                  className="pf-l-split"
+                  className="pf-l-split pf-m-gutter"
                 >
                   <SplitItem>
                     <div

--- a/src/SmartComponents/PatchSetDetail/PatchSetDetail.js
+++ b/src/SmartComponents/PatchSetDetail/PatchSetDetail.js
@@ -23,7 +23,7 @@ import ErrorHandler from '../../PresentationalComponents/Snippets/ErrorHandler';
 import { processDate } from '@redhat-cloud-services/frontend-components-utilities/helpers';
 import { patchSetDetailColumns } from './PatchSetDetailAssets';
 import { createPatchSetDetailRows } from '../../Utilities/DataMappers';
-import { createSortBy, decodeQueryparams, encodeURLParams } from '../../Utilities/Helpers';
+import { createSortBy, decodeQueryparams, encodeURLParams, templateDateFormat } from '../../Utilities/Helpers';
 import PatchSetWizard from '../PatchSetWizard/PatchSetWizard';
 import { CustomActionsToggle, patchSetDetailRowActions } from '../PatchSet/PatchSetAssets';
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
@@ -249,7 +249,7 @@ const PatchSetDetail = () => {
                                 <td>
                                     {isHeaderLoading
                                         ? <Skeleton style={{ width: 100 }} />
-                                        : processDate(templateDetails.data.attributes.config.to_time)}
+                                        : templateDateFormat(templateDetails.data.attributes.config.to_time)}
                                 </td>
                             </tr>
                             <tr>

--- a/src/SmartComponents/PatchSetWizard/steps/ReviewPatchSet.js
+++ b/src/SmartComponents/PatchSetWizard/steps/ReviewPatchSet.js
@@ -13,7 +13,7 @@ import {
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
 import { intl } from '../../../Utilities/IntlProvider';
 import messages from '../../../Messages';
-import { processDate } from '@redhat-cloud-services/frontend-components-utilities/helpers';
+import { templateDateFormat } from '../../../Utilities/Helpers';
 
 const renderTextListItem = (label, text) => (
     <Fragment>
@@ -54,7 +54,7 @@ const ReviewPatchSet = () => {
                         {intl.formatMessage(messages.textPatchTemplateContent)}
                     </Text>
                     <TextList component={TextListVariants.dl}>
-                        {renderTextListItem('labelsColumnsUpToDate', processDate(toDate))}
+                        {renderTextListItem('labelsColumnsUpToDate', templateDateFormat(toDate))}
                     </TextList>
                 </TextContent>
             </StackItem>

--- a/src/SmartComponents/Systems/__snapshots__/System.test.js.snap
+++ b/src/SmartComponents/Systems/__snapshots__/System.test.js.snap
@@ -57,9 +57,11 @@ exports[`Systems.js should match the snapshot 1`] = `
               data-ouia-component-type="systems-page-header"
               widget-type="InsightsPageHeader"
             >
-              <Split>
+              <Split
+                hasGutter={true}
+              >
                 <div
-                  className="pf-l-split"
+                  className="pf-l-split pf-m-gutter"
                 >
                   <SplitItem>
                     <div

--- a/src/Utilities/Helpers.js
+++ b/src/Utilities/Helpers.js
@@ -602,6 +602,25 @@ export const convertIsoToDate = (isoDate) => {
         `-${dateObject.getDate().toString().padStart(2, '0')}`;
 };
 
+// 2023-03-05 -> 05 Mar 2023
+// 2023-03-22T20:00:00-04:00 (ISO format) -> 23 Mar 2023
+export const templateDateFormat = (dateString) => {
+    if (!dateString) {
+        return 'N/A';
+    }
+
+    // handle ISO format - convert timezone to GMT and slice off the time
+    if (dateString.includes('T')) {
+        const gmtTime = (new Date(dateString)).toISOString();
+        [dateString] = gmtTime.split('T');
+    }
+
+    const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'June', 'July', 'Aug', 'Sept', 'Oct', 'Nov', 'Dec'];
+    const [year, month, day] = dateString.split('-');
+
+    return `${day} ${MONTHS[parseInt(month) - 1]} ${year}`;
+};
+
 export const filterSelectedActiveSystemIDs = (selectedSystemsObject) => {
     const formValueSystemIDs = [];
     if (typeof selectedSystemsObject === 'object') {


### PR DESCRIPTION
- Fix template up-to date being off by a day in negative UTC timezones
- add hasGutter to header so there's margin between long template names and dropdown, after screenshot:
![Screenshot from 2023-03-24 06-43-08](https://user-images.githubusercontent.com/8426204/227501325-593206fe-42aa-423d-b6a1-2c5743b8f610.png)

How to test:
1. Set your timezone to some place with negative UTC offset, for example New York. 
2. Create a template with some date.
3. In the last (review) step of the template creation check if the date is the same as you set.
4. Go to detail page of your just created template.
5. Check if the date in the header is the same as you set.
6. Don't forget to set your timezone back :grinning: 