### PR TITLE
Make package status columns sortable

### DIFF
--- a/src/PresentationalComponents/TableView/TableViewAssets.js
+++ b/src/PresentationalComponents/TableView/TableViewAssets.js
@@ -88,7 +88,7 @@ export const systemPackagesColumns = [
     },
     {
         title: intl.formatMessage(messages.labelsColumnsStatus),
-        transforms: [cellWidth(10)],
+        transforms: [sortable, cellWidth(10)],
         key: 'updatable'
     },
     {

--- a/src/SmartComponents/SystemPackages/__snapshots__/SystemPackages.test.js.snap
+++ b/src/SmartComponents/SystemPackages/__snapshots__/SystemPackages.test.js.snap
@@ -71,6 +71,7 @@ exports[`SystemPackages.js Should match the snapshots 1`] = `
                 "title": "Status",
                 "transforms": Array [
                   [Function],
+                  [Function],
                 ],
               },
               Object {

--- a/src/SmartComponents/Systems/SystemsListAssets.js
+++ b/src/SmartComponents/Systems/SystemsListAssets.js
@@ -105,11 +105,10 @@ export const packageSystemsColumns = [
         }
     },
     {
-        key: 'upgradable',
+        key: 'updatable',
         title: 'Status',
         props: {
-            width: 20,
-            isStatic: true
+            width: 20
         },
         renderFunc: value => createUpgradableColumn(value)
     }

--- a/src/Utilities/DataMappers.js
+++ b/src/Utilities/DataMappers.js
@@ -191,7 +191,6 @@ export const createPackageSystemsRows = (rows, selectedRows = {}) => {
                 available_evra: row.updatable && row.available_evra || row.installed_evra,
                 disableSelection: !row.updatable,
                 updatable: row.updatable,
-                upgradable: row.updatable,
                 selected: selectedRows[row.id] !== undefined,
                 tags: row.tags
             };


### PR DESCRIPTION
Status column in `System detail page > Packages table` and `Packages detail page > Systems table` is now sortable.