### PR TITLE
feat(RHINENG-6147): introduce paginated requests to fetch applicable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@unleash/proxy-client-react": "^3.5.0",
         "axios": "^0.21.4",
         "jest-environment-jsdom": "^29.7.0",
+        "p-all": "^5.0.0",
         "query-string": "^6.14.1",
         "react": "^17.0.0",
         "react-dom": "^17.0.2",
@@ -24402,6 +24403,31 @@
       "version": "1.2.2",
       "license": "MIT"
     },
+    "node_modules/p-all": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-all/-/p-all-5.0.0.tgz",
+      "integrity": "sha512-pofqu/1FhCVa+78xNAptCGc9V45exFz2pvBRyIvgXkNM0Rh18Py7j8pQuSjA+zpabI46v9hRjNWmL9EAFcEbpw==",
+      "dependencies": {
+        "p-map": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-all/node_modules/p-map": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-6.0.0.tgz",
+      "integrity": "sha512-T8BatKGY+k5rU+Q/GTYgrEf2r4xRMevAN5mtXc2aPc4rS1j3s+vWTaO2Wag94neXuCAUAs8cxBL9EeB5EA6diw==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-each-series": {
       "version": "2.2.0",
       "dev": true,
@@ -48369,6 +48395,21 @@
     },
     "ospath": {
       "version": "1.2.2"
+    },
+    "p-all": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-all/-/p-all-5.0.0.tgz",
+      "integrity": "sha512-pofqu/1FhCVa+78xNAptCGc9V45exFz2pvBRyIvgXkNM0Rh18Py7j8pQuSjA+zpabI46v9hRjNWmL9EAFcEbpw==",
+      "requires": {
+        "p-map": "^6.0.0"
+      },
+      "dependencies": {
+        "p-map": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-6.0.0.tgz",
+          "integrity": "sha512-T8BatKGY+k5rU+Q/GTYgrEf2r4xRMevAN5mtXc2aPc4rS1j3s+vWTaO2Wag94neXuCAUAs8cxBL9EeB5EA6diw=="
+        }
+      }
     },
     "p-each-series": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@unleash/proxy-client-react": "^3.5.0",
     "axios": "^0.21.4",
     "jest-environment-jsdom": "^29.7.0",
+    "p-all": "^5.0.0",
     "query-string": "^6.14.1",
     "react": "^17.0.0",
     "react-dom": "^17.0.2",
@@ -50,6 +51,9 @@
       "<rootDir>/src/SmartComponents/AdvisorySystems/AdvisorySystems.test.js",
       "src/SmartComponents/SystemDetail/InventoryDetail.test.js",
       "src/SmartComponents/PatchSet/PatchSet.test.js"
