### PR TITLE
AdvisoriesPage - Remove unused 'page' parameter from queryParams in the AdvisoryListStore

### DIFF
--- a/src/store/Reducers/AdvisoryListStore.js
+++ b/src/store/Reducers/AdvisoryListStore.js
@@ -9,7 +9,10 @@ import {
     fetchFulfilled
 } from './HelperReducers';
 
-export const AdvisoryListStore = (state = storeListDefaults, action) => {
+// eslint-disable-next-line
+const { queryParams: _queryParams, ...storeListDefaultsModified } = storeListDefaults;
+
+export const AdvisoryListStore = (state = storeListDefaultsModified, action) => {
     let newState = { ...state };
     switch (action.type) {
         case ActionTypes.FETCH_APPLICABLE_ADVISORIES + '_FULFILLED':

--- a/src/store/Reducers/AdvisoryListStore.test.js
+++ b/src/store/Reducers/AdvisoryListStore.test.js
@@ -16,18 +16,21 @@ const fulfilled_payload = {
     }
 };
 
+// eslint-disable-next-line
+const { queryParams: _queryParams, ...advisoryListStoreDefaults } = storeListDefaults;
+
 const error = 'Error';
 
 describe('AdvisoryListStore tests', () => {
     it.each`
     state                | action                                                               | result
-    ${storeListDefaults} | ${{ type: action_fulfilled, payload: fulfilled_payload }}            | ${{ ...storeListDefaults, metadata: fulfilled_payload.meta, rows: fulfilled_payload.data, status: { code: undefined, isLoading: false, hasError: false }, error: {} }}
-    ${storeListDefaults} | ${{ type: action_pending, payload: {} }}                             | ${{ ...storeListDefaults, status: { code: undefined, isLoading: true, hasError: false }, error: {} }}
-    ${storeListDefaults} | ${{ type: EXPAND_ADVISORY_ROW, payload: { rowId: 1, value: true } }} | ${{ ...storeListDefaults, expandedRows: { 1: true } }}
-    ${storeListDefaults} | ${{ type: CHANGE_ADVISORY_LIST_PARAMS, payload: { limit: 10 } }}     | ${{ ...storeListDefaults, queryParams: { limit: 10, offset: 0, page: 1, page_size: 20 } }}
-    ${storeListDefaults} | ${{ type: SELECT_ADVISORY_ROW, payload: { id: 1, selected: true } }} | ${{ ...storeListDefaults, selectedRows: { 1: true } }}
-    ${storeListDefaults} | ${{ type: 'NONSENSE', payload: {} }}                                 | ${storeListDefaults}
-    ${undefined}         | ${{ type: 'NONSENSE', payload: {} }}                                 | ${storeListDefaults}
+    ${advisoryListStoreDefaults} | ${{ type: action_fulfilled, payload: fulfilled_payload }}            | ${{ ...advisoryListStoreDefaults, metadata: fulfilled_payload.meta, rows: fulfilled_payload.data, status: { code: undefined, isLoading: false, hasError: false }, error: {} }}
+    ${advisoryListStoreDefaults} | ${{ type: action_pending, payload: {} }}                             | ${{ ...advisoryListStoreDefaults, status: { code: undefined, isLoading: true, hasError: false }, error: {} }}
+    ${advisoryListStoreDefaults} | ${{ type: EXPAND_ADVISORY_ROW, payload: { rowId: 1, value: true } }} | ${{ ...advisoryListStoreDefaults, expandedRows: { 1: true } }}
+    ${advisoryListStoreDefaults} | ${{ type: CHANGE_ADVISORY_LIST_PARAMS, payload: { limit: 10 } }}     | ${{ ...advisoryListStoreDefaults, queryParams: { limit: 10, offset: 0 } }}
+    ${advisoryListStoreDefaults} | ${{ type: SELECT_ADVISORY_ROW, payload: { id: 1, selected: true } }} | ${{ ...advisoryListStoreDefaults, selectedRows: { 1: true } }}
+    ${advisoryListStoreDefaults} | ${{ type: 'NONSENSE', payload: {} }}                                 | ${advisoryListStoreDefaults}
+    ${undefined}         | ${{ type: 'NONSENSE', payload: {} }}                                 | ${advisoryListStoreDefaults}
     `('$action', ({ state, action: { type, payload }, result }) => {
     const res = AdvisoryListStore(state, { type, payload });
     expect(res).toEqual(result);


### PR DESCRIPTION
# Description

Associated Jira ticket: [#SPM-1623](https://issues.redhat.com/browse/SPM-1623)

Current page is always set to 1 in the URL on Advisories Page, even though the current presented page value it is being handled by a PF4 Pagination component inside the page 
(the 'page' parameter from the queryParams in the AdvisoryListStore is not used).
It was suggested on the ticket by Jiri that the page parameter should be removed completely from the URL
After a conversation with Sebastian, we have decided to also remove page_size from queryParam, because we already handle offset & limit in the URL which have the same purposes of page & page_size

# How to test the PR
Insure the component is working correctly, even without the missing 'page' & 'page_size' parameters from the queryParams.

# Screenshots Before the change
Old URL of the 1st page, with 'page' & 'page_size' query parameters (page is 1 (pink), page_size (orange) & offset is 0 (yellow)): 
![old url with page & page_size queryParams (on page 1)](https://github.com/RedHatInsights/patchman-ui/assets/93318917/6fa7b6c1-6b70-46cb-b9f1-ea23f4ff47e8)

Old URL of the 2nd page, with 'page' query parameter which is still 1 (page is still 1 (pink) & offset is 20 (yellow)): 
![old url with the page queryParam (on page 2)](https://github.com/RedHatInsights/patchman-ui/assets/93318917/37a83db6-a79f-4155-a233-63539cb92935)


Whole Advisories Page on the 1st page (pink: page parameter in the URL is 1 as it should be, green: the 'page' in the page is also 1, yellow: offset is 0 (in the URL), red: the 1st page is being presented, items 1-20 are being shown in the table, insuring we are on the 1st page):
![before - whole page on page 1](https://github.com/RedHatInsights/patchman-ui/assets/93318917/a50af8fc-9e5c-4aad-a2ae-ab230d3d7238)


Whole Advisories Page on the 2nd page (pink: page parameter in the URL is 1 (this is the bug), green: the 'page' in the page is 2, yellow: offset is 20 (in the URL), red: the 2nd page is being presented, items 21-40 are being shown in the table, insuring we are on the 2nd page):
![before - whole page on page 2 (page in the URL is still 1)](https://github.com/RedHatInsights/patchman-ui/assets/93318917/c8abdc93-d16b-41ad-8135-968b76c58c0e)


# Screenshots After the change

New URL of the 1st page, without 'page' & 'page_size' in the query parameters, 'limit' has now swapped 'page_size' ('limit' swapped 'page_size' (pink) & 'offset' is 0 (yellow)): 
![new url without the page & page_size queryParams (on page 1)](https://github.com/RedHatInsights/patchman-ui/assets/93318917/1f76d36c-0454-476a-8131-b8941b7304c2)

New URL of the 2nd page, without 'page' & 'page_size' in the query parameters ('limit' swapped 'page_size' (pink) & 'offset' is 20 (yellow)): 
![new url without page   page_size in queryParams & limit is visible(on page 2)](https://github.com/RedHatInsights/patchman-ui/assets/93318917/7b2a77f7-f6fb-4664-a5c2-ed5708dbabb7)


Whole Advisories Page on the 1st page ('page' parameter is not shown in the URL (the fix), green: the 'page' in the page is 1, yellow: 'offset' is 0, orange: 'limit' has now swapped 'page_size', red: the 1st page is being presented, items 1-20 are being shown in the table, insuring we are on the 1st page):
![after - whole page on page 1 (page was removed from the url   page_size was switched with limit)](https://github.com/RedHatInsights/patchman-ui/assets/93318917/29807ee7-c18b-4f63-a06a-71f67ff69061)

Whole Advisories Page on the 2nd page (the 'page' query parameter in the URL is not shown (the fix), green: the 'page' in the page is 2, yellow: offset is 20, orange: 'limit' has now swapped 'page_size', red: the 2nd page is being presented, items 21-40 are being shown in the table, insuring we are on the 2nd page):
![after - whole page on page 2 (offset is still being handled in the url)](https://github.com/RedHatInsights/patchman-ui/assets/93318917/532b48a8-04b1-403e-8962-6a96fa215527)

# Checklist:

- [X] The commit message has the Jira ticket linked
- [X] PR has a short description
- [X] Screenshots before and after the change are added
- [X] Tests for the changes have been adjusted accordingly 
- [X] README.md is updated if necessary -> no need for an update
- [X] Needs additional dependent work -> no need 