### PR TITLE
Fix Advisory list page applicable system column

### DIFF
--- a/src/Messages.js
+++ b/src/Messages.js
@@ -19,7 +19,7 @@ export default defineMessages({
     labelsApplicableSystemsCount: {
         id: 'labelsApplicableSystemsCount',
         description: 'applicable systems number label',
-        defaultMessage: '{systemsCount} applicable systems'
+        defaultMessage: '{systemsCount} affected systems'
     },
     labelsBulkSelectAll: {
         id: 'labelsBulkSelectAll',
@@ -55,6 +55,11 @@ export default defineMessages({
         id: 'labelsCancel',
         description: 'Button label',
         defaultMessage: 'Cancel'
+    },
+    labelsColumnsAffectedSystems: {
+        id: 'labelsColumnsAffectedSystems',
+        description: 'shared label',
+        defaultMessage: 'Affected systems'
     },
     labelsColumnsApplicableSystems: {
         id: 'labelsColumnsApplicableSystems',

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -16,8 +16,8 @@ export default defineMessages({
         description: 'dropdown with actions label',
         defaultMessage: 'Actions'
     },
-    labelsApplicableSystemsCount: {
-        id: 'labelsApplicableSystemsCount',
+    labelsAffectedSystemsCount: {
+        id: 'labelsAffectedSystemsCount',
         description: 'applicable systems number label',
         defaultMessage: '{systemsCount} affected systems'
     },

--- a/src/PresentationalComponents/TableView/TableViewAssets.js
+++ b/src/PresentationalComponents/TableView/TableViewAssets.js
@@ -20,7 +20,7 @@ export const advisoriesColumns = [
         key: 'advisory_type_name'
     },
     {
-        title: intl.formatMessage(messages.labelsColumnsApplicableSystems),
+        title: intl.formatMessage(messages.labelsColumnsAffectedSystems),
         transforms: [sortable, cellWidth(15)],
         key: 'applicable_systems'
     },

--- a/src/Utilities/api.js
+++ b/src/Utilities/api.js
@@ -30,7 +30,7 @@ export function createApiCall(
 const systemProfile = new SystemProfileApi(undefined, INVENTORY_API_BASE, axios);
 
 export const fetchApplicableAdvisoriesApi = params => {
-    return createApiCall('/advisories', 'v2', 'get', params);
+    return createApiCall('/advisories', 'v3', 'get', params);
 };
 
 export const fetchApplicableSystemAdvisoriesApi = params => {


### PR DESCRIPTION
See comment in [SPM-1948](https://issues.redhat.com/browse/SPM-1948)

- rename "Applicable systems" to "Affected systems" in table and dashbar
- update `advisories/` endpoint version from v2 to v3 to fix incorrect count of systems in applicable/affected systems column