### PR TITLE
Show "Managed by Satellite" in place of Template name

### DIFF
--- a/src/SmartComponents/Systems/SystemsListAssets.js
+++ b/src/SmartComponents/Systems/SystemsListAssets.js
@@ -8,6 +8,17 @@ import {
 import './SystemsListAssets.scss';
 import { sortable } from '@patternfly/react-table';
 import { InsightsLink } from '@redhat-cloud-services/frontend-components/InsightsLink';
+import { Text, TextContent, Tooltip } from '@patternfly/react-core';
+
+export const ManagedBySatelliteCell = () => (
+    <Tooltip content="This system is managed by Satellite and does not use a template.">
+        <TextContent>
+            <Text className="pf-u-font-size-sm">
+                Managed by Satellite
+            </Text>
+        </TextContent>
+    </Tooltip>
+);
 
 export const systemsListColumns = () => [
     {
@@ -21,9 +32,12 @@ export const systemsListColumns = () => [
     {
         key: 'baseline_name',
         title: 'Template',
-        renderFunc: (value, _, row) => value
-            ? <InsightsLink to={{ pathname: `/templates/${row.baseline_id}` }}>{value}</InsightsLink>
-            : 'No template',
+        renderFunc: (value, _, row) =>
+            row.satellite_managed
+                ? <ManagedBySatelliteCell />
+                : value
+                    ? <InsightsLink to={{ pathname: `/templates/${row.baseline_id}` }}>{value}</InsightsLink>
+                    : 'No template',
         props: {
             width: 5
         }
@@ -58,9 +72,12 @@ export const advisorySystemsColumns = () => [
     {
         key: 'baseline_name',
         title: 'Template',
-        renderFunc: (value, _, row) => value
-            ? <InsightsLink to={`/templates/${row.baseline_id}`}>{value}</InsightsLink>
-            : 'No template',
+        renderFunc: (value, _, row) =>
+            row.satellite_managed
+                ? <ManagedBySatelliteCell />
+                : value
+                    ? <InsightsLink to={{ pathname: `/templates/${row.baseline_id}` }}>{value}</InsightsLink>
+                    : 'No template',
         props: {
             width: 5
         }
@@ -101,9 +118,12 @@ export const packageSystemsColumns = [
     {
         key: 'baseline_name',
         title: 'Template',
-        renderFunc: (value, _, row) => value
-            ? <InsightsLink to={`/templates/${row.baseline_id}`}>{value}</InsightsLink>
-            : 'No template',
+        renderFunc: (value, _, row) =>
+            row.satellite_managed
+                ? <ManagedBySatelliteCell />
+                : value
+                    ? <InsightsLink to={{ pathname: `/templates/${row.baseline_id}` }}>{value}</InsightsLink>
+                    : 'No template',
         props: {
             width: 5
         }
@@ -186,3 +206,4 @@ export const systemsRowActions = (
         ] : [])
     ];
 };
+

--- a/src/Utilities/DataMappers.js
+++ b/src/Utilities/DataMappers.js
@@ -15,6 +15,7 @@ import { advisorySeverities, entityTypes } from './constants';
 import { createUpgradableColumn, handleLongSynopsis, handlePatchLink } from './Helpers';
 import { intl } from './IntlProvider';
 import { InsightsLink } from '@redhat-cloud-services/frontend-components/InsightsLink';
+import { ManagedBySatelliteCell } from '../SmartComponents/Systems/SystemsListAssets';
 
 export const createAdvisoriesRows = (rows, expandedRows, selectedRows) => {
     if (rows.length !== 0) {
@@ -362,7 +363,9 @@ export const createSystemsRowsReview = (rows, selectedRows) => {
                         title: attributes.os || 'N/A'
                     },
                     {
-                        title: attributes.baseline_name || 'No template'
+                        title: attributes.satellite_managed
+                            ? <ManagedBySatelliteCell />
+                            : attributes.baseline_name || 'No template'
                     },
                     {
                         title: processDate(attributes.last_upload)


### PR DESCRIPTION
https://issues.redhat.com/browse/RHINENG-2485

How to test:

- Make sure "Managed by Satellite" text with tooltip according to the mockup is inside Template column for systems with "satellite_managed: true" attribute in the following tables
  - Systems list
  - Advisory system list
  - Package system list
  - Systems table inside Template Wizard > Apply to systems step
