### PR TITLE
fix(RHINENG-1260): OS filter works after refresh

### DIFF
--- a/src/PresentationalComponents/Filters/OsVersionFilter.js
+++ b/src/PresentationalComponents/Filters/OsVersionFilter.js
@@ -35,7 +35,7 @@ const useOsVersionFilter = (currentFilter = '', apply) => {
         }
     }, [versionsLoaded]);
 
-    const osVersionValue = (currentFilter === '' ? [] : currentFilter.split(','))
+    const osVersionValue = (currentFilter === '' ? [] : Array.isArray(currentFilter) ? currentFilter : currentFilter.split(','))
     // patchman uses "RHEL " prefix in values; need to remove
     .map((version) => version.substring(5));
 

--- a/src/PresentationalComponents/Filters/OsVersionFilter.test.js
+++ b/src/PresentationalComponents/Filters/OsVersionFilter.test.js
@@ -1,0 +1,74 @@
+import osVersionFilter from './OsVersionFilter';
+import { useSelector } from 'react-redux';
+
+const apply = jest.fn();
+
+const mockEntities = {
+    operatingSystems: [
+        {
+            label: 'RHEL 8.7',
+            value: '8.7'
+        },
+        {
+            label: 'RHEL 8.8',
+            value: '8.8'
+        },
+        {
+            label: 'RHEL 8.9',
+            value: '8.9'
+        },
+        {
+            label: 'RHEL 9.0',
+            value: '9.0'
+        }
+    ],
+    operatingSystemsLoaded: true
+};
+
+jest.mock('react', () => ({
+    ...jest.requireActual('react'),
+    useState: jest.fn().mockReturnValue(['', () => {}]),
+    useEffect: jest.fn(),
+    useCallback: jest.fn()
+}));
+
+jest.mock('react-redux', () => ({
+    ...jest.requireActual('react-redux'),
+    useSelector: jest.fn()
+}));
+
+jest.mock('@scalprum/react-core', () => ({
+    useLoadModule: jest.fn().mockImplementation(() => [
+        { toGroupSelectionValue: (val) => val, buildOSFilterConfig: (obj) => obj }
+    ])
+}));
+
+beforeEach(() => {
+    useSelector.mockImplementation(callback => {
+        return callback({ entities: mockEntities });
+    });
+});
+
+describe('OsVersionFilter', () => {
+    it('has nothing selected', () => {
+        const response = osVersionFilter('', apply);
+        console.log('RESPONSE', response);
+        expect(response[0].value).toEqual([]);
+    });
+    it('has one selected as a string', () => {
+        const response = osVersionFilter('RHEL 9.0', apply);
+        expect(response[0].value).toEqual(['9.0']);
+    });
+    it('has two selected as a string', () => {
+        const response = osVersionFilter('RHEL 8.9, RHEL 9.0', apply);
+        expect(response[0].value).toEqual(['8.9', ' 9.0']);
+    });
+    it('has one selected as an array', () => {
+        const response = osVersionFilter(['RHEL 8.7'], apply);
+        expect(response[0].value).toEqual(['8.7']);
+    });
+    it('has one selected as an array', () => {
+        const response = osVersionFilter(['RHEL 8.8', 'RHEL 8.9'], apply);
+        expect(response[0].value).toEqual(['8.8', '8.9']);
+    });
+});


### PR DESCRIPTION
# Description

Associated Jira ticket: [RHINENG-1260](https://issues.redhat.com/browse/RHINENG-1260)

When reloading the page the `currentValue` is loaded from the URL and is an `array`. But when you apply an OS filter through the UI it is an `string`. I've added a check for an array so the page doesn't crash.

# How to test the PR

In the systems table apply an OS filter and refresh, the load should be successful.


# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
