### PR TITLE
change(RemediationButton):RHINENG-3123 text for no advisory systems

### DIFF
--- a/src/SmartComponents/Remediation/AsyncRemediationButton.js
+++ b/src/SmartComponents/Remediation/AsyncRemediationButton.js
@@ -7,7 +7,7 @@ import { Spinner } from '@patternfly/react-core';
 import { intl } from '../../Utilities/IntlProvider';
 import messages from '../../Messages';
 
-const AsyncRemediationButton = ({ remediationProvider, isDisabled, isLoading }) => {
+const AsyncRemediationButton = ({ remediationProvider, isDisabled, isLoading, patchNoAdvisoryText }) => {
     const dispatch = useDispatch();
 
     const handleRemediationSuccess = res => {
@@ -23,6 +23,7 @@ const AsyncRemediationButton = ({ remediationProvider, isDisabled, isLoading }) 
             onRemediationCreated={handleRemediationSuccess}
             isDisabled={isDisabled}
             buttonProps={{ isLoading }}
+            patchNoAdvisoryText={patchNoAdvisoryText}
         >
             {intl.formatMessage(messages.labelsRemediate)}
         </AsyncComponent>
@@ -32,7 +33,8 @@ const AsyncRemediationButton = ({ remediationProvider, isDisabled, isLoading }) 
 AsyncRemediationButton.propTypes = {
     remediationProvider: propTypes.func,
     isDisabled: propTypes.bool,
-    isLoading: propTypes.bool
+    isLoading: propTypes.bool,
+    patchNoAdvisoryText: propTypes.string
 };
 
 export default AsyncRemediationButton;

--- a/src/SmartComponents/Systems/SystemsTable.js
+++ b/src/SmartComponents/Systems/SystemsTable.js
@@ -9,7 +9,7 @@ import { inventoryEntitiesReducer, modifyInventory } from '../../store/Reducers/
 import {
     exportSystemsCSV, exportSystemsJSON, fetchSystems
 } from '../../Utilities/api';
-import { systemsListDefaultFilters } from '../../Utilities/constants';
+import { systemsListDefaultFilters, NO_ADVISORIES_TEXT } from '../../Utilities/constants';
 import {
     arrayFromObj, persistantParams, filterSelectedActiveSystemIDs
 } from '../../Utilities/Helpers';
@@ -191,6 +191,7 @@ const SystemsTable = ({
                             arrayFromObj(selectedRows).length === 0 || isRemediationLoading
                         }
                         isLoading={isRemediationLoading}
+                        patchNoAdvisoryText={NO_ADVISORIES_TEXT}
                     />,
                     {
                         key: 'assign-multiple-systems',

--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -314,3 +314,5 @@ export const featureFlags = {
 
 export const TEMPLATES_DOCS_LINK = 'https://access.redhat.com/documentation/en-us/red_hat_insights/2022/html/'
     + 'system_patching_using_ansible_playbooks_via_remediations/index';
+
+export const NO_ADVISORIES_TEXT = 'There is no installable content that can be remediated with Ansible for selected systems.';


### PR DESCRIPTION
Change wording in NoDataModal when a system with no advisories is remediated

Associated Jira ticket: RHINENG-3123

# How to test 

1. Run this PR with https://github.com/RedHatInsights/insights-remediations-frontend/pull/408
2. Go to Patch systems page
3. Select system with no advisories available
4. The modal should have changed wording

# Before the change
![image](https://github.com/RedHatInsights/insights-remediations-frontend/assets/62351699/3c5b4fcc-992e-43bf-931a-476e1f9777e6)

# After the change
![image](https://github.com/RedHatInsights/patchman-ui/assets/62351699/16c8fadd-2f1d-4c29-94ef-f2326ee36230)

# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [x] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
