### PR TITLE
Remove redundant group column from package systems table

### DIFF
--- a/src/SmartComponents/PackageSystems/PackageSystems.js
+++ b/src/SmartComponents/PackageSystems/PackageSystems.js
@@ -147,7 +147,7 @@ const PackageSystems = ({ packageName }) => {
         <React.Fragment>
             {status.hasError && <ErrorHandler code={status.code} /> || (
                 <InventoryTable
-                    disableDefaultColumns={['system_profile', 'updated']}
+                    disableDefaultColumns={['system_profile', 'updated', 'groups']}
                     isFullView
                     autoRefresh
                     initialLoading


### PR DESCRIPTION
Removed this empty "group" column:
![Screenshot from 2023-05-10 18-28-24](https://github.com/RedHatInsights/patchman-ui/assets/8426204/72a18ae9-c4de-458d-8cde-8eabc6575371)
