### PR TITLE
Fix template modal system table not resetting to page 1

### DIFF
--- a/src/SmartComponents/PatchSetWizard/steps/ReviewSystems.js
+++ b/src/SmartComponents/PatchSetWizard/steps/ReviewSystems.js
@@ -80,7 +80,9 @@ export const ReviewSystems = ({ systemsIDs = [], ...props }) => {
         setQueryParams((prevQueryParams) => ({
             ...prevQueryParams,
             ...params,
-            filter: { ...prevQueryParams.filter, ...params.filter }
+            filter: { ...prevQueryParams.filter, ...params.filter },
+            page: 1,
+            offset: 0
         }));
     };
 


### PR DESCRIPTION
See https://github.com/RedHatInsights/patchman-ui/pull/1028#pullrequestreview-1391792579

Bug that was fixed happened in Template modal -> System review step if you navigated to page 2 and then applied filter which returned less than 20 rows; calling page 2 on this data caused 400 error. Fixed by resetting to page 1 on every filter change, which is behaviour of all other Patchman tables (and Vulnerabilities as well).