### PR TITLE
feat(RHINENG-1836): Make group column sortable

### DIFF
--- a/src/Utilities/Helpers.js
+++ b/src/Utilities/Helpers.js
@@ -503,6 +503,12 @@ export const filterRemediatablePackageSystems = result => ({ data: result.data.f
 
 export const persistantParams = (patchParams, decodedParams) => {
     const persistantParams = { ...patchParams, ...decodedParams };
+
+    if (typeof persistantParams.sort === 'string' && persistantParams.sort.match(/-?groups/)) {
+        // "group_name" is the sort key used by Inventory (requires translation between Patch and Inventory)
+        persistantParams.sort = persistantParams.sort.replace('groups', 'group_name');
+    }
+
     return (
         {
             page: Number(persistantParams.page || 1),

--- a/src/Utilities/Helpers.test.js
+++ b/src/Utilities/Helpers.test.js
@@ -5,7 +5,7 @@ import { publicDateOptions, remediationIdentifiers } from '../Utilities/constant
 import { addOrRemoveItemFromSet, arrayFromObj, buildFilterChips, changeListParams, convertLimitOffset, 
     createAdvisoriesIcons, createSortBy, decodeQueryparams, encodeApiParams, encodeParams, encodeURLParams,
     getFilterValue, getLimitFromPageSize, getNewSelectedItems, getOffsetFromPageLimit, getRowIdByIndexExpandable, 
-    getSeverityById, handlePatchLink, remediationProvider, mapGlobalFilters, transformPairs, templateDateFormat } from './Helpers';
+    getSeverityById, handlePatchLink, remediationProvider, mapGlobalFilters, transformPairs, templateDateFormat, persistantParams } from './Helpers';
 
 const TestHook = ({ callback }) => {
     callback();
@@ -330,3 +330,49 @@ describe('Test global filters', () => {
     });
 })
 /* eslint-enable */
+
+describe('persistantParams', () => {
+    it('should translate descoded desc group sort parameter correctly', () => {
+        expect(persistantParams({}, { sort: '-groups' })).toEqual({
+            page: 1,
+            perPage: 20,
+            sortBy: {
+                key: 'group_name',
+                direction: 'desc'
+            }
+        });
+    });
+
+    it('should translate descoded asc group sort parameter correctly', () => {
+        expect(persistantParams({}, { sort: 'groups' })).toEqual({
+            page: 1,
+            perPage: 20,
+            sortBy: {
+                key: 'group_name',
+                direction: 'asc'
+            }
+        });
+    });
+
+    it('should translate other descoded desc sort parameter correctly', () => {
+        expect(persistantParams({}, { sort: '-abc' })).toEqual({
+            page: 1,
+            perPage: 20,
+            sortBy: {
+                key: 'abc',
+                direction: 'desc'
+            }
+        });
+    });
+
+    it('should translate other descoded asc sort parameter correctly', () => {
+        expect(persistantParams({}, { sort: 'abc' })).toEqual({
+            page: 1,
+            perPage: 20,
+            sortBy: {
+                key: 'abc',
+                direction: 'asc'
+            }
+        });
+    });
+});

--- a/src/Utilities/SystemHelpers.test.js
+++ b/src/Utilities/SystemHelpers.test.js
@@ -1,0 +1,107 @@
+import { createSystemsSortBy, systemsColumnsMerger } from './SystemsHelpers';
+
+describe('createSystemsSortBy,', () => {
+    it('should translate main parameters', () => {
+        expect(createSystemsSortBy('abc', 'ASC', undefined)).toEqual('abc');
+        expect(createSystemsSortBy('abc', 'DESC', undefined)).toEqual('-abc');
+    });
+
+    it('should translate group name parameter', () => {
+        expect(createSystemsSortBy('group_name', 'ASC', undefined)).toEqual(
+            'groups'
+        );
+        expect(createSystemsSortBy('group_name', 'DESC', undefined)).toEqual(
+            '-groups'
+        );
+    });
+
+    it('should translate updated parameter', () => {
+        expect(createSystemsSortBy('updated', 'ASC', false)).toEqual(
+            'last_upload'
+        );
+        expect(createSystemsSortBy('updated', 'DESC', false)).toEqual(
+            '-last_upload'
+        );
+    });
+
+    it('should translate updated parameter while having last upload', () => {
+        expect(createSystemsSortBy('updated', 'ASC', true)).toEqual(
+            'display_name'
+        );
+        expect(createSystemsSortBy('updated', 'DESC', true)).toEqual(
+            '-display_name'
+        );
+    });
+});
+
+describe('systemsColumnsMerger', () => {
+    const baseColumns = [
+        {
+            key: 'updated'
+        },
+        {
+            key: 'display_name'
+        }
+    ];
+
+    it('should merge basic columns correctly', () => {
+        expect(systemsColumnsMerger(baseColumns, () => []))
+        .toMatchInlineSnapshot(`
+[
+  {
+    "key": "display_name",
+    "renderFunc": [Function],
+  },
+  {
+    "key": "last_upload",
+    "sortKey": "last_upload",
+  },
+]
+`);
+    });
+
+    it('should omit extra columns', () => {
+        expect(
+            systemsColumnsMerger(
+                [...baseColumns, { key: 'omitted' }],
+                () => []
+            ).map(({ key }) => key)
+        ).not.toContain('omitted');
+    });
+
+    it('should keep group column', () => {
+        expect(systemsColumnsMerger([...baseColumns, { key: 'groups' }], () => [])).toMatchInlineSnapshot(`
+[
+  {
+    "key": "display_name",
+    "renderFunc": [Function],
+  },
+  {
+    "key": "groups",
+  },
+  {
+    "key": "last_upload",
+    "sortKey": "last_upload",
+  },
+]
+`);
+    });
+
+    it('should keep tags column', () => {
+        expect(systemsColumnsMerger([...baseColumns, { key: 'tags' }], () => [])).toMatchInlineSnapshot(`
+[
+  {
+    "key": "display_name",
+    "renderFunc": [Function],
+  },
+  {
+    "key": "tags",
+  },
+  {
+    "key": "last_upload",
+    "sortKey": "last_upload",
+  },
+]
+`);
+    });
+});

--- a/src/Utilities/SystemsHelpers.js
+++ b/src/Utilities/SystemsHelpers.js
@@ -85,8 +85,15 @@ export const templateSystemsColumnsMerger = (defaultColumns) => {
 };
 
 export const createSystemsSortBy = (orderBy, orderDirection, hasLastUpload) => {
-    orderBy = (orderBy === 'updated' && !hasLastUpload) && 'last_upload' ||
-        (orderBy === 'updated' && hasLastUpload) && packageSystemsColumns[0].key || orderBy;
+    if (orderBy === 'updated') {
+        if (!hasLastUpload) {
+            orderBy = 'last_upload';
+        } else {
+            orderBy = packageSystemsColumns[0].key;
+        }
+    } else if (orderBy === 'group_name') {
+        orderBy = 'groups'; // patch API service uses 'groups' instead of 'group_name' sort parameter
+    }
 
     let sort = `${orderDirection === 'ASC' ? '' : '-'}${orderBy}`;
 


### PR DESCRIPTION
## Description

Associated Jira ticket: https://issues.redhat.com/browse/RHINENG-1836.

This makes the "Group" column sortable on two views: /patch/systems and /patch/advisories/%id.

## How to test the PR

The Inventory change is not yet merged to ensure that the tenant apps support sorting first and avoid breaking change.

1. Pull this Inventory PR locally https://github.com/RedHatInsights/insights-inventory-frontend/pull/2070.
2. Run Patch with this PR `npm run start -- --port=8004`
3. Run Inventory with `LOCAL_APPS=patch:8004~http npm run start:proxy`
4. Navigate to the updated views (in stage-stable environment) and make sure you can sort by system groups.
5. Check the URL search parameters too: while sorting the table, and then refreshing the page - the same sorting must be applied.

## After the change

<img width="1512" alt="Screenshot 2023-11-01 at 17 03 55" src="https://github.com/RedHatInsights/patchman-ui/assets/31385370/3fc3f8ec-e38d-416e-aee0-4b4656bdee58">

<img width="1512" alt="Screenshot 2023-11-01 at 17 04 10" src="https://github.com/RedHatInsights/patchman-ui/assets/31385370/27cd0b64-2dcd-406c-b726-746dfc4497e4">

## Dependent work link

https://issues.redhat.com/browse/RHINENG-1658

## Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [x] Tests for the changes have been added
- [x] README.md is updated if necessary
- [x] Needs additional dependent work
