### PR TITLE
Downgrade PF/react to fix date picker crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@data-driven-forms/pf4-component-mapper": "^3.20.4",
         "@data-driven-forms/react-form-renderer": "^3.20.4",
-        "@patternfly/react-core": "^4.276.8",
+        "@patternfly/react-core": "^4.267.14",
         "@patternfly/react-icons": "^4.93.6",
         "@patternfly/react-table": "^4.113.0",
         "@redhat-cloud-services/frontend-components": "3.9.27",
@@ -3402,12 +3402,13 @@
       "license": "MIT"
     },
     "node_modules/@patternfly/react-core": {
-      "version": "4.276.8",
-      "license": "MIT",
+      "version": "4.267.14",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.267.14.tgz",
+      "integrity": "sha512-a43F6GApAZSh+YF2vWUExFeB1nttAHw3Lc/ZMkaHxim3Sh5eClgLB50NkPggd+npdzkFKUe1XdCYkvgv+TfkLA==",
       "dependencies": {
-        "@patternfly/react-icons": "^4.93.6",
-        "@patternfly/react-styles": "^4.92.6",
-        "@patternfly/react-tokens": "^4.94.6",
+        "@patternfly/react-icons": "^4.93.3",
+        "@patternfly/react-styles": "^4.92.3",
+        "@patternfly/react-tokens": "^4.94.3",
         "focus-trap": "6.9.2",
         "react-dropzone": "9.0.0",
         "tippy.js": "5.1.2",
@@ -3439,6 +3440,24 @@
         "@patternfly/react-styles": "^4.92.6",
         "@patternfly/react-tokens": "^4.94.6",
         "lodash": "^4.17.19",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18",
+        "react-dom": "^16.8 || ^17 || ^18"
+      }
+    },
+    "node_modules/@patternfly/react-table/node_modules/@patternfly/react-core": {
+      "version": "4.276.8",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.276.8.tgz",
+      "integrity": "sha512-dn322rEzBeiVztZEuCZMUUittNb8l1hk30h9ZN31FLZLLVtXGlThFNV9ieqOJYA9zrYxYZrHMkTnOxSWVacMZg==",
+      "dependencies": {
+        "@patternfly/react-icons": "^4.93.6",
+        "@patternfly/react-styles": "^4.92.6",
+        "@patternfly/react-tokens": "^4.94.6",
+        "focus-trap": "6.9.2",
+        "react-dropzone": "9.0.0",
+        "tippy.js": "5.1.2",
         "tslib": "^2.0.0"
       },
       "peerDependencies": {
@@ -30858,11 +30877,13 @@
       "dev": true
     },
     "@patternfly/react-core": {
-      "version": "4.276.8",
+      "version": "4.267.14",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.267.14.tgz",
+      "integrity": "sha512-a43F6GApAZSh+YF2vWUExFeB1nttAHw3Lc/ZMkaHxim3Sh5eClgLB50NkPggd+npdzkFKUe1XdCYkvgv+TfkLA==",
       "requires": {
-        "@patternfly/react-icons": "^4.93.6",
-        "@patternfly/react-styles": "^4.92.6",
-        "@patternfly/react-tokens": "^4.94.6",
+        "@patternfly/react-icons": "^4.93.3",
+        "@patternfly/react-styles": "^4.92.3",
+        "@patternfly/react-tokens": "^4.94.3",
         "focus-trap": "6.9.2",
         "react-dropzone": "9.0.0",
         "tippy.js": "5.1.2",
@@ -30885,6 +30906,22 @@
         "@patternfly/react-tokens": "^4.94.6",
         "lodash": "^4.17.19",
         "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "@patternfly/react-core": {
+          "version": "4.276.8",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.276.8.tgz",
+          "integrity": "sha512-dn322rEzBeiVztZEuCZMUUittNb8l1hk30h9ZN31FLZLLVtXGlThFNV9ieqOJYA9zrYxYZrHMkTnOxSWVacMZg==",
+          "requires": {
+            "@patternfly/react-icons": "^4.93.6",
+            "@patternfly/react-styles": "^4.92.6",
+            "@patternfly/react-tokens": "^4.94.6",
+            "focus-trap": "6.9.2",
+            "react-dropzone": "9.0.0",
+            "tippy.js": "5.1.2",
+            "tslib": "^2.0.0"
+          }
+        }
       }
     },
     "@patternfly/react-tokens": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@data-driven-forms/pf4-component-mapper": "^3.20.4",
     "@data-driven-forms/react-form-renderer": "^3.20.4",
-    "@patternfly/react-core": "^4.276.8",
+    "@patternfly/react-core": "^4.267.14",
     "@patternfly/react-icons": "^4.93.6",
     "@patternfly/react-table": "^4.113.0",
     "@redhat-cloud-services/frontend-components": "3.9.27",


### PR DESCRIPTION
Fix the following bug:
1. Go to Template list page
2. Click `Create template` button
3. Select date
4. Page crashes