### PR TITLE
fix(RHIF-194): show empty account state on template details

### DIFF
--- a/src/PresentationalComponents/Snippets/ErrorHandler.js
+++ b/src/PresentationalComponents/Snippets/ErrorHandler.js
@@ -14,6 +14,10 @@ import NoRegisteredSystems from './NoRegisteredSystems';
 //import { NoRegisteredSystems } from '@redhat-cloud-services/frontend-components/NoRegisteredSystems';
 
 const ErrorHandler = ({ code, ErrorState, EmptyState, metadata = {} }) => {
+    if (metadata && metadata.has_systems === false) {
+        return <NoRegisteredSystems />;
+    }
+
     switch (code) {
         case 204:
             return <NotConnected />;
@@ -50,7 +54,6 @@ const ErrorHandler = ({ code, ErrorState, EmptyState, metadata = {} }) => {
         default:
             return ErrorState && <ErrorState />
                 || EmptyState && <EmptyState />
-                || !metadata.has_systems && <NoRegisteredSystems />
                 || <SkeletonTable colSize={5} rowSize={20} /> ;
     }
 };

--- a/src/SmartComponents/AdvisorySystems/AdvisorySystems.js
+++ b/src/SmartComponents/AdvisorySystems/AdvisorySystems.js
@@ -59,7 +59,7 @@ const AdvisorySystems = ({ advisoryName }) => {
         ({ entities }) => entities?.selectedRows || []
     );
     const metadata = useSelector(
-        ({ AdvisorySystemsStore }) => AdvisorySystemsStore?.metadata || {}
+        ({ AdvisoryListStore }) => AdvisoryListStore?.metadata || {}
     );
 
     const { systemProfile, selectedTags,

--- a/src/SmartComponents/PackageSystems/PackageSystems.js
+++ b/src/SmartComponents/PackageSystems/PackageSystems.js
@@ -51,6 +51,10 @@ const PackageSystems = ({ packageName }) => {
         ({ PackageSystemsStore }) => PackageSystemsStore?.queryParams || {}
     );
 
+    const metadata = useSelector(
+        ({ PackageSystemsStore }) => PackageSystemsStore?.metadata || {}
+    );
+
     const { systemProfile, selectedTags,
         filter, search, sort, page, perPage } = queryParams;
 
@@ -145,7 +149,9 @@ const PackageSystems = ({ packageName }) => {
 
     return (
         <React.Fragment>
-            {status.hasError && <ErrorHandler code={status.code} /> || (
+            {(status.hasError || metadata?.has_systems === false)
+            && <ErrorHandler code={status.code} metadata={metadata}/>
+            || (
                 <InventoryTable
                     disableDefaultColumns={['system_profile', 'updated']}
                     isFullView

--- a/src/SmartComponents/PatchSet/PatchSet.js
+++ b/src/SmartComponents/PatchSet/PatchSet.js
@@ -32,6 +32,7 @@ import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { Popover } from '@patternfly/react-core';
 import DeleteSetModal from '../Modals/DeleteSetModal';
 import { NoPatchSetList, NoSatellite } from '../../PresentationalComponents/Snippets/EmptyStates';
+import ErrorHandler from '../../PresentationalComponents/Snippets/ErrorHandler';
 
 const PatchSet = () => {
     const pageTitle = intl.formatMessage(messages.titlesTemplate);
@@ -210,7 +211,9 @@ const PatchSet = () => {
                     patchSetID={patchSetState.patchSetID}
                 />}
             <Main>
-                {hasSatellite
+                {(status.hasError || metadata?.has_systems === false)
+                && <ErrorHandler code={status.code} metadata={metadata}/>
+                || (hasSatellite
                     ? (rows.length === 0 && !status.isLoading)
                         ? <NoPatchSetList Button={CreatePatchSetButton}/>
                         : <TableView
@@ -232,7 +235,7 @@ const PatchSet = () => {
                             ToolbarButton={CreatePatchSetButton}
                             actionsToggle={!hasAccess ? CustomActionsToggle : null}
                         />
-                    : <NoSatellite />}
+                    : <NoSatellite />)}
             </Main>
         </React.Fragment>
     );

--- a/src/SmartComponents/PatchSet/PatchSet.test.js
+++ b/src/SmartComponents/PatchSet/PatchSet.test.js
@@ -11,6 +11,7 @@ import patchSets from '../../../cypress/fixtures/api/patchSets.json';
 import { initMocks } from '../../Utilities/unitTestingUtilities.js';
 import PatchSet from './PatchSet';
 import { NoSatellite } from '../../PresentationalComponents/Snippets/EmptyStates';
+import NoRegisteredSystems from '../../PresentationalComponents/Snippets/NoRegisteredSystems';
 
 jest.mock('react-redux', () => ({
     ...jest.requireActual('react-redux'),
@@ -69,7 +70,7 @@ beforeEach(() => {
     </Provider>);
 });
 
-describe('HeaderBreadcrumbs', () => {
+describe('PatchSet', () => {
     it('Should render correctly', () => {
         expect(toJson(wrapper)).toMatchSnapshot();
     });
@@ -91,4 +92,22 @@ describe('HeaderBreadcrumbs', () => {
 
         expect(wrapper.find(NoSatellite)).toHaveLength(1);
     });
+
+    it('Should render account empty state on empty account', () => {
+        const emptyAccState = {
+            ...mockState,
+            metadata: {
+                has_systems: false
+            }
+        };
+        useSelector.mockImplementation(callback => {
+            return callback({ PatchSetsStore: emptyAccState });
+        });
+        wrapper = mount(<Provider store={store}>
+            <Router><PatchSet history={{ location: {}, push: () => {} }}/></Router>
+        </Provider>);
+
+        expect(wrapper.find(NoRegisteredSystems)).toHaveLength(1);
+    });
 });
+


### PR DESCRIPTION
# Description

Associated Jira ticket: # https://issues.redhat.com/browse/RHIF-194

Enables rendering **NoRegisteredSystems** on Patch set page.  

# How to test the PR

1. Run the pr locally
2. login to following acc
  login: empty-account
  password: interact-team
3. Navigate to templates page.
4. observer that table is hidden and NoRegisteredSystem component is shown.


# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
