### PR TITLE
Fix System list installable advisories empty state text

### DIFF
--- a/src/SmartComponents/Systems/SystemListAssets.test.js
+++ b/src/SmartComponents/Systems/SystemListAssets.test.js
@@ -19,7 +19,7 @@ describe('SystemListAssets.js', () => {
 
     it('Should call systemsListColumns on Applicable advisories renderFunc with correct params', () => {
         systemsListColumns()[2].renderFunc('testValue');
-        expect(createAdvisoriesIcons).toHaveBeenCalledWith('testValue');
+        expect(createAdvisoriesIcons).toHaveBeenCalledWith('testValue', 'installable');
     });
 
     it('Should call createUpgradableColumn on Status renderFunc with correct params', () => {

--- a/src/SmartComponents/Systems/SystemsListAssets.js
+++ b/src/SmartComponents/Systems/SystemsListAssets.js
@@ -34,7 +34,7 @@ export const systemsListColumns = () => [
         props: {
             width: 15
         },
-        renderFunc: value => createAdvisoriesIcons(value)
+        renderFunc: value => createAdvisoriesIcons(value, 'installable')
     },
     {
         key: 'packages_installed',


### PR DESCRIPTION
https://issues.redhat.com/browse/SPM-2085

On the System list page the "Installable advisories" column used to say "No applicable advisories" instead of "No installable advisories" when the system had no advisories.

## Before:
![Screenshot from 2023-08-28 10-08-45](https://github.com/RedHatInsights/patchman-ui/assets/8426204/87c93712-0a19-4149-8a7b-31d9fa469c4f)

## After:
![Screenshot from 2023-08-28 10-09-07](https://github.com/RedHatInsights/patchman-ui/assets/8426204/7e153524-74c7-47ac-b036-f5c5b8191f80)
