### PR TITLE
chore: verify preview env better in prod webpack config

### DIFF
--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -4,7 +4,8 @@ const { sentryWebpackPlugin } = require('@sentry/webpack-plugin');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const config = require('@redhat-cloud-services/frontend-components-config');
 const { config: webpackConfig, plugins } = config({
-    rootFolder: resolve(__dirname, '../')
+    rootFolder: resolve(__dirname, '../'),
+    deployment: process.env.BETA === 'true' ? 'beta/apps' : 'apps'
 });
 
 plugins.push(


### PR DESCRIPTION
# Description

Associated Jira ticket: # [(issue)](https://issues.redhat.com/browse/RHINENG-502)

As the app containerized build start getting used, we are required to precisely differentiate preview and stable builds. This makes it possible by adjusting the prod webpack config a bit.


# How to test the PR

Testing happens after gets merged

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