+    ],
+    "transformIgnorePatterns": [
+      "<rootDir>/node_modules/(?!(@patternfly/react-core/|@patternfly/react-icons/|@redhat-cloud-services|@openshift|lodash-es|@patternfly/react-table|@patternfly/react-tokens|p-all)).*$"
     ]
   },
   "devDependencies": {

--- a/src/SmartComponents/Systems/Systems.js
+++ b/src/SmartComponents/Systems/Systems.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { TableVariant } from '@patternfly/react-table';
 import { InventoryTable } from '@redhat-cloud-services/frontend-components/Inventory';
 import { Main } from '@redhat-cloud-services/frontend-components/Main';
@@ -31,6 +31,7 @@ import { combineReducers } from 'redux';
 import { systemsColumnsMerger } from '../../Utilities/SystemsHelpers';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+import RemediationWizard from '../Remediation/RemediationWizard';
 
 const Systems = () => {
     const store = useStore();
@@ -43,13 +44,9 @@ const Systems = () => {
 
     const [searchParams, setSearchParams] = useSearchParams();
     const dispatch = useDispatch();
-    const [isRemediationOpen, setRemediationOpen] = React.useState(false);
-    const [isRemediationLoading, setRemediationLoading] = React.useState(false);
-    const [
-        RemediationModalCmp,
-        setRemediationModalCmp
-    ] = React.useState(() => () => null);
-
+    const [isRemediationOpen, setRemediationOpen] = useState(false);
+    const [isRemediationLoading, setRemediationLoading] = useState(false);
+    const [remediationIssues, setRemediationIssues] = useState([]);
     const decodedParams = decodeQueryparams('?' + searchParams.toString());
     const systems = useSelector(({ entities }) => entities?.rows || [], shallowEqual);
     const totalItems = useSelector(
@@ -138,7 +135,7 @@ const Systems = () => {
 
     const bulkSelectConfig = useBulkSelectConfig(selectedCount, onSelect, { total_items: totalItems }, systems);
     const activateRemediationModal = useActivateRemediationModal(
-        setRemediationModalCmp,
+        setRemediationIssues,
         setRemediationOpen
     );
 
@@ -150,7 +147,14 @@ const Systems = () => {
             || <React.Fragment>
                 <SystemsStatusReport apply={apply} queryParams={queryParams} />
                 <PatchSetWrapper patchSetState={patchSetState} setPatchSetState={setPatchSetState} />
-                {isRemediationOpen && <RemediationModalCmp /> || null}
+                {isRemediationOpen &&
+                    <RemediationWizard
+                        data={remediationIssues}
+                        isRemediationOpen
+                        setRemediationOpen={setRemediationOpen}
+                    />
+                    || null
+                }
                 <Main>
                     <InventoryTable
                         ref={inventory}

--- a/src/SmartComponents/Systems/Systems.js
+++ b/src/SmartComponents/Systems/Systems.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { TableVariant } from '@patternfly/react-table';
 import { InventoryTable } from '@redhat-cloud-services/frontend-components/Inventory';
 import { Main } from '@redhat-cloud-services/frontend-components/Main';
@@ -22,9 +22,8 @@ import { useBulkSelectConfig, useGetEntities, useOnExport,
     useRemoveFilter, useRemediationDataProvider, usePatchSetState, useOnSelect, ID_API_ENDPOINTS
 } from '../../Utilities/hooks';
 import { intl } from '../../Utilities/IntlProvider';
-import { systemsListColumns, systemsRowActions } from './SystemsListAssets';
+import { systemsListColumns, systemsRowActions, useActivateRemediationModal } from './SystemsListAssets';
 import SystemsStatusReport from '../../PresentationalComponents/StatusReports/SystemsStatusReport';
-import RemediationWizard from '../Remediation/RemediationWizard';
 import AsyncRemediationButton from '../Remediation/AsyncRemediationButton';
 import { buildFilterConfig, buildActiveFiltersConfig } from '../../Utilities/SystemsHelpers';
 import PatchSetWrapper from '../../PresentationalComponents/PatchSetWrapper/PatchSetWrapper';
@@ -86,16 +85,6 @@ const Systems = () => {
         return () => dispatch(clearInventoryReducer());
     }, []);
 
-    const showRemediationModal = useCallback(async (data) => {
-        const resolvedData = await data;
-        setRemediationModalCmp(() =>
-            () => <RemediationWizard
-                data={resolvedData}
-                isRemediationOpen
-                setRemediationOpen={setRemediationOpen} />);
-        setRemediationOpen(!isRemediationOpen);
-    }, [isRemediationOpen]);
-
     function apply(queryParams) {
         dispatch(changeSystemsParams(queryParams));
     }
@@ -148,6 +137,10 @@ const Systems = () => {
     const remediationDataProvider = useRemediationDataProvider(selectedRows, setRemediationLoading, 'systems', areAllSelected);
 
     const bulkSelectConfig = useBulkSelectConfig(selectedCount, onSelect, { total_items: totalItems }, systems);
+    const activateRemediationModal = useActivateRemediationModal(
+        setRemediationModalCmp,
+        setRemediationOpen
+    );
 
     return (
         <React.Fragment>
@@ -191,7 +184,7 @@ const Systems = () => {
                         tableProps={{
                             actionResolver: (row) =>
                                 systemsRowActions(
-                                    showRemediationModal,
+                                    activateRemediationModal,
                                     openAssignSystemsModal,
                                     openUnassignSystemsModal,
                                     row,

--- a/src/SmartComponents/Systems/SystemsListAssets.js
+++ b/src/SmartComponents/Systems/SystemsListAssets.js
@@ -10,7 +10,6 @@ import { sortable } from '@patternfly/react-table';
 import { InsightsLink } from '@redhat-cloud-services/frontend-components/InsightsLink';
 import { Text, TextContent, Tooltip } from '@patternfly/react-core';
 import { useFetchBatched } from '../../Utilities/hooks';
-import RemediationWizard from '../Remediation/RemediationWizard';
 
 export const ManagedBySatelliteCell = () => (
     <Tooltip content="This system is managed by Satellite and does not use a template.">
@@ -166,7 +165,7 @@ const isPatchSetRemovalDisabled = (row) => {
     return !baselineName || (typeof baselineName === 'string' && baselineName === '');
 };
 
-export const useActivateRemediationModal = (setRemediationModalCmp, setRemediationOpen) => {
+export const useActivateRemediationModal = (setRemediationIssues, setRemediationOpen) => {
     const { fetchBatched } = useFetchBatched();
 
     return useCallback(async (rowData) => {
@@ -191,11 +190,7 @@ export const useActivateRemediationModal = (setRemediationModalCmp, setRemediati
                 remediationIdentifiers.advisory
             );
 
-            setRemediationModalCmp(() =>
-                () => <RemediationWizard
-                    data={remediationIssues}
-                    isRemediationOpen
-                    setRemediationOpen={setRemediationOpen} />);
+            setRemediationIssues(remediationIssues);
 
             setRemediationOpen(true);
         })

--- a/src/Utilities/hooks/index.js
+++ b/src/Utilities/hooks/index.js
@@ -3,4 +3,4 @@ export * from './useFeatureFlag';
 export * from './useOnSelect';
 export * from './usePatchSetState';
 export { useRemediationDataProvider } from './useRemediationDataProvider';
-
+export * from './useFetchBatched';

--- a/src/Utilities/hooks/useFetchBatched.js
+++ b/src/Utilities/hooks/useFetchBatched.js
@@ -1,0 +1,37 @@
+import usePromiseQueue from './usePromiseQueue';
+
+export const useFetchBatched = () => {
+    const { isResolving: isLoading, resolve } = usePromiseQueue();
+
+    return {
+        isLoading,
+        fetchBatched: (fetchFunction, total, filter, batchSize = 50) => {
+            const pages = Math.ceil(total / batchSize) || 1;
+
+            const results = resolve(
+                [...new Array(pages)].map(
+                    // eslint-disable-next-line camelcase
+                    (_, pageIdx) => () =>
+                        fetchFunction(filter, { offset: pageIdx + 1, limit: batchSize })
+                )
+            );
+
+            return results;
+        },
+        fetchBatchedInline: (fetchFunction, list, batchSize = 20) => {
+            const pages = Math.ceil(list.length / batchSize) || 1;
+
+            const results = resolve(
+                [...new Array(pages)].map(
+                    (_, pageIdx) => () =>
+                        fetchFunction(
+                            list.slice(batchSize * pageIdx, batchSize * (pageIdx + 1))
+                        )
+                )
+            );
+
+            return results;
+        }
+    };
+};
+

--- a/src/Utilities/hooks/usePromiseQueue.js
+++ b/src/Utilities/hooks/usePromiseQueue.js
@@ -1,0 +1,38 @@
+import { useCallback, useState } from 'react';
+import pAll from 'p-all';
+
+const DEFAULT_CONCURRENT_PROMISES = 2;
+
+const usePromiseQueue = (limit = DEFAULT_CONCURRENT_PROMISES) => {
+    const [results, setResults] = useState({
+        isResolving: false,
+        promiseResults: undefined
+    });
+
+    const resolve = useCallback(
+        async (fns) => {
+            setResults((state) => ({
+                ...state,
+                isResolving: true
+            }));
+            const results = await pAll(fns, {
+                concurrency: limit
+            });
+            setResults({
+                isResolving: false,
+                promiseResults: results
+            });
+
+            return results;
+        },
+        [limit]
+    );
+
+    return {
+        isResolving: results.isResolving,
+        results: results.promiseResults,
+        resolve
+    };
+};
+
+export default usePromiseQueue;


### PR DESCRIPTION
# Description

Associated Jira ticket: https://issues.redhat.com/browse/RHINENG-6147

TO BE REVIEWED AFTER: https://github.com/RedHatInsights/patchman-ui/pull/1154. This is intended to clean up hooks used in the codebase before introducing new ones for RHINENG-6147.

Introduces batched/paginated requests to fetch applicable advisories that are used to populate the remediation modal. This is required by the backend as they have disabled fetching everything using limit=-1. There should no be change in the functionality

# How to test the PR

1. Navigate to the systems page
2. click on some row action kebab
3. click on the 'Apply applicable advisories' action item
4. Observe that the remediation modal opens, the number of fetched issues matches with the total count and remedition can be generated

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
