### PR TITLE
fix(RHINENG-391): Create func for various newline scenarios

### DIFF
--- a/src/Utilities/Helpers.js
+++ b/src/Utilities/Helpers.js
@@ -119,8 +119,15 @@ export function truncate(str, max, end) {
     ) : str;
 }
 
+const findBullets = (description) => {
+    let substringIndex = description.search(/:/);
+    // + 2 accounts for the 2 new lines to separate the sentence from the start of the bullets
+    return substringIndex > 0
+        ? description.slice(0, substringIndex + 2) + preserveNewlines(description.substring(substringIndex + 2)) : description;
+};
+
 export const truncateDescription = (description, wordLength, setWordLength) => (
-    truncate(preserveNewlines(description), wordLength,
+    truncate(findBullets(description), wordLength,
         <a onClick={() => setWordLength(description.length)}>
             {intl.formatMessage(messages.linksReadMore)}
         </a>)
@@ -431,8 +438,8 @@ export function subtractDate(days) {
 
 export function preserveNewlines(input) {
     return input && input.replace(
-        new RegExp('\\n(?=[^\\n])', 'g'),
-        ''
+        new RegExp('\\n\\n(?=.*[\\n\\n])', 'g'),
+        '\n'
     );
 }
 


### PR DESCRIPTION
To see what's broken check the 2 following advisories: RHBA-2023:2052
RHSA-2023:3246

We have 2 different ways that descriptions come in for Advisories. The most common way is to separate every line with `\n\n`. This would create double space between each line. To remedy this, we have a `preserveNewlines` function in `Helpers.js` that removes the extra `\n`.

But, the new variation of description correctly provides `\n\n` for paragraph separations and only `\n` for bullet separations. But with the current `preserveNewlines` functionality, it removes the `\n` for the bullets, making them appear as a single line (see RHBA-2023:2052).

This PR adds an additional function that takes the substring of the description that includes the bullets and replaces any `\n\n` with a single `\n`, ignoring the final `\n\n` because it is for the paragraph that comes after the bullets.

I expect this to fix most, if not all, of our current descriptions. If a new layout for descriptions comes through at some point, it could be broken. The best fix is to standardize the descriptions for all advisories.

# Description

Associated Jira ticket: # (issue)

Please include a summary of the change, what this fixes/creates/improves.


# How to test the PR

Please include steps to test your PR.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
