### PR TITLE
fix(SPM-2055): Select all on disabled advisories

### DIFF
--- a/src/SmartComponents/Advisories/Advisories.test.js
+++ b/src/SmartComponents/Advisories/Advisories.test.js
@@ -170,7 +170,7 @@ describe('Advisories.js', () => {
 
         expect(fetchIDs).toHaveBeenCalledWith(
             '/ids/advisories',
-            { limit: -1, page: 1, page_size: 20 }
+            { limit: -1, offset: 0, page: 1, page_size: 20 }
         );
     });
 

--- a/src/SmartComponents/AdvisorySystems/AdvisorySystem.test.js
+++ b/src/SmartComponents/AdvisorySystems/AdvisorySystem.test.js
@@ -139,7 +139,7 @@ describe('AdvisorySystems.js', () => {
             const { bulkSelect } = wrapper.find('.testInventroyComponentChild').parent().props();
 
             bulkSelect.items[2].onClick();
-            expect(fetchIDs).toHaveBeenCalledWith('/ids/advisories/RHSA-2020:2755/systems', { limit: -1 });
+            expect(fetchIDs).toHaveBeenCalledWith('/ids/advisories/RHSA-2020:2755/systems', { limit: -1, offset: 0 });
             expect(bulkSelect.items[2].title).toEqual('Select all (2)');
         });
 

--- a/src/SmartComponents/AdvisorySystems/AdvisorySystems.js
+++ b/src/SmartComponents/AdvisorySystems/AdvisorySystems.js
@@ -124,7 +124,9 @@ const AdvisorySystems = ({ advisoryName }) => {
         remediationIdentifiers.advisory
     );
 
-    const bulkSelectConfig = useBulkSelectConfig(selectedCount, onSelect, { total_items: totalItems }, systems);
+    const bulkSelectConfig = useBulkSelectConfig(
+        selectedCount, onSelect, { total_items: totalItems }, systems, null, queryParams
+    );
 
     return (
         <React.Fragment>

--- a/src/SmartComponents/PackageSystems/PackageSystems.test.js
+++ b/src/SmartComponents/PackageSystems/PackageSystems.test.js
@@ -162,7 +162,7 @@ describe('PackageSystems.js', () => {
             const { bulkSelect } = wrapper.find('.testInventroyComponentChild').parent().props();
 
             bulkSelect.items[2].onClick();
-            expect(fetchIDs).toHaveBeenCalledWith('/packages/testName/systems', { limit: -1 });
+            expect(fetchIDs).toHaveBeenCalledWith('/packages/testName/systems', { limit: -1, offset: 0 });
             expect(bulkSelect.items[2].title).toEqual('Select all (2)');
         });
     });

