### PR TITLE
Handle 504 errors with correct empty state

### DIFF
--- a/src/PresentationalComponents/Snippets/ErrorHandler.js
+++ b/src/PresentationalComponents/Snippets/ErrorHandler.js
@@ -45,6 +45,7 @@ const ErrorHandler = ({ code, ErrorState, EmptyState, metadata = {} }) => {
         case 500:
         case 502:
         case 503:
+        case 504:
             return <Unavailable />;
 
         default:


### PR DESCRIPTION
Ticket: https://issues.redhat.com/browse/SPM-2131

Show correct empty state when 504 (Gateway timeout) is received in API response.

## Before:
![Screenshot from 2023-06-30 16-47-51](https://github.com/RedHatInsights/patchman-ui/assets/8426204/4c534b50-b4eb-48ca-a495-ffdf25ecbbda)

## After:
![Screenshot from 2023-06-30 16-47-39](https://github.com/RedHatInsights/patchman-ui/assets/8426204/0f312ff8-6c9d-452c-b27c-23431ec3b36b)
