### PR TITLE
Include only installable advisories when remediating all

### DIFF
--- a/src/SmartComponents/Systems/SystemListAssets.test.js
+++ b/src/SmartComponents/Systems/SystemListAssets.test.js
@@ -34,7 +34,8 @@ describe('SystemListAssets.js', () => {
         it('Should call fetchApplicableSystemAdvisoriesApi with row id and limit: 10000', () => {
             expect(fetchApplicableSystemAdvisoriesApi).toHaveBeenCalledWith({
                 id: 'testId',
-                limit: 10000
+                limit: -1,
+                'filter[status]': 'in:Installable'
             });
         });
         it('Should call remediationProvider and testShowRemediationModal', () => {

--- a/src/SmartComponents/Systems/SystemsListAssets.js
+++ b/src/SmartComponents/Systems/SystemsListAssets.js
@@ -138,7 +138,8 @@ export const systemsRowActions = (
             onClick: (event, rowId, rowData) => {
                 fetchApplicableSystemAdvisoriesApi({
                     id: rowData.id,
-                    limit: 10000
+                    limit: -1,
+                    'filter[status]': 'in:Installable'
                 }).then(res =>
                     showRemediationModal(
                         remediationProvider(

--- a/src/Utilities/RemediationPairs.js
+++ b/src/Utilities/RemediationPairs.js
@@ -5,7 +5,7 @@ const BATCH_REQUEST_SIZE = 5;
 const REQUEST_INTERVAL = 15000; //15 seconds. AKAMAI allowed life for 5 API calls
 
 const fetchDataCallback = (endpoint, authToken) => (input) => {
-    return fetch(`/api/patch/v1/views${endpoint}`, {
+    return fetch(`/api/patch/v3/views${endpoint}`, {
         method: 'POST',
         credentials: 'include',
         headers: {


### PR DESCRIPTION
https://issues.redhat.com/browse/SPM-2069

1. Go to system list page
2. Find a system with a template, that has some applicable (non-installable) advisories
3. In row actions menu select "Apply all applicable advisories"
4. Observe how many issues are selected -- previously it selected applicable and installable advisories, now it should only select installable 