### PR TITLE
chore(deps): Update axios to fix CVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@redhat-cloud-services/host-inventory-client": "^1.2.2",
         "@scalprum/react-core": "^0.4.1",
         "@unleash/proxy-client-react": "^3.5.0",
-        "axios": "^0.21.4",
+        "axios": "^0.28.0",
         "jest-environment-jsdom": "^29.7.0",
         "p-all": "^5.0.0",
         "query-string": "^6.14.1",
@@ -4857,8 +4857,9 @@
     },
     "node_modules/@redhat-cloud-services/frontend-components-config/node_modules/axios": {
       "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.14.9",
         "form-data": "^4.0.0"
@@ -5017,8 +5018,9 @@
     },
     "node_modules/@redhat-cloud-services/frontend-components-config/node_modules/form-data": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -5898,7 +5900,8 @@
     },
     "node_modules/@redhat-cloud-services/frontend-components-utilities/node_modules/axios": {
       "version": "0.27.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "dependencies": {
         "follow-redirects": "^1.14.9",
         "form-data": "^4.0.0"
@@ -5910,7 +5913,8 @@
     },
     "node_modules/@redhat-cloud-services/frontend-components-utilities/node_modules/form-data": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -5987,7 +5991,8 @@
     },
     "node_modules/@redhat-cloud-services/host-inventory-client/node_modules/axios": {
       "version": "0.27.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "dependencies": {
         "follow-redirects": "^1.14.9",
         "form-data": "^4.0.0"
@@ -5995,7 +6000,8 @@
     },
     "node_modules/@redhat-cloud-services/host-inventory-client/node_modules/form-data": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -6015,7 +6021,8 @@
     },
     "node_modules/@redhat-cloud-services/rbac-client/node_modules/axios": {
       "version": "0.27.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "peer": true,
       "dependencies": {
         "follow-redirects": "^1.14.9",
@@ -6024,7 +6031,8 @@
     },
     "node_modules/@redhat-cloud-services/rbac-client/node_modules/form-data": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -8433,11 +8441,32 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "0.21.4",
-      "license": "MIT",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.0.tgz",
+      "integrity": "sha512-Tu7NYoGY4Yoc7I+Npf9HhUMtEEpV7ZiLH9yndTCoNhcpBH0kwcvFbzYN9/u5QKI5A6uefjsNNWaz5olJVYS62Q==",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/babel-core": {
       "version": "7.0.0-bridge.0",
@@ -34841,6 +34870,8 @@
         },
         "axios": {
           "version": "0.27.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
           "dev": true,
           "requires": {
             "follow-redirects": "^1.14.9",
@@ -34956,6 +34987,8 @@
         },
         "form-data": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
           "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
@@ -35618,6 +35651,8 @@
       "dependencies": {
         "axios": {
           "version": "0.27.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
           "requires": {
             "follow-redirects": "^1.14.9",
             "form-data": "^4.0.0"
@@ -35628,6 +35663,8 @@
         },
         "form-data": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
@@ -35644,6 +35681,8 @@
       "dependencies": {
         "axios": {
           "version": "0.27.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
           "requires": {
             "follow-redirects": "^1.14.9",
             "form-data": "^4.0.0"
@@ -35651,6 +35690,8 @@
         },
         "form-data": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
@@ -35668,6 +35709,8 @@
       "dependencies": {
         "axios": {
           "version": "0.27.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
           "peer": true,
           "requires": {
             "follow-redirects": "^1.14.9",
@@ -35676,6 +35719,8 @@
         },
         "form-data": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
           "peer": true,
           "requires": {
             "asynckit": "^0.4.0",
@@ -37379,9 +37424,30 @@
       "version": "1.12.0"
     },
     "axios": {
-      "version": "0.21.4",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.0.tgz",
+      "integrity": "sha512-Tu7NYoGY4Yoc7I+Npf9HhUMtEEpV7ZiLH9yndTCoNhcpBH0kwcvFbzYN9/u5QKI5A6uefjsNNWaz5olJVYS62Q==",
       "requires": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "proxy-from-env": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+          "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+        }
       }
     },
     "babel-core": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@redhat-cloud-services/host-inventory-client": "^1.2.2",
     "@scalprum/react-core": "^0.4.1",
     "@unleash/proxy-client-react": "^3.5.0",
-    "axios": "^0.21.4",
+    "axios": "^0.28.0",
     "jest-environment-jsdom": "^29.7.0",
     "p-all": "^5.0.0",
     "query-string": "^6.14.1",

--- a/src/Utilities/axiosInterceptors.js
+++ b/src/Utilities/axiosInterceptors.js
@@ -9,18 +9,16 @@ const axiosInstance = axios.create();
 export function errorInterceptor(err) {
 
     if (!axios.isCancel(err)) {
+        const { response } = { ...err };
 
-        const { response, isAxiosError } = { ...err };
-
-        if (response && isAxiosError) {
+        if (response && err.isAxiosError) {
             const { status, statusText, data } = response;
 
             if (!status) {
                 return err;
             } else {
                 const genericError = {
-                    title:
-                            'There was an error getting data'
+                    title: 'There was an error getting data'
                 };
 
                 const result = { ...genericError, detail: data.error || statusText, status };


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHINENG-8635

Axios did have an [error handler refactoring](https://github.com/axios/axios/pull/3645) in [0.27.0](https://github.com/axios/axios/releases/tag/v0.27.0), therefore I had to change the accessor to `isAxiosError`.