### PR TITLE
Do not allow template application for Satellite managed systems

### DIFF
--- a/src/Messages.js
+++ b/src/Messages.js
@@ -694,12 +694,17 @@ export default defineMessages({
     templateSelect: {
         id: 'templateSelect',
         description: 'title with capital letters',
-        defaultMessage: 'Select a template to apply to the selected {systemCount, plural, one {# system} other {# systems}}.'
+        defaultMessage: 'Select a template to apply to the selected {systemCount, plural, one {<b>#</b> system} other {<b>#</b> systems}}.'
     },
     templateSelectExisting: {
         id: 'templateSelectExisting',
         description: 'title with capital letters',
         defaultMessage: 'Select an existing template'
+    },
+    templateSelectSatellite: {
+        id: 'templateSelectSatellite',
+        description: 'title with capital letters',
+        defaultMessage: '<b>{systemCount}</b> of the selected systems content is Managed by Satellite therefore Template is not applicable.'
     },
     templateStepSystems: {
         id: 'templateStepSystems',
@@ -815,6 +820,11 @@ export default defineMessages({
         id: 'textTemplateSelectedSystems',
         description: 'text for patch template wizard',
         defaultMessage: 'You selected {systemsCount, plural, one {<b> # </b> system } other {<b> # </b> systems }}'
+    },
+    textUnassignSystemsNoAssignedSystems: {
+        id: 'textUnassignSystemsNoAssignedSystems',
+        description: 'text about systems being removed',
+        defaultMessage: 'None of the systems you have selected are assigned to existing Patch template.'
     },
     textUnassignSystemsShortTitle: {
         id: 'textUnassignSystemsShortTitle',

--- a/src/SmartComponents/Modals/Helpers.js
+++ b/src/SmartComponents/Modals/Helpers.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { GridItem } from '@patternfly/react-core';
 
 import messages from '../../Messages';
-import { fetchSystems } from '../../Utilities/api';
+import { fetchIDs, fetchSystems } from '../../Utilities/api';
 
 export const filterSystemsWithoutSets = (systemsIDs) =>  {
     return fetchSystems({
@@ -10,7 +10,18 @@ export const filterSystemsWithoutSets = (systemsIDs) =>  {
         filter: { stale: [true, false] }
     }).then((allSystemsWithPatchSet) => {
         return systemsIDs.filter(systemID =>
-            allSystemsWithPatchSet?.data.some(system => system.id === systemID)
+            allSystemsWithPatchSet?.data?.some(system => system.id === systemID)
+        );
+    });
+};
+
+export const filterSatelliteManagedSystems = (systemsIDs) =>  {
+    return fetchIDs('/ids/systems', {
+        limit: -1, 'filter[satellite_managed]': 'false',
+        filter: { stale: [true, false] }
+    }).then((systemsNotManagedBySatellite) => {
+        return systemsIDs.filter(systemID =>
+            systemsNotManagedBySatellite?.data?.some(system => system.id === systemID)
         );
     });
 };

--- a/src/SmartComponents/Modals/UnassignSystemsModal.js
+++ b/src/SmartComponents/Modals/UnassignSystemsModal.js
@@ -62,10 +62,13 @@ const UnassignSystemsModal = ({ unassignSystemsModalState = {}, setUnassignSyste
                 {systemsLoading
                     ? <Skeleton />
                     : <Fragment>
+                        {systemsWithPatchSet.length === 0 &&
+                            renderUnassignModalMessages('textUnassignSystemsNoAssignedSystems', systemsWithPatchSet.length, intl)
+                        }
                         {systemsWithPatchSet.length > 0 &&
                             renderUnassignModalMessages('textUnassignSystemsStatement', systemsWithPatchSet.length, intl)
                         }
-                        {systemsWithoutPatchSetCount > 0 &&
+                        {systemsWithPatchSet.length > 0 && systemsWithoutPatchSetCount > 0 &&
                             renderUnassignModalMessages('textUnassignSystemsWarning', systemsWithoutPatchSetCount, intl)
                         }
                     </Fragment>

--- a/src/SmartComponents/Modals/useUnassignSystemsHook.js
+++ b/src/SmartComponents/Modals/useUnassignSystemsHook.js
@@ -14,13 +14,19 @@ export const useUnassignSystemsHook = (handleModalToggle, systemsWithPatchSet) =
     const dispatch = useDispatch();
     const handleSystemsRemoval = async () => {
         const result = await unassignSystemFromPatchSet({ inventory_ids: systemsWithPatchSet });
+        handleModalToggle(true);
 
-        //TODO: mockups do not have error notifications designed, add them if UX designes.
         if (result.status === 200) {
-            handleModalToggle(true);
             dispatch(
                 addNotification(
                     patchSetUnassignSystemsNotifications(systemsWithPatchSet?.length || 0).success
+                )
+            );
+        }
+        else {
+            dispatch(
+                addNotification(
+                    patchSetUnassignSystemsNotifications().failure
                 )
             );
         }

--- a/src/SmartComponents/PatchSet/PatchSetAssets.js
+++ b/src/SmartComponents/PatchSet/PatchSetAssets.js
@@ -82,12 +82,15 @@ export const CustomActionsToggle = () => <Tooltip content='For editing access, c
     </Button>
 </Tooltip>;
 
-// TODO: Failure notifications
 export const patchSetUnassignSystemsNotifications = (systemsCount) => ({
     success: {
         title: `Systems succesfully removed from this Patch template.`,
         description: `${systemsCount} ${systemsCount > 1 ? 'systems' : 'system'} removed from Patch template(s)`,
         variant: 'success'
+    },
+    failure: {
+        title: `Failed to remove systems from this Patch template.`,
+        variant: 'danger'
     }
 });
 
@@ -96,5 +99,9 @@ export const patchSetAssignSystemsNotifications = (systemsCount) => ({
         title: `Systems succesfully applied to this Patch template.`,
         description: `${systemsCount} ${systemsCount > 1 ? 'systems' : 'system'} added to Patch template(s)`,
         variant: 'success'
+    },
+    failure: {
+        title: `Failed to apply systems to this Patch template.`,
+        variant: 'danger'
     }
 });

--- a/src/SmartComponents/PatchSetWizard/steps/ReviewSystems.js
+++ b/src/SmartComponents/PatchSetWizard/steps/ReviewSystems.js
@@ -48,8 +48,12 @@ export const ReviewSystems = ({ systemsIDs = [], ...props }) => {
 
     useEffect(() => {
         fetchSystems({
-            ...queryParams, filter: { ...queryParams.filter,
-                id: systemsIDs.length > 0 ? `in:${systemsIDs.join(',')}` : undefined }
+            ...queryParams,
+            filter: {
+                ...queryParams.filter,
+                id: systemsIDs.length > 0 ? `in:${systemsIDs.join(',')}` : undefined,
+                satellite_managed: false
+            }
         }).then(result => {
             setSystems(
                 createSystemsRowsReview(
@@ -115,7 +119,11 @@ export const ReviewSystems = ({ systemsIDs = [], ...props }) => {
             endpoint: ID_API_ENDPOINTS.systems,
             queryParams: {
                 ...queryParams,
-                filter: { ...queryParams.filter, ...systemsIDs.length > 0 && { id: `in:${systemsIDs.join(',')}` } }
+                filter: {
+                    ...queryParams.filter,
+                    ...systemsIDs.length > 0 && { id: `in:${systemsIDs.join(',')}` },
+                    satellite_managed: false
+                }
             },
             customSelector: selectRows
         }

--- a/src/SmartComponents/SystemDetail/InventoryDetail.js
+++ b/src/SmartComponents/SystemDetail/InventoryDetail.js
@@ -88,12 +88,13 @@ const InventoryDetail = () => {
                         {
                             title: intl.formatMessage(messages.titlesTemplateAssign),
                             key: 'assign-to-template',
+                            isDisabled: satelliteManaged,
                             onClick: () => openAssignSystemsModal({ [inventoryId]: true })
                         },
                         {
                             title: intl.formatMessage(messages.titlesTemplateRemoveMultipleButton),
                             key: 'remove-from-template',
-                            isDisabled: !patchSetName,
+                            isDisabled: !patchSetName || satelliteManaged,
                             onClick: () => openUnassignSystemsModal([inventoryId])
                         }]}
                     //FIXME: remove this prop after inventory detail gets rid of activeApps in redux

--- a/src/SmartComponents/Systems/SystemsListAssets.js
+++ b/src/SmartComponents/Systems/SystemsListAssets.js
@@ -192,13 +192,14 @@ export const systemsRowActions = (
         },
         ...(showTemplateAssignSystemsModal ? [{
             title: 'Assign to a template',
+            isDisabled: row.satellite_managed,
             onClick: (event, rowId, rowData) => {
                 showTemplateAssignSystemsModal({ [rowData.id]: true });
             }
         },
         {
             title: 'Remove from a template',
-            isDisabled: isPatchSetRemovalDisabled(row),
+            isDisabled: isPatchSetRemovalDisabled(row) || row.satellite_managed,
             onClick: (event, rowId, rowData) => {
                 openUnassignSystemsModal([rowData.id]);
             }


### PR DESCRIPTION
Ticket: https://issues.redhat.com/browse/RHINENG-2489
Mockups: https://www.sketch.com/s/598ac9a1-16ce-47b1-8515-e79928a2b2fb/a/P19w2K1


- Disable row action kebab items related to templates on System list table, but do not disable row checkbox (since Remediation is allowed)
- Disable row action kebab items related to templates in System detail header
- Update Template assignment and removal modals to handle some Satellite managed systems being selected.
- Make sure Systems table in Template wizard contains only Systems not managed by Satellite
