### PR TITLE
chore: Update npm run start scripts and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ There is [a comprehensive quick start guide in the Storybook Documentation](http
 
 Note: You will need to set up the Insights environment if you want to develop with the starter app due to the consumption of the chroming service as well as setting up your global/app navigation through the API.
 
-
-
 ## Run the app for the first time
 
 1. ```git clone git@github.com:RedHatInsights/patchman-ui.git```
@@ -76,6 +74,26 @@ Any push to the following branches will trigger a build in [patchman-ui-build re
 | stage-stable                 | stage-stable                  | stage stable      | https://console.stage.redhat.com
 | prod-beta                    | prod-beta                     | production beta   | https://console.redhat.com/preview
 | prod-stable                  | prod-stable                   | production stable | https://console.redhat.com
+
+## Testing federated modules with another application
+
+If you want to test Patch with another application deployed locally, you can utilise `LOCAL_APPS` environment variable and deploy the needed application on separate ports. To learn more about the variable, see https://github.com/RedHatInsights/frontend-components/tree/master/packages/config#running-multiple-local-frontend-applications.
+
+### Example
+
+We'll take for example [insights-inventory-frontend](https://github.com/RedHatInsights/insights-inventory-frontend).
+
+Open new terminal, navigate to Inventory repository, and run it on a separate port without proxy:
+
+```
+npm run start -- --port=8003
+```
+
+In a separate terminal, run Patch with proxy enabled and list Inventory:
+
+```
+LOCAL_APPS=inventory:8003~http npm run start:proxy
+```
 
 ## Patternfly
 

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -2,31 +2,17 @@
 const { resolve } = require('path');
 const config = require('@redhat-cloud-services/frontend-components-config');
 
-const insightsProxy = {
-    https: true,
-    port: process.env.FRONTEND_PORT ? process.env.FRONTEND_PORT : '8002',
-    ...(process.env.BETA && { deployment: 'beta/apps' })
-};
-
-const webpackProxy = {
-    deployment: process.env.BETA ? 'beta/apps' : 'apps',
-    appUrl: process.env.BETA ? ['/beta/insights/patch', '/preview/insights/patch'] : ['/insights/patch'],
-    env: `stage-${process.env.BETA ? 'beta' : 'stable'}`,
-    useProxy: true,
-    proxyVerbose: true,
-    useCloud: false, // until console pre-prod env is ready
-    //localChrome: '/home/muslimjon/RedHat/insights-chrome/build', // for local chrome builds
-    routes: {
-        //   '/beta/config': { host: 'http://localhost:8003' }, // for local CSC config
-    }
-};
-
-const { config: webpackConfig, plugins } = config({
+const proxyConfiguration = {
     rootFolder: resolve(__dirname, '../'),
-    debug: true,
-    useFileHash: false,
-    ...(process.env.PROXY ? webpackProxy : insightsProxy)
-});
+    useProxy: process.env.PROXY === 'true',
+    appUrl: process.env.BETA ? ['/beta/insights/patch', '/preview/insights/patch'] : ['/insights/patch'],
+    deployment: process.env.BETA ? 'beta/apps' : 'apps',
+    env: process.env.BETA ? 'stage-beta' : 'stage-stable',
+    proxyVerbose: true,
+    debug: true
+};
+
+const { config: webpackConfig, plugins } = config(proxyConfiguration);
 
 plugins.push(
     require('@redhat-cloud-services/frontend-components-config/federated-modules')({

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "@cypress/react": "^6.2.1",
         "@formatjs/cli": "^3.2.0",
         "@patternfly/patternfly": "^4.224.2",
-        "@redhat-cloud-services/frontend-components-config": "^5.0.4",
+        "@redhat-cloud-services/frontend-components-config": "^5.1.1",
         "@rollup/plugin-commonjs": "^17.1.0",
         "@rollup/plugin-image": "^2.1.1",
         "@rollup/plugin-json": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@cypress/react": "^6.2.1",
     "@formatjs/cli": "^3.2.0",
     "@patternfly/patternfly": "^4.224.2",
-    "@redhat-cloud-services/frontend-components-config": "^5.0.4",
+    "@redhat-cloud-services/frontend-components-config": "^5.1.1",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-image": "^2.1.1",
     "@rollup/plugin-json": "^4.1.0",


### PR DESCRIPTION
no jira.

This is a quick PR that aims to make npm run start* scripts consistent across Insights frontend applications.