### PR TITLE
Refresh System detail tables on template change

### DIFF
--- a/src/SmartComponents/SystemAdvisories/SystemAdvisories.js
+++ b/src/SmartComponents/SystemAdvisories/SystemAdvisories.js
@@ -22,7 +22,7 @@ import { intl } from '../../Utilities/IntlProvider';
 import messages from '../../Messages';
 import { useOnSelect, ID_API_ENDPOINTS } from '../../Utilities/useOnSelect';
 
-const SystemAdvisories = ({ handleNoSystemData, inventoryId }) => {
+const SystemAdvisories = ({ handleNoSystemData, inventoryId, shouldRefresh }) => {
     const dispatch = useDispatch();
     const [firstMount, setFirstMount] = useState(true);
     const advisories = useSelector(
@@ -69,6 +69,12 @@ const SystemAdvisories = ({ handleNoSystemData, inventoryId }) => {
             );
         }
     }, [queryParams]);
+
+    useEffect(() => {
+        if (shouldRefresh) {
+            dispatch(fetchApplicableSystemAdvisories({ id: inventoryId, ...queryParams }));
+        }
+    }, [shouldRefresh]);
 
     const onCollapse = useCallback((_, rowId, value) =>
         dispatch(
@@ -157,6 +163,7 @@ const SystemAdvisories = ({ handleNoSystemData, inventoryId }) => {
 
 SystemAdvisories.propTypes = {
     handleNoSystemData: propTypes.func,
-    inventoryId: propTypes.string.isRequired
+    inventoryId: propTypes.string.isRequired,
+    shouldRefresh: propTypes.bool
 };
 export default SystemAdvisories;

--- a/src/SmartComponents/SystemDetail/InventoryDetail.js
+++ b/src/SmartComponents/SystemDetail/InventoryDetail.js
@@ -35,13 +35,17 @@ const InventoryDetail = () => {
     const { patchSetState, setPatchSetState, openAssignSystemsModal, openUnassignSystemsModal } = usePatchSetState();
 
     useEffect(() => {
+        dispatch(fetchSystemDetailsAction(inventoryId));
+
         return () => {
             dispatch(clearNotifications());
         };
     }, []);
 
     useEffect(() => {
-        dispatch(fetchSystemDetailsAction(inventoryId));
+        if (patchSetState.shouldRefresh) {
+            dispatch(fetchSystemDetailsAction(inventoryId));
+        }
     }, [patchSetState.shouldRefresh]);
 
     const chrome = useChrome();
@@ -117,7 +121,10 @@ const InventoryDetail = () => {
                 </InventoryDetailHead>
             </Header>
             <Main>
-                <SystemDetail inventoryId={inventoryId} />
+                <SystemDetail
+                    inventoryId={inventoryId}
+                    shouldRefresh={patchSetState.shouldRefresh}
+                />
             </Main>
         </DetailWrapper>);
 };

--- a/src/SmartComponents/SystemDetail/SystemDetail.js
+++ b/src/SmartComponents/SystemDetail/SystemDetail.js
@@ -9,7 +9,7 @@ import messages from '../../Messages';
 import { NotConnected } from '@redhat-cloud-services/frontend-components/NotConnected';
 import propTypes from 'prop-types';
 
-const SystemDetail = ({ isInventoryApp, inventoryId }) => {
+const SystemDetail = ({ isInventoryApp, inventoryId, shouldRefresh }) => {
     const { state } = useLocation();
 
     const [activeTabKey, setActiveTabKey] = useState(
@@ -35,6 +35,7 @@ const SystemDetail = ({ isInventoryApp, inventoryId }) => {
                 <SystemAdvisories
                     handleNoSystemData={handleNoSystemData}
                     inventoryId={inventoryId}
+                    shouldRefresh={shouldRefresh}
                 />
             </Tab>
             <Tab
@@ -46,6 +47,7 @@ const SystemDetail = ({ isInventoryApp, inventoryId }) => {
                 <SystemPackages
                     handleNoSystemData={handleNoSystemData}
                     inventoryId={inventoryId}
+                    shouldRefresh={shouldRefresh}
                 />
             </Tab>
         </Tabs>
@@ -54,6 +56,7 @@ const SystemDetail = ({ isInventoryApp, inventoryId }) => {
 
 SystemDetail.propTypes = {
     isInventoryApp: propTypes.bool,
-    inventoryId: propTypes.string.isRequired
+    inventoryId: propTypes.string.isRequired,
+    shouldRefresh: propTypes.bool
 };
 export default SystemDetail;

--- a/src/SmartComponents/SystemDetail/__snapshots__/SystemDetail.test.js.snap
+++ b/src/SmartComponents/SystemDetail/__snapshots__/SystemDetail.test.js.snap
@@ -3,10 +3,10 @@
 exports[`SystemDetail.js Should match the snapshot when Package tab is active by default 1`] = `
 "<Tabs activeKey={1} onSelect={[Function: onTabSelect]} className=\\"patchTabSelect\\" isHidden={true} isFilled={false} isSecondary={false} isVertical={false} isBox={false} hasBorderBottom={true} leftScrollAriaLabel=\\"Scroll left\\" rightScrollAriaLabel=\\"Scroll right\\" component=\\"div\\" mountOnEnter={false} unmountOnExit={false} ouiaSafe={true} variant=\\"default\\" onToggle={[Function: onToggle]}>
   <Tab eventKey={0} title={{...}} data-ouia-component-type=\\"system-advisories-tab\\" data-ouia-component-id=\\"system-advisories-tab\\">
-    <SystemAdvisories handleNoSystemData={[Function: handleNoSystemData]} inventoryId={[undefined]} />
+    <SystemAdvisories handleNoSystemData={[Function: handleNoSystemData]} inventoryId={[undefined]} shouldRefresh={[undefined]} />
   </Tab>
   <Tab eventKey={1} title={{...}} data-ouia-component-type=\\"system-packages-tab\\" data-ouia-component-id=\\"system-packages-tab\\">
-    <SystemPackages handleNoSystemData={[Function: handleNoSystemData]} inventoryId={[undefined]} />
+    <SystemPackages handleNoSystemData={[Function: handleNoSystemData]} inventoryId={[undefined]} shouldRefresh={[undefined]} />
   </Tab>
 </Tabs>"
 `;
@@ -14,10 +14,10 @@ exports[`SystemDetail.js Should match the snapshot when Package tab is active by
 exports[`SystemDetail.js Should match the snapshots 1`] = `
 "<Tabs activeKey={0} onSelect={[Function: onTabSelect]} className=\\"patchTabSelect\\" isHidden={true} isFilled={false} isSecondary={false} isVertical={false} isBox={false} hasBorderBottom={true} leftScrollAriaLabel=\\"Scroll left\\" rightScrollAriaLabel=\\"Scroll right\\" component=\\"div\\" mountOnEnter={false} unmountOnExit={false} ouiaSafe={true} variant=\\"default\\" onToggle={[Function: onToggle]}>
   <Tab eventKey={0} title={{...}} data-ouia-component-type=\\"system-advisories-tab\\" data-ouia-component-id=\\"system-advisories-tab\\">
-    <SystemAdvisories handleNoSystemData={[Function: handleNoSystemData]} inventoryId={[undefined]} />
+    <SystemAdvisories handleNoSystemData={[Function: handleNoSystemData]} inventoryId={[undefined]} shouldRefresh={[undefined]} />
   </Tab>
   <Tab eventKey={1} title={{...}} data-ouia-component-type=\\"system-packages-tab\\" data-ouia-component-id=\\"system-packages-tab\\">
-    <SystemPackages handleNoSystemData={[Function: handleNoSystemData]} inventoryId={[undefined]} />
+    <SystemPackages handleNoSystemData={[Function: handleNoSystemData]} inventoryId={[undefined]} shouldRefresh={[undefined]} />
   </Tab>
 </Tabs>"
 `;

--- a/src/SmartComponents/SystemPackages/SystemPackages.js
+++ b/src/SmartComponents/SystemPackages/SystemPackages.js
@@ -20,7 +20,7 @@ import { usePerPageSelect, useSetPage, useSortColumn, useOnExport } from '../../
 import { intl } from '../../Utilities/IntlProvider';
 import { useOnSelect, ID_API_ENDPOINTS } from '../../Utilities/useOnSelect';
 
-const SystemPackages = ({ handleNoSystemData, inventoryId }) => {
+const SystemPackages = ({ handleNoSystemData, inventoryId, shouldRefresh }) => {
     const dispatch = useDispatch();
     const packages = useSelector(
         ({ SystemPackageListStore }) => SystemPackageListStore.rows
@@ -53,6 +53,12 @@ const SystemPackages = ({ handleNoSystemData, inventoryId }) => {
     useEffect(()=> {
         dispatch(fetchApplicableSystemPackages({ id: inventoryId, ...queryParams }));
     }, [queryParams]);
+
+    useEffect(() => {
+        if (shouldRefresh) {
+            dispatch(fetchApplicableSystemPackages({ id: inventoryId, ...queryParams }));
+        }
+    }, [shouldRefresh]);
 
     const constructFilename = (pkg) => {
         const pkgUpdates = pkg.updates || [];
@@ -140,7 +146,8 @@ const SystemPackages = ({ handleNoSystemData, inventoryId }) => {
 
 SystemPackages.propTypes = {
     handleNoSystemData: propTypes.func,
-    inventoryId: propTypes.string.isRequired
+    inventoryId: propTypes.string.isRequired,
+    shouldRefresh: propTypes.bool
 };
 export default SystemPackages;
 


### PR DESCRIPTION
https://issues.redhat.com/browse/SPM-2062

How to test:

1. Go to system detail page
2. Try to apply/remove template multiple times from the "Actions" toolbar in top-right corner of the page
3. Make sure Advisories and Packages tables are refreshed after applying/removing template and show the correct data