### PR TITLE
refactor(TemplateWizard): Remove obsolete code

### DIFF
--- a/src/PresentationalComponents/Snippets/EmptyStates.js
+++ b/src/PresentationalComponents/Snippets/EmptyStates.js
@@ -81,13 +81,6 @@ export const NoPatchSetList = ({ Button }) => (
             {intl.formatMessage(messages.statesNoTemplateBody)}
             <br />
             <br />
-            {/*
-            <a href={TEMPLATES_DOCS_LINK} target="__blank" rel="noopener noreferrer">
-                {intl.formatMessage(messages.statesNoTemplateLink)} <ExternalLinkAltIcon />
-            </a>
-            <br />
-            <br />
-            */}
             <Button />
         </EmptyStateBody>
     </EmptyState>

--- a/src/SmartComponents/PatchSet/PatchSet.js
+++ b/src/SmartComponents/PatchSet/PatchSet.js
@@ -178,13 +178,6 @@ const PatchSet = () => {
                         bodyContent={
                             intl.formatMessage(messages.templatePopoverBody)
                         }
-                    /*
-                    footerContent={
-                        <a href={TEMPLATES_DOCS_LINK} target="__blank" rel="noopener noreferrer">
-                            {intl.formatMessage(messages.linksLearnMore)} <ExternalLinkAltIcon />
-                        </a>
-                    }
-                    */
                     >
                         <Icon>
                             <OutlinedQuestionCircleIcon

--- a/src/SmartComponents/PatchSetWizard/PatchSetWizard.js
+++ b/src/SmartComponents/PatchSetWizard/PatchSetWizard.js
@@ -77,7 +77,6 @@ export const PatchSetWizard = ({ systemsIDs, setBaselineState, patchSetID }) => 
         },
         configurationStep: {
             component: ConfigurationStepFields,
-            systemsIDs: systemsIDs || [],
             patchSetID
         },
         reviewSystems: {
@@ -129,11 +128,6 @@ export const PatchSetWizard = ({ systemsIDs, setBaselineState, patchSetID }) => 
                         description={
                             <Fragment>
                                 {intl.formatMessage(messages.templateDescription)}
-                                {/*<a href={TEMPLATES_DOCS_LINK} target="__blank" rel="noopener noreferrer"
-                                    className="pf-v5-u-ml-sm">
-                                    {intl.formatMessage(messages.labelsDocumentation)}
-                                    <ExternalLinkAltIcon className="pf-v5-u-ml-xs"/>
-                                </a>*/}
                             </Fragment>
                         }
                         steps={[

--- a/src/SmartComponents/PatchSetWizard/WizardAssets.js
+++ b/src/SmartComponents/PatchSetWizard/WizardAssets.js
@@ -101,11 +101,6 @@ export const schema = (wizardType) => {
                 title: getWizardTitle(wizardType),
                 description: <Fragment>
                     {intl.formatMessage(messages.templateDescription)}
-                    {/*
-                    <a href={TEMPLATES_DOCS_LINK} target="__blank" rel="noopener noreferrer" className="pf-v5-u-ml-sm">
-                        {intl.formatMessage(messages.labelsDocumentation)}
-                        <ExternalLinkAltIcon className="pf-v5-u-ml-xs"/>
-                    </a>*/}
                 </Fragment>,
                 fields: [
                     {

--- a/src/SmartComponents/PatchSetWizard/steps/ConfigurationStepFields.js
+++ b/src/SmartComponents/PatchSetWizard/steps/ConfigurationStepFields.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import propTypes from 'prop-types';
 import { useSelector, shallowEqual } from 'react-redux';
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
@@ -6,31 +6,17 @@ import {
     Text,
     TextContent,
     Stack,
-    StackItem,
-    Radio,
-    TextVariants
+    StackItem
 } from '@patternfly/react-core';
 import { intl } from '../../../Utilities/IntlProvider';
 import messages from '../../../Messages';
-import SelectExistingSets from '../InputFields/SelectExistingSets';
 import ConfigurationFields from '../InputFields/ConfigurationFields';
 
-const ConfigurationStepFields = ({ systemsIDs, patchSetID }) => {
+const ConfigurationStepFields = ({ patchSetID }) => {
     const formOptions = useFormApi();
-    // TODO: Cleanup this unused code later
-    const shouldShowRadioButtons = false;
-
-    const [shouldApplyExisting, setShouldApplyExisting] = useState(false);
-    const [shouldCreateNew, setShouldCreateNew] = useState(true);
-    const [selectedPatchSet, setSelectedPatchSet] = useState([]);
 
     const { patchSet, status, areTakenTemplateNamesLoading } =
         useSelector(({ SpecificPatchSetReducer }) => SpecificPatchSetReducer, shallowEqual);
-
-    const handleRadioChange = () => {
-        setShouldCreateNew(!shouldCreateNew);
-        setShouldApplyExisting(!shouldApplyExisting);
-    };
 
     useEffect(() => {
         if (patchSetID) {
@@ -53,54 +39,16 @@ const ConfigurationStepFields = ({ systemsIDs, patchSetID }) => {
             <StackItem>
                 {intl.formatMessage(messages.templateDetailStepText)}
             </StackItem>
-            {shouldShowRadioButtons && <TextContent style={{ marginTop: '-15px' }}>
-                <Text component={TextVariants.p}>
-                    {intl.formatMessage(
-                        messages.textTemplateSelectedSystems,
-                        { systemsCount: systemsIDs.length, b: (...chunks) => <b>{chunks}</b> }
-                    )}
-                </Text>
-            </TextContent>}
             <StackItem>
-                <Stack hasGutter>
-                    {shouldShowRadioButtons && (<><StackItem>
-                        <Radio
-                            isChecked={shouldApplyExisting}
-                            name="radio"
-                            onChange={handleRadioChange}
-                            label={intl.formatMessage(messages.textTemplateAddToExisting)}
-                            id="existing-template"
-                        />
-                    </StackItem>
-                    <StackItem>
-                        {shouldApplyExisting ? <SelectExistingSets
-                            setSelectedPatchSet={setSelectedPatchSet}
-                            selectedSets={selectedPatchSet}
-                            systems={systemsIDs}
-                        /> : null}
-                    </StackItem>
-                    <StackItem>
-                        <Radio
-                            isChecked={shouldCreateNew}
-                            name="radio"
-                            onChange={handleRadioChange}
-                            label={intl.formatMessage(messages.textTemplateCreateNew)}
-                            id="new-template"
-                        />
-                    </StackItem></>) || null}
-                    <StackItem>
-                        {shouldCreateNew ? <ConfigurationFields
-                            isLoading={(patchSetID && status.isLoading) || areTakenTemplateNamesLoading}
-                        /> : null}
-                    </StackItem>
-                </Stack>
+                <ConfigurationFields
+                    isLoading={(patchSetID && status.isLoading) || areTakenTemplateNamesLoading}
+                />
             </StackItem>
         </Stack>
     );
 };
 
 ConfigurationStepFields.propTypes = {
-    systemsIDs: propTypes.array,
     patchSetID: propTypes.string
 };
 export default ConfigurationStepFields;

--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -312,7 +312,4 @@ export const featureFlags = {
     patch_set: 'patch.patch_set'
 };
 
-export const TEMPLATES_DOCS_LINK = 'https://access.redhat.com/documentation/en-us/red_hat_insights/2022/html/'
-    + 'system_patching_using_ansible_playbooks_via_remediations/index';
-
 export const NO_ADVISORIES_TEXT = 'There is no installable content that can be remediated with Ansible for selected systems.';


### PR DESCRIPTION
- removed commented in docs template link that was planned, but later scrapped
- removed dead code in `ConfigurationStepFields` which was unreachable due to `shouldShowRadioButtons = false;`, this code was only used for migrations between two development versions of Template wizard