### PR TITLE
fix(RHIF-245): remove smart management gate for patch templates

### DIFF
--- a/src/SmartComponents/PatchSet/PatchSet.js
+++ b/src/SmartComponents/PatchSet/PatchSet.js
@@ -15,7 +15,7 @@ import { deletePatchSet } from '../../Utilities/api';
 import { createPatchSetRows } from '../../Utilities/DataMappers';
 import { createSortBy, decodeQueryparams, encodeURLParams } from '../../Utilities/Helpers';
 import {
-    setPageTitle, useDeepCompareEffect, useEntitlements, usePerPageSelect, useSetPage, useSortColumn
+    setPageTitle, useDeepCompareEffect, usePerPageSelect, useSetPage, useSortColumn
 } from '../../Utilities/Hooks';
 import { intl } from '../../Utilities/IntlProvider';
 import { clearNotifications, addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
@@ -31,7 +31,7 @@ import { useOnSelect, ID_API_ENDPOINTS } from '../../Utilities/useOnSelect';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { Popover } from '@patternfly/react-core';
 import DeleteSetModal from '../Modals/DeleteSetModal';
-import { NoPatchSetList, NoSatellite } from '../../PresentationalComponents/Snippets/EmptyStates';
+import { NoPatchSetList } from '../../PresentationalComponents/Snippets/EmptyStates';
 
 const PatchSet = () => {
     const pageTitle = intl.formatMessage(messages.titlesTemplate);
@@ -43,7 +43,6 @@ const PatchSet = () => {
     const dispatch = useDispatch();
     const history = useHistory();
     const [firstMount, setFirstMount] = React.useState(true);
-    const [hasSatellite, setSatellite] = React.useState(true);
     const [isDeleteConfirmModalOpen, setDeleteConfirmModalOpen] = React.useState(false);
     const [patchSetToDelete, setPatchSetToDelete] = React.useState(null);
 
@@ -69,8 +68,6 @@ const PatchSet = () => {
         [patchSets, selectedRows]
     );
 
-    const getEntitlements = useEntitlements();
-
     function apply(params) {
         dispatch(changePatchSetsParams(params));
     }
@@ -80,12 +77,6 @@ const PatchSet = () => {
     };
 
     useEffect(() => {
-        getEntitlements().then((entitelements) => {
-            setSatellite(
-                entitelements?.smart_management?.is_entitled
-            );
-        });
-
         return () => {
             dispatch(clearPatchSetsAction());
             dispatch(clearNotifications());
@@ -210,29 +201,27 @@ const PatchSet = () => {
                     patchSetID={patchSetState.patchSetID}
                 />}
             <Main>
-                {hasSatellite
-                    ? (rows.length === 0 && !status.isLoading)
-                        ? <NoPatchSetList Button={CreatePatchSetButton}/>
-                        : <TableView
-                            columns={patchSetColumns}
-                            compact
-                            onSetPage={onSetPage}
-                            onPerPageSelect={onPerPageSelect}
-                            onSort={onSort}
-                            selectedRows={IS_SELECTION_ENABLED ? selectedRows : undefined}
-                            onSelect={IS_SELECTION_ENABLED ? onSelect : undefined}
-                            sortBy={sortBy}
-                            apply={apply}
-                            tableOUIA={'patch-set-table'}
-                            paginationOUIA={'patch-set-pagination'}
-                            store={{ rows, metadata, status, queryParams }}
-                            actionsConfig={patchSets?.length > 0 ? actionsConfig : []}
-                            filterConfig={filterConfig}
-                            searchChipLabel={intl.formatMessage(messages.labelsFiltersSearchTemplateTitle)}
-                            ToolbarButton={CreatePatchSetButton}
-                            actionsToggle={!hasAccess ? CustomActionsToggle : null}
-                        />
-                    : <NoSatellite />}
+                {(rows.length === 0 && !status.isLoading)
+                    ? <NoPatchSetList Button={CreatePatchSetButton}/>
+                    : <TableView
+                        columns={patchSetColumns}
+                        compact
+                        onSetPage={onSetPage}
+                        onPerPageSelect={onPerPageSelect}
+                        onSort={onSort}
+                        selectedRows={IS_SELECTION_ENABLED ? selectedRows : undefined}
+                        onSelect={IS_SELECTION_ENABLED ? onSelect : undefined}
+                        sortBy={sortBy}
+                        apply={apply}
+                        tableOUIA={'patch-set-table'}
+                        paginationOUIA={'patch-set-pagination'}
+                        store={{ rows, metadata, status, queryParams }}
+                        actionsConfig={actionsConfig}
+                        filterConfig={filterConfig}
+                        searchChipLabel={intl.formatMessage(messages.labelsFiltersSearchTemplateTitle)}
+                        ToolbarButton={CreatePatchSetButton}
+                        actionsToggle={!hasAccess ? CustomActionsToggle : null}
+                    />}
             </Main>
         </React.Fragment>
     );

--- a/src/SmartComponents/PatchSet/PatchSet.test.js
+++ b/src/SmartComponents/PatchSet/PatchSet.test.js
@@ -3,14 +3,12 @@ import toJson from 'enzyme-to-json';
 import { Provider, useSelector } from 'react-redux';
 import { BrowserRouter as Router } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
-import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 
 import { storeListDefaults } from '../../Utilities/constants';
 import { createPatchSetRows } from '../../Utilities/DataMappers';
 import patchSets from '../../../cypress/fixtures/api/patchSets.json';
 import { initMocks } from '../../Utilities/unitTestingUtilities.js';
 import PatchSet from './PatchSet';
-import { NoSatellite } from '../../PresentationalComponents/Snippets/EmptyStates';
 
 jest.mock('react-redux', () => ({
     ...jest.requireActual('react-redux'),
@@ -72,23 +70,5 @@ beforeEach(() => {
 describe('HeaderBreadcrumbs', () => {
     it('Should render correctly', () => {
         expect(toJson(wrapper)).toMatchSnapshot();
-    });
-
-    it('Should render "No Satellite" empty state', () => {
-        useChrome.mockImplementation(() => ({
-            auth: {
-                getUser: () => new Promise(
-                    (resolve) => resolve({
-                        entitlements: {
-                            smart_management: { is_entitled: false }
-                        }
-                    })
-                )
-            }
-        }));
-
-        wrapper.update();
-
-        expect(wrapper.find(NoSatellite)).toHaveLength(1);
     });
 });

--- a/src/SmartComponents/PatchSetDetail/PatchSetDetail.js
+++ b/src/SmartComponents/PatchSetDetail/PatchSetDetail.js
@@ -5,8 +5,8 @@ import { useDispatch, useSelector, useStore } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import messages from '../../Messages';
 import Header from '../../PresentationalComponents/Header/Header';
-import { NoAppliedSystems, NoSatellite } from '../../PresentationalComponents/Snippets/EmptyStates';
-import { useDeepCompareEffect, useEntitlements, useGetEntities } from '../../Utilities/Hooks';
+import { useDeepCompareEffect, useGetEntities } from '../../Utilities/Hooks';
+import { NoAppliedSystems } from '../../PresentationalComponents/Snippets/EmptyStates';
 import {
     changePatchSetDetailsSystemsMetadata,
     changePatchSetDetailsSystemsParams,
@@ -35,7 +35,6 @@ import { systemsListColumns } from '../Systems/SystemsListAssets';
 import { processDate } from '@redhat-cloud-services/frontend-components-utilities/helpers';
 
 const PatchSetDetail = () => {
-    const getEntitlements = useEntitlements();
     const intl = useIntl();
     const dispatch = useDispatch();
     const history = useHistory();
@@ -47,7 +46,6 @@ const PatchSetDetail = () => {
 
     const [firstMount, setFirstMount] = React.useState(true);
     const [isHeaderDropdownOpen, setHeaderDropdownOpen] = useState(false);
-    const [hasSatellite, setSatellite] = React.useState(true);
     const [isDeleteConfirmModalOpen, setDeleteConfirmModalOpen] = useState(false);
     const [patchSetState, setPatchSetState] = useState({
         isPatchSetWizardOpen: false,
@@ -111,12 +109,6 @@ const PatchSetDetail = () => {
     };
 
     useEffect(() => {
-        getEntitlements().then((entitelements) => {
-            setSatellite(
-                entitelements?.smart_management?.is_entitled
-            );
-        });
-
         return () => {
             dispatch(clearTemplateDetail());
         };
@@ -300,48 +292,47 @@ const PatchSetDetail = () => {
                             {intl.formatMessage(messages.templateDetailTableTitle)}
                         </Text>
                     </TextContent>
-                    {hasSatellite
-                        ? (totalItems === 0 && loaded)
-                            ? <NoAppliedSystems onButtonClick={() => openPatchSetAssignWizard()} />
-                            : systemStatus.hasError
-                                ? <ErrorHandler code={systemStatus.code} />
-                                : <InventoryTable
-                                    ref={inventory}
-                                    isFullView
-                                    autoRefresh
-                                    initialLoading
-                                    hideFilters={{ all: true }}
-                                    columns={(defaultColumns) => templateSystemsColumnsMerger(defaultColumns)}
-                                    showTags
-                                    onLoad={({ mergeWithEntities }) => {
-                                        store.replaceReducer(combineReducers({
-                                            ...defaultReducers,
-                                            ...mergeWithEntities(
-                                                inventoryEntitiesReducer(systemsListColumns(true), modifyTemplateDetailSystems),
-                                                persistantParams({ page, perPage, sort, search }, decodedParams)
-                                            )
-                                        }));
-                                    }}
-                                    customFilters={{
-                                        patchParams: {
-                                            filter,
-                                            systemProfile,
-                                            selectedTags
-                                        }
-                                    }}
-                                    paginationProps={{
-                                        isDisabled: totalItems === 0
-                                    }}
-                                    getEntities={getEntities}
-                                    tableProps={{
-                                        canSelectAll: true,
-                                        variant: TableVariant.compact,
-                                        className: 'patchCompactInventory',
-                                        isStickyHeader: true,
-                                        actionResolver: () => hasAccess ? patchSetDetailRowActions(openSystemUnassignModal) : []
-                                    }}
-                                    hasCheckbox={false} /* TODO: Remove this when implementing bulk actions */
-                                /> : <NoSatellite />}
+                    {(totalItems === 0 && loaded)
+                        ? <NoAppliedSystems onButtonClick={() => openPatchSetAssignWizard()} />
+                        : systemStatus.hasError
+                            ? <ErrorHandler code={systemStatus.code} />
+                            : <InventoryTable
+                                ref={inventory}
+                                isFullView
+                                autoRefresh
+                                initialLoading
+                                hideFilters={{ all: true }}
+                                columns={(defaultColumns) => templateSystemsColumnsMerger(defaultColumns)}
+                                showTags
+                                onLoad={({ mergeWithEntities }) => {
+                                    store.replaceReducer(combineReducers({
+                                        ...defaultReducers,
+                                        ...mergeWithEntities(
+                                            inventoryEntitiesReducer(systemsListColumns(true), modifyTemplateDetailSystems),
+                                            persistantParams({ page, perPage, sort, search }, decodedParams)
+                                        )
+                                    }));
+                                }}
+                                customFilters={{
+                                    patchParams: {
+                                        filter,
+                                        systemProfile,
+                                        selectedTags
+                                    }
+                                }}
+                                paginationProps={{
+                                    isDisabled: totalItems === 0
+                                }}
+                                getEntities={getEntities}
+                                tableProps={{
+                                    canSelectAll: true,
+                                    variant: TableVariant.compact,
+                                    className: 'patchCompactInventory',
+                                    isStickyHeader: true,
+                                    actionResolver: () => hasAccess ? patchSetDetailRowActions(openSystemUnassignModal) : []
+                                }}
+                                hasCheckbox={false} /* TODO: Remove this when implementing bulk actions */
+                            />}
                 </Main>
             </Fragment>
     );


### PR DESCRIPTION
# Description

Associated Jira ticket: # [RHIF-245](https://issues.redhat.com/browse/RHIF-245)

Removes the smart management check on Patch template work


# How to test the PR

I do not have currently an account with/without smart management entitlements, but this change must work without any issues.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