--- a/src/SmartComponents/SystemPackages/SystemPackages.test.js
+++ b/src/SmartComponents/SystemPackages/SystemPackages.test.js
@@ -123,7 +123,7 @@ describe('SystemPackages.js', () => {
     it('Should select all with limit=-1', () => {
         const { onSelect } = wrapper.update().find('TableView').props();
         onSelect('all');
-        expect(fetchIDs).toHaveBeenCalledWith('/systems/entity/packages', { limit: -1, page: 1, page_size: 20 });
+        expect(fetchIDs).toHaveBeenCalledWith('/systems/entity/packages', { limit: -1, offset: 0, page: 1, page_size: 20 });
     });
 
     it('Should provide correct remediation data', () => {

--- a/src/SmartComponents/Systems/System.test.js
+++ b/src/SmartComponents/Systems/System.test.js
@@ -273,7 +273,7 @@ describe('Systems.js', () => {
 
             bulkSelect.items[2].onClick();
 
-            expect(fetchIDs).toHaveBeenCalledWith('/ids/systems', { limit: -1 });
+            expect(fetchIDs).toHaveBeenCalledWith('/ids/systems', { limit: -1, offset: 0 });
             expect(bulkSelect.items[2].title).toEqual('Select all (2)');
         });
 
@@ -299,7 +299,7 @@ describe('Systems.js', () => {
 
             expect(fetchIDs).toHaveBeenCalledWith(
                 '/ids/systems',
-                { limit: -1, search: 'test-system-1' }
+                { limit: -1, search: 'test-system-1', offset: 0 }
             );
             expect(bulkSelect.items[2].title).toEqual('Select all (1)');
         });

--- a/src/Utilities/Hooks.js
+++ b/src/Utilities/Hooks.js
@@ -19,6 +19,470 @@ import { createSystemsSortBy } from './SystemsHelpers';
 // eslint-disable-next-line no-unused-vars
 import { useFlag, useFlagsStatus } from '@unleash/proxy-client-react';
 
+/*const mockedSystems1 = {
+    data: [
+        {
+            attributes: {
+                baseline_id: 0,
+                baseline_name: '',
+                created: '2023-05-31T18:34:25.073767Z',
+                culled_timestamp: '2023-06-15T23:34:24.83586Z',
+                display_name: 'rhel8-rhui-test.aig1lzmjp4mejkbwrqwbe45sre.cx.internal.cloudapp.net',
+                last_upload: '2023-05-31T18:34:25.228098Z',
+                os: 'RHEL 8.6',
+                rhsm: '',
+                stale: false,
+                stale_timestamp: '2023-06-01T23:34:24.83586Z',
+                stale_warning_timestamp: '2023-06-08T23:34:24.83586Z',
+                status: 'Applicable',
+                tags: []
+            },
+            id: '1234',
+            type: 'system'
+        },
+        {
+            attributes: {
+                baseline_id: 0,
+                baseline_name: '',
+                created: '2023-05-31T18:34:25.073767Z',
+                culled_timestamp: '2023-06-15T23:34:24.83586Z',
+                display_name: 'rhel8-rhui-test.aig1lzmjp4mejkbwrqwbe45sre.cx.internal.cloudapp.net',
+                last_upload: '2023-05-31T18:34:25.228098Z',
+                os: 'RHEL 8.6',
+                rhsm: '',
+                stale: false,
+                stale_timestamp: '2023-06-01T23:34:24.83586Z',
+                stale_warning_timestamp: '2023-06-08T23:34:24.83586Z',
+                status: 'Applicable',
+                tags: []
+            },
+            id: '5678',
+            type: 'system'
+        },
+        {
+            attributes: {
+                baseline_id: 0,
+                baseline_name: '',
+                created: '2023-05-31T18:34:25.073767Z',
+                culled_timestamp: '2023-06-15T23:34:24.83586Z',
+                display_name: 'rhel8-rhui-test.aig1lzmjp4mejkbwrqwbe45sre.cx.internal.cloudapp.net',
+                last_upload: '2023-05-31T18:34:25.228098Z',
+                os: 'RHEL 8.6',
+                rhsm: '',
+                stale: false,
+                stale_timestamp: '2023-06-01T23:34:24.83586Z',
+                stale_warning_timestamp: '2023-06-08T23:34:24.83586Z',
+                status: 'Installable',
+                tags: []
+            },
+            id: '9101',
+            type: 'system'
+        },
+        {
+            attributes: {
+                baseline_id: 0,
+                baseline_name: '',
+                created: '2023-05-31T18:34:25.073767Z',
+                culled_timestamp: '2023-06-15T23:34:24.83586Z',
+                display_name: 'rhel8-rhui-test.aig1lzmjp4mejkbwrqwbe45sre.cx.internal.cloudapp.net',
+                last_upload: '2023-05-31T18:34:25.228098Z',
+                os: 'RHEL 8.6',
+                rhsm: '',
+                stale: false,
+                stale_timestamp: '2023-06-01T23:34:24.83586Z',
+                stale_warning_timestamp: '2023-06-08T23:34:24.83586Z',
+                status: 'Installable',
+                tags: []
+            },
+            id: '2131',
+            type: 'system'
+        },
+        {
+            attributes: {
+                baseline_id: 0,
+                baseline_name: '',
+                created: '2023-05-31T18:34:25.073767Z',
+                culled_timestamp: '2023-06-15T23:34:24.83586Z',
+                display_name: 'rhel8-rhui-test.aig1lzmjp4mejkbwrqwbe45sre.cx.internal.cloudapp.net',
+                last_upload: '2023-05-31T18:34:25.228098Z',
+                os: 'RHEL 8.6',
+                rhsm: '',
+                stale: false,
+                stale_timestamp: '2023-06-01T23:34:24.83586Z',
+                stale_warning_timestamp: '2023-06-08T23:34:24.83586Z',
+                status: 'Installable',
+                tags: []
+            },
+            id: '4151',
+            type: 'system'
+        },
+        {
+            attributes: {
+                baseline_id: 0,
+                baseline_name: '',
+                created: '2023-05-31T18:34:25.073767Z',
+                culled_timestamp: '2023-06-15T23:34:24.83586Z',
+                display_name: 'rhel8-rhui-test.aig1lzmjp4mejkbwrqwbe45sre.cx.internal.cloudapp.net',
+                last_upload: '2023-05-31T18:34:25.228098Z',
+                os: 'RHEL 8.6',
+                rhsm: '',
+                stale: false,
+                stale_timestamp: '2023-06-01T23:34:24.83586Z',
+                stale_warning_timestamp: '2023-06-08T23:34:24.83586Z',
+                status: 'Installable',
+                tags: []
+            },
+            id: '6171',
+            type: 'system'
+        },
+        {
+            attributes: {
+                baseline_id: 0,
+                baseline_name: '',
+                created: '2023-05-31T18:34:25.073767Z',
+                culled_timestamp: '2023-06-15T23:34:24.83586Z',
+                display_name: 'rhel8-rhui-test.aig1lzmjp4mejkbwrqwbe45sre.cx.internal.cloudapp.net',
+                last_upload: '2023-05-31T18:34:25.228098Z',
+                os: 'RHEL 8.6',
+                rhsm: '',
+                stale: false,
+                stale_timestamp: '2023-06-01T23:34:24.83586Z',
+                stale_warning_timestamp: '2023-06-08T23:34:24.83586Z',
+                status: 'Installable',
+                tags: []
+            },
+            id: '8192',
+            type: 'system'
+        },
+        {
+            attributes: {
+                baseline_id: 0,
+                baseline_name: '',
+                created: '2023-05-31T18:34:25.073767Z',
+                culled_timestamp: '2023-06-15T23:34:24.83586Z',
+                display_name: 'rhel8-rhui-test.aig1lzmjp4mejkbwrqwbe45sre.cx.internal.cloudapp.net',
+                last_upload: '2023-05-31T18:34:25.228098Z',
+                os: 'RHEL 8.6',
+                rhsm: '',
+                stale: false,
+                stale_timestamp: '2023-06-01T23:34:24.83586Z',
+                stale_warning_timestamp: '2023-06-08T23:34:24.83586Z',
+                status: 'Installable',
+                tags: []
+            },
+            id: '0212',
+            type: 'system'
+        },
+        {
+            attributes: {
+                baseline_id: 0,
+                baseline_name: '',
+                created: '2023-05-31T18:34:25.073767Z',
+                culled_timestamp: '2023-06-15T23:34:24.83586Z',
+                display_name: 'rhel8-rhui-test.aig1lzmjp4mejkbwrqwbe45sre.cx.internal.cloudapp.net',
+                last_upload: '2023-05-31T18:34:25.228098Z',
+                os: 'RHEL 8.6',
+                rhsm: '',
+                stale: false,
+                stale_timestamp: '2023-06-01T23:34:24.83586Z',
+                stale_warning_timestamp: '2023-06-08T23:34:24.83586Z',
+                status: 'Installable',
+                tags: []
+            },
+            id: '2232',
+            type: 'system'
+        },
+        {
+            attributes: {
+                baseline_id: 0,
+                baseline_name: '',
+                created: '2023-05-31T18:34:25.073767Z',
+                culled_timestamp: '2023-06-15T23:34:24.83586Z',
+                display_name: 'rhel8-rhui-test.aig1lzmjp4mejkbwrqwbe45sre.cx.internal.cloudapp.net',
+                last_upload: '2023-05-31T18:34:25.228098Z',
+                os: 'RHEL 8.6',
+                rhsm: '',
+                stale: false,
+                stale_timestamp: '2023-06-01T23:34:24.83586Z',
+                stale_warning_timestamp: '2023-06-08T23:34:24.83586Z',
+                status: 'Installable',
+                tags: []
+            },
+            id: '4252',
+            type: 'system'
+        },
+        {
+            attributes: {
+                baseline_id: 0,
+                baseline_name: '',
+                created: '2023-05-31T18:34:25.073767Z',
+                culled_timestamp: '2023-06-15T23:34:24.83586Z',
+                display_name: 'rhel8-rhui-test.aig1lzmjp4mejkbwrqwbe45sre.cx.internal.cloudapp.net',
+                last_upload: '2023-05-31T18:34:25.228098Z',
+                os: 'RHEL 8.6',
+                rhsm: '',
+                stale: false,
+                stale_timestamp: '2023-06-01T23:34:24.83586Z',
+                stale_warning_timestamp: '2023-06-08T23:34:24.83586Z',
+                status: 'Installable',
+                tags: []
+            },
+            id: '6272',
+            type: 'system'
+        },
+        {
+            attributes: {
+                baseline_id: 0,
+                baseline_name: '',
+                created: '2023-05-31T18:34:25.073767Z',
+                culled_timestamp: '2023-06-15T23:34:24.83586Z',
+                display_name: 'rhel8-rhui-test.aig1lzmjp4mejkbwrqwbe45sre.cx.internal.cloudapp.net',
+                last_upload: '2023-05-31T18:34:25.228098Z',
+                os: 'RHEL 8.6',
+                rhsm: '',
+                stale: false,
+                stale_timestamp: '2023-06-01T23:34:24.83586Z',
+                stale_warning_timestamp: '2023-06-08T23:34:24.83586Z',
+                status: 'Installable',
+                tags: []
+            },
+            id: '8293',
+            type: 'system'
+        },
+        {
+            attributes: {
+                baseline_id: 0,
+                baseline_name: '',
+                created: '2023-05-31T18:34:25.073767Z',
+                culled_timestamp: '2023-06-15T23:34:24.83586Z',
+                display_name: 'rhel8-rhui-test.aig1lzmjp4mejkbwrqwbe45sre.cx.internal.cloudapp.net',
+                last_upload: '2023-05-31T18:34:25.228098Z',
+                os: 'RHEL 8.6',
+                rhsm: '',
+                stale: false,
+                stale_timestamp: '2023-06-01T23:34:24.83586Z',
+                stale_warning_timestamp: '2023-06-08T23:34:24.83586Z',
+                status: 'Installable',
+                tags: []
+            },
+            id: '0313',
+            type: 'system'
+        },
+        {
+            attributes: {
+                baseline_id: 0,
+                baseline_name: '',
+                created: '2023-05-31T18:34:25.073767Z',
+                culled_timestamp: '2023-06-15T23:34:24.83586Z',
+                display_name: 'rhel8-rhui-test.aig1lzmjp4mejkbwrqwbe45sre.cx.internal.cloudapp.net',
+                last_upload: '2023-05-31T18:34:25.228098Z',
+                os: 'RHEL 8.6',
+                rhsm: '',
+                stale: false,
+                stale_timestamp: '2023-06-01T23:34:24.83586Z',
+                stale_warning_timestamp: '2023-06-08T23:34:24.83586Z',
+                status: 'Installable',
+                tags: []
+            },
+            id: '2333',
+            type: 'system'
+        },
+        {
+            attributes: {
+                baseline_id: 0,
+                baseline_name: '',
+                created: '2023-05-31T18:34:25.073767Z',
+                culled_timestamp: '2023-06-15T23:34:24.83586Z',
+                display_name: 'rhel8-rhui-test.aig1lzmjp4mejkbwrqwbe45sre.cx.internal.cloudapp.net',
+                last_upload: '2023-05-31T18:34:25.228098Z',
+                os: 'RHEL 8.6',
+                rhsm: '',
+                stale: false,
+                stale_timestamp: '2023-06-01T23:34:24.83586Z',
+                stale_warning_timestamp: '2023-06-08T23:34:24.83586Z',
+                status: 'Installable',
+                tags: []
+            },
+            id: '4353',
+            type: 'system'
+        },
+        {
+            attributes: {
+                baseline_id: 0,
+                baseline_name: '',
+                created: '2023-05-31T18:34:25.073767Z',
+                culled_timestamp: '2023-06-15T23:34:24.83586Z',
+                display_name: 'rhel8-rhui-test.aig1lzmjp4mejkbwrqwbe45sre.cx.internal.cloudapp.net',
+                last_upload: '2023-05-31T18:34:25.228098Z',
+                os: 'RHEL 8.6',
+                rhsm: '',
+                stale: false,
+                stale_timestamp: '2023-06-01T23:34:24.83586Z',
+                stale_warning_timestamp: '2023-06-08T23:34:24.83586Z',
+                status: 'Installable',
+                tags: []
+            },
+            id: '6373',
+            type: 'system'
+        },
+        {
+            attributes: {
+                baseline_id: 0,
+                baseline_name: '',
+                created: '2023-05-31T18:34:25.073767Z',
+                culled_timestamp: '2023-06-15T23:34:24.83586Z',
+                display_name: 'rhel8-rhui-test.aig1lzmjp4mejkbwrqwbe45sre.cx.internal.cloudapp.net',
+                last_upload: '2023-05-31T18:34:25.228098Z',
+                os: 'RHEL 8.6',
+                rhsm: '',
+                stale: false,
+                stale_timestamp: '2023-06-01T23:34:24.83586Z',
+                stale_warning_timestamp: '2023-06-08T23:34:24.83586Z',
+                status: 'Installable',
+                tags: []
+            },
+            id: '8394',
+            type: 'system'
+        },
+        {
+            attributes: {
+                baseline_id: 0,
+                baseline_name: '',
+                created: '2023-05-31T18:34:25.073767Z',
+                culled_timestamp: '2023-06-15T23:34:24.83586Z',
+                display_name: 'rhel8-rhui-test.aig1lzmjp4mejkbwrqwbe45sre.cx.internal.cloudapp.net',
+                last_upload: '2023-05-31T18:34:25.228098Z',
+                os: 'RHEL 8.6',
+                rhsm: '',
+                stale: false,
+                stale_timestamp: '2023-06-01T23:34:24.83586Z',
+                stale_warning_timestamp: '2023-06-08T23:34:24.83586Z',
+                status: 'Installable',
+                tags: []
+            },
+            id: '0414',
+            type: 'system'
+        },
+        {
+            attributes: {
+                baseline_id: 0,
+                baseline_name: '',
+                created: '2023-05-31T18:34:25.073767Z',
+                culled_timestamp: '2023-06-15T23:34:24.83586Z',
+                display_name: 'rhel8-rhui-test.aig1lzmjp4mejkbwrqwbe45sre.cx.internal.cloudapp.net',
+                last_upload: '2023-05-31T18:34:25.228098Z',
+                os: 'RHEL 8.6',
+                rhsm: '',
+                stale: false,
+                stale_timestamp: '2023-06-01T23:34:24.83586Z',
+                stale_warning_timestamp: '2023-06-08T23:34:24.83586Z',
+                status: 'Installable',
+                tags: []
+            },
+            id: '2434',
+            type: 'system'
+        },
+        {
+            attributes: {
+                baseline_id: 0,
+                baseline_name: '',
+                created: '2023-05-31T18:34:25.073767Z',
+                culled_timestamp: '2023-06-15T23:34:24.83586Z',
+                display_name: 'rhel8-rhui-test.aig1lzmjp4mejkbwrqwbe45sre.cx.internal.cloudapp.net',
+                last_upload: '2023-05-31T18:34:25.228098Z',
+                os: 'RHEL 8.6',
+                rhsm: '',
+                stale: false,
+                stale_timestamp: '2023-06-01T23:34:24.83586Z',
+                stale_warning_timestamp: '2023-06-08T23:34:24.83586Z',
+                status: 'Installable',
+                tags: []
+            },
+            id: '4454',
+            type: 'system'
+        },
+        {
+            attributes: {
+                baseline_id: 0,
+                baseline_name: '',
+                created: '2023-05-31T18:34:25.073767Z',
+                culled_timestamp: '2023-06-15T23:34:24.83586Z',
+                display_name: 'rhel8-rhui-test.aig1lzmjp4mejkbwrqwbe45sre.cx.internal.cloudapp.net',
+                last_upload: '2023-05-31T18:34:25.228098Z',
+                os: 'RHEL 8.6',
+                rhsm: '',
+                stale: false,
+                stale_timestamp: '2023-06-01T23:34:24.83586Z',
+                stale_warning_timestamp: '2023-06-08T23:34:24.83586Z',
+                status: 'Installable',
+                tags: []
+            },
+            id: '6474',
+            type: 'system'
+        }
+    ],
+    meta: {
+        filter: {
+            stale: {
+                op: 'eq',
+                values: ['false']
+            },
+            status: {
+                op: 'in',
+                values: ['Applicable', 'Installable']
+            }
+        },
+        has_systems: true,
+        limit: 20,
+        offset: 0,
+        sort: ['-last_upload'],
+        total_items: 21
+    },
+    status: 200
+};
+
+const mockedSystems2 = {
+    data: [
+        {
+            attributes: {
+                baseline_id: 0,
+                baseline_name: '',
+                created: '2023-05-31T18:34:25.073767Z',
+                culled_timestamp: '2023-06-15T23:34:24.83586Z',
+                display_name: 'rhel8-rhui-test.aig1lzmjp4mejkbwrqwbe45sre.cx.internal.cloudapp.net',
+                last_upload: '2023-05-31T18:34:25.228098Z',
+                os: 'RHEL 8.6',
+                rhsm: '',
+                stale: false,
+                stale_timestamp: '2023-06-01T23:34:24.83586Z',
+                stale_warning_timestamp: '2023-06-08T23:34:24.83586Z',
+                status: 'Installable',
+                tags: []
+            },
+            id: '6474',
+            type: 'system'
+        }
+    ],
+    meta: {
+        filter: {
+            stale: {
+                op: 'eq',
+                values: ['false']
+            },
+            status: {
+                op: 'in',
+                values: ['Applicable', 'Installable']
+            }
+        },
+        has_systems: true,
+        limit: 20,
+        offset: 1,
+        sort: ['-last_upload'],
+        total_items: 21
+    },
+    status: 200
+};*/
+
 export const useSetPage = (limit, callback) => {
     const onSetPage = React.useCallback((_, page) =>
         callback({ offset: getOffsetFromPageLimit(page, limit) })
@@ -142,7 +606,7 @@ export const useDeepCompareEffect = (effect, deps) => {
     React.useEffect(effect, ref.current);
 };
 
-export const useBulkSelectConfig = (selectedCount, onSelect, metadata, rows, onCollapse) => {
+export const useBulkSelectConfig = (selectedCount, onSelect, metadata, rows, onCollapse, queryParams) => {
     const [isBulkLoading, setBulkLoading] = React.useState(false);
 
     return ({
@@ -185,7 +649,8 @@ export const useBulkSelectConfig = (selectedCount, onSelect, metadata, rows, onC
             ] : `     ${selectedCount} selected`
         },
         checked: selectedCount === 0 ? false : selectedCount === metadata.total_items ? true : null,
-        isDisabled: metadata.total_items === 0 && selectedCount === 0
+        isDisabled: (metadata.total_items === 0 && selectedCount === 0)
+        || (queryParams?.filter?.status?.length === 1 && queryParams?.filter?.status?.[0] === 'Applicable')
     });
 };
 
@@ -210,6 +675,7 @@ export const useGetEntities = (fetchApi, apply, config, history, applyMetadata, 
             ...id && { id } || {},
             ...packageName && { package_name: packageName } || {}
         });
+        //const items = page === 1 ? mockedSystems1 : mockedSystems2;
 
         apply({
             page,

--- a/src/Utilities/useOnSelect.js
+++ b/src/Utilities/useOnSelect.js
@@ -79,9 +79,15 @@ const createSelectors = (
     };
 
     const selectAll = (fetchIDs, queryParams) => {
+        queryParams.offset = 0;
         return fetchIDs(queryParams).then(response => {
-            dispatchSelection(createSelectedRow(response));
-            toggleAllSystemsSelected(true);
+            if (Array.isArray(response.data)) {
+                let rowsToSelect = response.data.filter(row => row.status !== 'Applicable');
+                dispatchSelection(createSelectedRow({ data: rowsToSelect }));
+            } else {
+                dispatchSelection(createSelectedRow(response));
+                toggleAllSystemsSelected(true);
+            }
         });
     };
 

--- a/src/Utilities/useOnSelect.test.js
+++ b/src/Utilities/useOnSelect.test.js
@@ -136,7 +136,7 @@ describe('useOnSelect', () => {
             result.current('all', {});
         });
 
-        expect(fetchIDs).toHaveBeenCalledWith('/some/api/endpoint', { limit: -1, search: 'test-search' });
+        expect(fetchIDs).toHaveBeenCalledWith('/some/api/endpoint', { limit: -1, offset: 0, search: 'test-search' });
     });
 
     it('Should skip invalid rows while selection', () => {


### PR DESCRIPTION
Steps to Reproduce:
Navigate to the Advosry details page
Apply status filter-select Applicable
then select all() from filter

This PR correctly avoids selecting systems with the status, "Applicable", which should be disabled. Also check this functionality by going to Inventory -> Systems -> choose a system -> Click Patch tab. This should show the same selection functionality.

This PR also fixes a bug not mentioned in the Jira card. There is a bug on Patch -> Systems where if you select a system and then you go to any page after page 1 and `Select all`, it will only select advisories on that page and after. It will not select any items on previous pages.

# Description

Associated Jira ticket: # (issue)

Please include a summary of the change, what this fixes/creates/improves.


# How to test the PR

Please include steps to test your PR.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
