### PR TITLE
Fix stale system count in Dashbar

### DIFF
--- a/src/PresentationalComponents/StatusReports/SystemsStatusReport.js
+++ b/src/PresentationalComponents/StatusReports/SystemsStatusReport.js
@@ -41,7 +41,7 @@ const StatusCard = ({ title, color, Icon, value, filter, apply }) => {
     );
 };
 
-const SystemsStatusreport = ({ apply, queryParams }) => {
+const SystemsStatusReport = ({ apply, queryParams }) => {
     const [subtotals, setSubtotals] = React.useState({});
 
     const { selectedTags, selectedGlobalTags, systemProfile } = useSelector(({ GlobalFilterStore }) => GlobalFilterStore);
@@ -52,12 +52,14 @@ const SystemsStatusreport = ({ apply, queryParams }) => {
         let result;
 
         try {
-            result = await fetchSystems({ filter: {
-                os: queryParams?.filter?.os
-            },
-            selectedTags: [...selectedTags, ...selectedGlobalTags],
-            systemProfile,
-            limit: 1
+            result = await fetchSystems({
+                filter: {
+                    os: queryParams?.filter?.os
+                },
+                selectedTags: [...selectedTags, ...selectedGlobalTags],
+                systemProfile,
+                limit: 1,
+                'filter[stale]': 'in:true,false'
             });
         }
         catch {
@@ -80,7 +82,7 @@ const SystemsStatusreport = ({ apply, queryParams }) => {
     return (
         <Main style={{ paddingBottom: 0 }}>
             <Grid hasGutter span={12} >
-                <GridItem span={12} md={3}>
+                <GridItem lg={3} md={4}>
                     <StatusCard
                         title={intl.formatMessage(messages.labelsStatusSystemsUpToDate)}
                         Icon={CheckCircleIcon}
@@ -90,7 +92,7 @@ const SystemsStatusreport = ({ apply, queryParams }) => {
                         filter={{ filter: { packages_updatable: 'eq:0' } }}
                     />
                 </GridItem>
-                <GridItem span={12} md={3}>
+                <GridItem lg={3} md={4}>
                     <StatusCard
                         title={intl.formatMessage(messages.labelsStatusSystemsWithPatchesAvailable)}
                         Icon={PackageIcon}
@@ -100,7 +102,7 @@ const SystemsStatusreport = ({ apply, queryParams }) => {
                         filter={{ filter: { packages_updatable: 'gt:0' } }}
                     />
                 </GridItem>
-                <GridItem span={12} md={3}>
+                <GridItem lg={3} md={4}>
                     <StatusCard
                         title={intl.formatMessage(messages.labelsStatusStaleSystems)}
                         Icon={ExclamationTriangleIcon}
@@ -124,9 +126,9 @@ StatusCard.propTypes = {
     filter: propTypes.object
 };
 
-SystemsStatusreport.propTypes = {
+SystemsStatusReport.propTypes = {
     apply: propTypes.func,
     queryParams: propTypes.object
 };
 
-export default SystemsStatusreport;
+export default SystemsStatusReport;

--- a/src/SmartComponents/Systems/__snapshots__/System.test.js.snap
+++ b/src/SmartComponents/Systems/__snapshots__/System.test.js.snap
@@ -106,7 +106,7 @@ exports[`Systems.js should match the snapshot 1`] = `
             </section>
           </PageHeader>
         </Header>
-        <SystemsStatusreport
+        <SystemsStatusReport
           apply={[Function]}
           queryParams={Object {}}
         >
@@ -141,11 +141,11 @@ exports[`Systems.js should match the snapshot 1`] = `
                     className="pf-l-grid pf-m-all-12-col pf-m-gutter"
                   >
                     <GridItem
-                      md={3}
-                      span={12}
+                      lg={3}
+                      md={4}
                     >
                       <div
-                        className="pf-l-grid__item pf-m-12-col pf-m-3-col-on-md"
+                        className="pf-l-grid__item pf-m-4-col-on-md pf-m-3-col-on-lg"
                       >
                         <StatusCard
                           Icon={[Function]}
@@ -295,11 +295,11 @@ exports[`Systems.js should match the snapshot 1`] = `
                       </div>
                     </GridItem>
                     <GridItem
-                      md={3}
-                      span={12}
+                      lg={3}
+                      md={4}
                     >
                       <div
-                        className="pf-l-grid__item pf-m-12-col pf-m-3-col-on-md"
+                        className="pf-l-grid__item pf-m-4-col-on-md pf-m-3-col-on-lg"
                       >
                         <StatusCard
                           Icon={[Function]}
@@ -449,11 +449,11 @@ exports[`Systems.js should match the snapshot 1`] = `
                       </div>
                     </GridItem>
                     <GridItem
-                      md={3}
-                      span={12}
+                      lg={3}
+                      md={4}
                     >
                       <div
-                        className="pf-l-grid__item pf-m-12-col pf-m-3-col-on-md"
+                        className="pf-l-grid__item pf-m-4-col-on-md pf-m-3-col-on-lg"
                       >
                         <StatusCard
                           Icon={[Function]}
@@ -607,7 +607,7 @@ exports[`Systems.js should match the snapshot 1`] = `
               </section>
             </InternalMain>
           </Connect(InternalMain)>
-        </SystemsStatusreport>
+        </SystemsStatusReport>
         <PatchSetWrapper
           patchSetState={
             Object {


### PR DESCRIPTION
https://issues.redhat.com/browse/SPM-2054

### After
![Screenshot from 2023-05-25 12-16-06](https://github.com/RedHatInsights/patchman-ui/assets/8426204/2667ee11-c1a3-4e14-a11f-d8c3ff42c917)

- stale system count used to display 0 instead of the correct amount, this was fixed by adding staleness param to the API request
- improved the responsivity of the dashbar
- fixed camel case `SystemsStatusreport` -> `SystemsStatusReport`