### PR TITLE
fix(RHINENG-8745): update patch status filter keys

### DIFF
--- a/src/PresentationalComponents/Filters/PackagesListStatusFilter.js
+++ b/src/PresentationalComponents/Filters/PackagesListStatusFilter.js
@@ -5,10 +5,10 @@ import messages from '../../Messages';
 
 const packagesListStatusFilter = (apply, currentFilter = {}) => {
 
-    let { systems_updatable: currentValue } = currentFilter;
+    let { systems_applicable: currentValue } = currentFilter;
 
     const filterByType = value => {
-        apply({ filter: { systems_updatable: value } });
+        apply({ filter: { systems_applicable: value } });
     };
 
     return {

--- a/src/PresentationalComponents/Filters/PackagesListStatusFilter.test.js
+++ b/src/PresentationalComponents/Filters/PackagesListStatusFilter.test.js
@@ -1,7 +1,7 @@
 import packageListStatusFilter from './PackagesListStatusFilter';
 
 const apply = jest.fn();
-const currentFilter = { systems_updatable: 'filter' };
+const currentFilter = { systems_applicable: 'filter' };
 
 describe('PackageListStatusFilter', () => {
     it('Should set currentValue to zero and init', () => {
@@ -14,13 +14,13 @@ describe('PackageListStatusFilter', () => {
     it('Should call apply with a date', () => {
         const response = packageListStatusFilter(apply, currentFilter);
         response.filterValues.onChange('event', 'testValue');
-        expect(apply).toHaveBeenCalledWith({ filter: { systems_updatable: 'testValue' } });
+        expect(apply).toHaveBeenCalledWith({ filter: { systems_applicable: 'testValue' } });
     });
 
     it('Should call apply with empty string ', () => {
         const response = packageListStatusFilter(apply);
         response.filterValues.onChange();
-        expect(apply).toHaveBeenCalledWith({ filter: { systems_updatable: 'testValue' } });
+        expect(apply).toHaveBeenCalledWith({ filter: { systems_applicable: 'testValue' } });
     });
 });
 

--- a/src/Utilities/api.js
+++ b/src/Utilities/api.js
@@ -76,12 +76,12 @@ export const fetchPackageVersions = params => {
 };
 
 export const fetchPackagesList = params => {
-    const { systems_updatable: systemsUpdatable } = params.filter;
+    const { systems_applicable: systemsUpdatable } = params.filter;
 
-    // we have to reset systems_updatable filter to include all filters when we want to show all the data
+    // we have to reset systems_applicable filter to include all filters when we want to show all the data
     if (Array.isArray(systemsUpdatable) && systemsUpdatable.length === 2) {
         const paramsWithoutSystemsUpdatable = JSON.parse(JSON.stringify(params));
-        delete paramsWithoutSystemsUpdatable.filter.systems_updatable;
+        delete paramsWithoutSystemsUpdatable.filter.systems_applicable;
 
         return createApiCall('/packages', 'v3', 'get', paramsWithoutSystemsUpdatable);
     }

--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -54,7 +54,7 @@ export const systemPackagesDefaultFilters = {
 };
 
 export const packagesListDefaultFilters = {
-    filter: { systems_updatable: ['gt:0'] }
+    filter: { systems_applicable: ['gt:0'] }
 };
 
 export const systemsListDefaultFilters = {
@@ -234,7 +234,7 @@ export const filterCategories = {
         label: 'Status',
         values: updatableTypes
     },
-    systems_updatable: {
+    systems_applicable: {
         label: 'Status',
         values: packagesListUpdatableTypes
     },

--- a/src/Utilities/hooks/Hooks.test.js
+++ b/src/Utilities/hooks/Hooks.test.js
@@ -107,8 +107,8 @@ describe('Custom hooks tests', () => {
 
     it.each`
     filter                    | apply        | selected                                       |finalResult
-    ${{ advisory_type: 2 }}     | ${jest.fn()} | ${[{ id: "advisory_type", chips: [{ id: 1 }] }]} | ${{ filter: { advisory_type: undefined, systems_updatable: ["gt:0"] } }}
-    ${{ search: "asd" }}        | ${jest.fn()} | ${[{ id: "search" }]}                           | ${{ filter: { systems_updatable: ["gt:0"] }, search: '' }}
+    ${{ advisory_type: 2 }}     | ${jest.fn()} | ${[{ id: "advisory_type", chips: [{ id: 1 }] }]} | ${{ filter: { advisory_type: undefined, systems_applicable: ["gt:0"] } }}
+    ${{ search: "asd" }}        | ${jest.fn()} | ${[{ id: "search" }]}                           | ${{ filter: { systems_applicable: ["gt:0"] }, search: '' }}
     `('useRemoveFilter: should reset to default filters for $filter while ', ({ filter, apply, finalResult, selected }) => {
         const { result } = renderHook(() => useRemoveFilter(filter, apply, packagesListDefaultFilters));
         result.current[0]({}, selected, true)


### PR DESCRIPTION
# Description

Associated Jira ticket: # [(issue)](https://issues.redhat.com/browse/RHINENG-8745)

This fixes the broken packages page by updating the Patch status filter key from system_updatable which is obsolete to the new systems_applicable


# How to test the PR
1. Visit the packages page
2. Observe that the page works as expected and the table is filtered by **Systems with patches available** by default
3. From the filters dropdown find **Patch status** filter
4. Play with it, make sure it works correclt

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
