### PR TITLE
fix: ungate the templates route

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -3,8 +3,6 @@ import React, { lazy, Suspense, useCallback, useEffect, useState } from 'react';
 import { Redirect, Route, Switch, useHistory } from 'react-router-dom';
 import WithPermission from './PresentationalComponents/WithPermission/WithPermission';
 import { Bullseye, Spinner } from '@patternfly/react-core';
-import { useFeatureFlag } from './Utilities/Hooks';
-import { featureFlags } from './Utilities/constants';
 import some from 'lodash/some';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import axios from 'axios';
@@ -96,7 +94,6 @@ export const Routes = () => {
     const history = useHistory();
     const chrome = useChrome();
 
-    const isPatchSetEnabled = useFeatureFlag(featureFlags.patch_set, chrome);
     const generalPermissions = ['patch:*:*', 'patch:*:read'];
     const [hasSystems, setHasSystems] = useState(true);
     const INVENTORY_TOTAL_FETCH_URL = '/api/inventory/v1/hosts';
@@ -150,7 +147,7 @@ export const Routes = () => {
             requiredPermissions: generalPermissions,
             component: PackagesPage
         },
-        ...(isPatchSetEnabled ? [{
+        {
             path: '/templates/:templateName',
             isExact: true,
             requiredPermissions: generalPermissions,
@@ -161,7 +158,7 @@ export const Routes = () => {
             isExact: true,
             requiredPermissions: generalPermissions,
             component: Templates
-        }] : [])
+        }
     ];
 
     const listenNavigation = useCallback(() => {
@@ -221,7 +218,7 @@ export const Routes = () => {
                     />
                     <Route render={() =>
                         (
-                            (!isPatchSetEnabled || !some(paths, p => p.to === history.location.pathname)) && (
+                            (!some(paths, p => p.to === history.location.pathname)) && (
                                 <Redirect to={'/advisories'} />
                             )
                         )


### PR DESCRIPTION
# Description

Associated Jira ticket: # (issue)

This un gates the templates routes completely.


# How to test the PR

1. Run the PR locally
2. open C.R.C with insights-qa acc on stage-beta env
3. navigate to /templates route from the left sidebar
4. observer that you are not redirected to /advisories route
5. Now open a new session on stage-stable env
6. navigate to /templates route as previously done
7. observe that you are not redirected to /advisories
8. The same procedure applies to /templates/:templateName route as well 

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
