### PR TITLE
feat(ESSNTL-4496): Replace SmartManager w/ satellite

### DIFF
--- a/src/Messages.js
+++ b/src/Messages.js
@@ -481,8 +481,8 @@ export default defineMessages({
         description: 'Label',
         defaultMessage: 'No matching patch template found'
     },
-    statesNoSmartManagementBody: {
-        id: 'statesNoSmartManagementBody',
+    statesNoSatelliteBody: {
+        id: 'statesNoSatelliteBody',
         description: 'Label',
         defaultMessage: `Manage your infrastructure directly from console.redhat.com by controlling the
         scope of package and advisory updates to be installed on selected systems based on 
@@ -490,12 +490,12 @@ export default defineMessages({
         and time from the console.  
         {br}
         {br}
-        Creating content templates from console.redhat.com is a premium feature only available with Red Hat Smart Management.`
+        Creating content templates from console.redhat.com is a premium feature only available with Red Hat Satellite.`
     },
-    statesNoSmartManagementHeader: {
-        id: 'statesNoSmartManagement',
+    statesNoSatelliteHeader: {
+        id: 'statesNoSatellite',
         description: 'Label',
-        defaultMessage: 'Create a content with Red Hat Smart Management'
+        defaultMessage: 'Create a content with Red Hat Satellite'
     },
     statesNoTemplate: {
         id: 'statesNoTemplate',

--- a/src/PresentationalComponents/Snippets/EmptyStates.js
+++ b/src/PresentationalComponents/Snippets/EmptyStates.js
@@ -98,15 +98,15 @@ NoPatchSetList.propTypes = {
     Button: PropTypes.node
 };
 
-export const NoSmartManagement = () => (
+export const NoSatellite = () => (
     <EmptyState variant={EmptyStateVariant.large}>
         <EmptyStateIcon icon={LockIcon} />
         <Title headingLevel="h5" size="lg">
-            {intl.formatMessage(messages.statesNoSmartManagementHeader)}
+            {intl.formatMessage(messages.statesNoSatelliteHeader)}
         </Title>
         <EmptyStateBody>
             {intl.formatMessage(
-                messages.statesNoSmartManagementBody,
+                messages.statesNoSatelliteBody,
                 { br: <br></br> }
             )}
         </EmptyStateBody>

--- a/src/PresentationalComponents/Snippets/EmptyStates.test.js
+++ b/src/PresentationalComponents/Snippets/EmptyStates.test.js
@@ -1,7 +1,7 @@
 import {
     EmptyAdvisoryList,
     EmptyPackagesList,
-    NoSmartManagement
+    NoSatellite
 } from './EmptyStates';
 import toJson from 'enzyme-to-json';
 import { shallow } from 'enzyme';
@@ -20,9 +20,9 @@ describe('EmptyPackagesList', () => {
     });
 });
 
-describe('NoSmartManagement', () => {
+describe('NoSatellite', () => {
     it('Should match the snapshot', () => {
-        const wrapper = shallow(<NoSmartManagement />);
+        const wrapper = shallow(<NoSatellite />);
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 });

--- a/src/PresentationalComponents/Snippets/__snapshots__/EmptyStates.test.js.snap
+++ b/src/PresentationalComponents/Snippets/__snapshots__/EmptyStates.test.js.snap
@@ -35,7 +35,7 @@ exports[`EmptyPackagesList Should match the snapshot 1`] = `
 </EmptyState>
 `;
 
-exports[`NoSmartManagement Should match the snapshot 1`] = `
+exports[`NoSatellite Should match the snapshot 1`] = `
 <EmptyState
   variant="large"
 >
@@ -46,7 +46,7 @@ exports[`NoSmartManagement Should match the snapshot 1`] = `
     headingLevel="h5"
     size="lg"
   >
-    Create a content with Red Hat Smart Management
+    Create a content with Red Hat Satellite
   </Title>
   <EmptyStateBody>
     Manage your infrastructure directly from console.redhat.com by controlling the
@@ -63,7 +63,7 @@ exports[`NoSmartManagement Should match the snapshot 1`] = `
       key=".3"
     />
     
-        Creating content templates from console.redhat.com is a premium feature only available with Red Hat Smart Management.
+        Creating content templates from console.redhat.com is a premium feature only available with Red Hat Satellite.
   </EmptyStateBody>
 </EmptyState>
 `;

--- a/src/SmartComponents/PatchSet/PatchSet.js
+++ b/src/SmartComponents/PatchSet/PatchSet.js
@@ -31,7 +31,7 @@ import { useOnSelect, ID_API_ENDPOINTS } from '../../Utilities/useOnSelect';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { Popover } from '@patternfly/react-core';
 import DeleteSetModal from '../Modals/DeleteSetModal';
-import { NoPatchSetList, NoSmartManagement } from '../../PresentationalComponents/Snippets/EmptyStates';
+import { NoPatchSetList, NoSatellite } from '../../PresentationalComponents/Snippets/EmptyStates';
 
 const PatchSet = () => {
     const pageTitle = intl.formatMessage(messages.titlesTemplate);
@@ -43,7 +43,7 @@ const PatchSet = () => {
     const dispatch = useDispatch();
     const history = useHistory();
     const [firstMount, setFirstMount] = React.useState(true);
-    const [hasSmartManagement, setSmartManagement] = React.useState(true);
+    const [hasSatellite, setSatellite] = React.useState(true);
     const [isDeleteConfirmModalOpen, setDeleteConfirmModalOpen] = React.useState(false);
     const [patchSetToDelete, setPatchSetToDelete] = React.useState(null);
 
@@ -81,7 +81,7 @@ const PatchSet = () => {
 
     useEffect(() => {
         getEntitlements().then((entitelements) => {
-            setSmartManagement(
+            setSatellite(
                 entitelements?.smart_management?.is_entitled
             );
         });
@@ -210,7 +210,7 @@ const PatchSet = () => {
                     patchSetID={patchSetState.patchSetID}
                 />}
             <Main>
-                {hasSmartManagement
+                {hasSatellite
                     ? (rows.length === 0 && !status.isLoading)
                         ? <NoPatchSetList Button={CreatePatchSetButton}/>
                         : <TableView
@@ -232,7 +232,7 @@ const PatchSet = () => {
                             ToolbarButton={CreatePatchSetButton}
                             actionsToggle={!hasAccess ? CustomActionsToggle : null}
                         />
-                    : <NoSmartManagement />}
+                    : <NoSatellite />}
             </Main>
         </React.Fragment>
     );

--- a/src/SmartComponents/PatchSet/PatchSet.test.js
+++ b/src/SmartComponents/PatchSet/PatchSet.test.js
@@ -10,7 +10,7 @@ import { createPatchSetRows } from '../../Utilities/DataMappers';
 import patchSets from '../../../cypress/fixtures/api/patchSets.json';
 import { initMocks } from '../../Utilities/unitTestingUtilities.js';
 import PatchSet from './PatchSet';
-import { NoSmartManagement } from '../../PresentationalComponents/Snippets/EmptyStates';
+import { NoSatellite } from '../../PresentationalComponents/Snippets/EmptyStates';
 
 jest.mock('react-redux', () => ({
     ...jest.requireActual('react-redux'),
@@ -74,7 +74,7 @@ describe('HeaderBreadcrumbs', () => {
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
-    it('Should render No Smart management state', () => {
+    it('Should not render Satellite state', () => {
         useChrome.mockImplementation(() => ({
             auth: {
                 getUser: () => new Promise(
@@ -89,6 +89,6 @@ describe('HeaderBreadcrumbs', () => {
 
         wrapper.update();
 
-        expect(wrapper.find(NoSmartManagement)).toHaveLength(1);
+        expect(wrapper.find(NoSatellite)).toHaveLength(1);
     });
 });

--- a/src/SmartComponents/PatchSet/PatchSet.test.js
+++ b/src/SmartComponents/PatchSet/PatchSet.test.js
@@ -74,7 +74,7 @@ describe('HeaderBreadcrumbs', () => {
         expect(toJson(wrapper)).toMatchSnapshot();
     });
 
-    it('Should not render Satellite state', () => {
+    it('Should render "No Satellite" empty state', () => {
         useChrome.mockImplementation(() => ({
             auth: {
                 getUser: () => new Promise(

--- a/src/SmartComponents/PatchSetDetail/PatchSetDetail.js
+++ b/src/SmartComponents/PatchSetDetail/PatchSetDetail.js
@@ -5,7 +5,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import messages from '../../Messages';
 import Header from '../../PresentationalComponents/Header/Header';
-import { NoAppliedSystems, NoSmartManagement } from '../../PresentationalComponents/Snippets/EmptyStates';
+import { NoAppliedSystems, NoSatellite } from '../../PresentationalComponents/Snippets/EmptyStates';
 import TableView from '../../PresentationalComponents/TableView/TableView';
 import { useDeepCompareEffect, useEntitlements, usePerPageSelect, useSetPage, useSortColumn } from '../../Utilities/Hooks';
 import {
@@ -39,7 +39,7 @@ const PatchSetDetail = () => {
 
     const [firstMount, setFirstMount] = React.useState(true);
     const [isHeaderDropdownOpen, setHeaderDropdownOpen] = useState(false);
-    const [hasSmartManagement, setSmartManagement] = React.useState(true);
+    const [hasSatellite, setSatellite] = React.useState(true);
     const [isDeleteConfirmModalOpen, setDeleteConfirmModalOpen] = useState(false);
     const [patchSetState, setPatchSetState] = useState({
         isPatchSetWizardOpen: false,
@@ -113,7 +113,7 @@ const PatchSetDetail = () => {
 
     useEffect(() => {
         getEntitlements().then((entitelements) => {
-            setSmartManagement(
+            setSatellite(
                 entitelements?.smart_management?.is_entitled
             );
         });
@@ -285,7 +285,7 @@ const PatchSetDetail = () => {
                             {intl.formatMessage(messages.templateDetailTableTitle)}
                         </Text>
                     </TextContent>
-                    {hasSmartManagement
+                    {hasSatellite
                         ? (rows.length === 0 && !status.isLoading)
                             ? <NoAppliedSystems onButtonClick={() => openPatchSetAssignWizard()} />
                             : <TableView
@@ -303,7 +303,7 @@ const PatchSetDetail = () => {
                                 actionsToggle={!hasAccess ? CustomActionsToggle : null}
                                 searchChipLabel={intl.formatMessage(messages.labelsFiltersSearchTemplateTitle)}
                             />
-                        : <NoSmartManagement />}
+                        : <NoSatellite />}
                 </Main>
             </Fragment >);
 };


### PR DESCRIPTION
# Description
Associated Jira ticket: # ([ESSNTL-4496)](https://issues.redhat.com/browse/ESSNTL-4496)
This replaces all references of Red Hat Smart Manager with Satellite. I've left entitlements as is for the time being as thats user schema.

# How to test the PR
Just skim the code and UI for any references to smart manager and verify there are none the user can see.

# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [ ] Screenshots before and after the change are added
- [x] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work