### PR TITLE
Fix date-to resetting when assigning a system to template

### DIFF
--- a/src/Utilities/Hooks.js
+++ b/src/Utilities/Hooks.js
@@ -261,7 +261,7 @@ export const usePatchSetApi = (wizardState, setWizardState, patchSetID) => {
 
     const onSubmit = React.useCallback((formValues) => {
         const { name, description, toDate, id } = formValues.existing_patch_set || formValues;
-        const fomattedDate = convertDateToISO(toDate);
+        const formattedDate = convertDateToISO(toDate);
 
         const { systems } = formValues;
 
@@ -269,7 +269,7 @@ export const usePatchSetApi = (wizardState, setWizardState, patchSetID) => {
             name,
             description,
             inventory_ids: (patchSetID || id) ? objUndefinedToFalse(systems) : Object.keys(systems),
-            ...fomattedDate ? { config: { to_time: fomattedDate } } : {}
+            ...formattedDate && { config: { to_time: formattedDate } }
         };
 
         setWizardState({ ...wizardState, submitted: true, failed: false, requestPending: true });

--- a/src/Utilities/Hooks.js
+++ b/src/Utilities/Hooks.js
@@ -269,7 +269,7 @@ export const usePatchSetApi = (wizardState, setWizardState, patchSetID) => {
             name,
             description,
             inventory_ids: (patchSetID || id) ? objUndefinedToFalse(systems) : Object.keys(systems),
-            config: { to_time: fomattedDate }
+            ...fomattedDate ? { config: { to_time: fomattedDate } } : {}
         };
 
         setWizardState({ ...wizardState, submitted: true, failed: false, requestPending: true });


### PR DESCRIPTION
There was a bug when you assigned a system to a template in the system list table, the template would have the date-to reset to January 1, year 1. This has now been fixed.