### PR TITLE
fix(RHINENG-8948): update request content-type for vulnerability api calls

### DIFF
--- a/src/Utilities/api.js
+++ b/src/Utilities/api.js
@@ -95,8 +95,8 @@ export const fetchCvesInfo = async ({ cveIds }) => {
         method: 'POST',
         credentials: 'include',
         headers: {
-            Accept: 'application/json',
-            'Content-Type': 'application/json'
+            Accept: 'application/vnd.api+json',
+            'Content-Type': 'application/vnd.api+json'
         },
         body: JSON.stringify({ cve_list: cveIds })
     }).then(res => res.json()).then(data => data).catch(err => err);


### PR DESCRIPTION
Updates the request content-type from application/json to application/vnd.api+json. After the vulnerability api has upgraded their connexion package, application/json type is no longer supported