### PR TITLE
Add fallback to OS column on Template detail page

### DIFF
--- a/src/Utilities/DataMappers.js
+++ b/src/Utilities/DataMappers.js
@@ -439,7 +439,7 @@ export const createPatchSetDetailRows = (rows) => {
                 display_name: row.display_name,
                 key: row.inventory_id,
                 os: {
-                    osName: row.os,
+                    osName: row.os || 'N/A',
                     rhsm: row.rhsm
                 },
                 last_upload: row.last_upload,

--- a/src/Utilities/Helpers.js
+++ b/src/Utilities/Helpers.js
@@ -457,7 +457,7 @@ export function sortCves(cves, index, direction) {
 
 }
 
-export const createOSColumn = ({ osName, rhsm }) => (rhsm === '' || rhsm === undefined) && osName || (
+export const createOSColumn = ({ osName, rhsm }) => !rhsm ? osName : (
     <Tooltip
         content={
             intl.formatMessage(messages.textLockVersionTooltip, { lockedVersion: rhsm })


### PR DESCRIPTION
If template system had OS data unavailable it only showed the blue icon. Correct behaviour is to show "N/A" and no blue icon. 

### Before:
![Screenshot from 2023-05-19 16-02-01](https://github.com/RedHatInsights/patchman-ui/assets/8426204/74c2b963-04f3-4e4d-ae9a-17b21e052cd9)

### After:
![Screenshot from 2023-05-19 16-02-03](https://github.com/RedHatInsights/patchman-ui/assets/8426204/faa02266-481b-4003-81a2-6a5a0dde8084)


### How to test:
- go to https://stage.foo.redhat.com:1337/beta/insights/patch/templates/8264?page=4&perPage=20&sort=os
- observe OS column contents