### PR TITLE
Remove async func useEffect callbacks.

### DIFF
--- a/src/PresentationalComponents/StatusReports/AdvisoriesStatusReport.js
+++ b/src/PresentationalComponents/StatusReports/AdvisoriesStatusReport.js
@@ -83,10 +83,8 @@ const StatusCard = ({ advisory: { attributes, id } }) =>
 
 const AdvisoriesStatusBar = () => {
     const [advisories, setAdvisories] = React.useState({});
-    React.useEffect(async () => {
-        setAdvisories(
-            await fetchApplicableAdvisoriesApi({ limit: 4, sort: '-advisory_type_name,-applicable_systems' })
-        );
+    React.useEffect(() => {
+        fetchApplicableAdvisoriesApi({ limit: 4, sort: '-advisory_type_name,-applicable_systems' }).then(setAdvisories);
     }, []);
 
     return advisories.data && advisories.data.length && (

--- a/src/SmartComponents/PackageSystems/PackageSystems.js
+++ b/src/SmartComponents/PackageSystems/PackageSystems.js
@@ -58,9 +58,9 @@ const PackageSystems = ({ packageName }) => {
         dispatch(changePackageSystemsParams(params));
     }, []);
 
-    useEffect(async () => {
+    useEffect(() => {
         apply(decodedParams);
-        setPackageVersions(await fetchPackageVersions({ package_name: packageName }));
+        fetchPackageVersions({ package_name: packageName }).then(setPackageVersions);
     }, []);
 
     useEffect(() => {


### PR DESCRIPTION
Related ticket: https://issues.redhat.com/browse/RHCLOUD-20494

### Why

TLDR: React only accepts functions as `effect` return value from its callback. Directly used `async` function will always have a return type of `Promise`.

You can read further here: https://github.com/facebook/react/issues/14326
