### PR TITLE
fix(RHINENG-9035): bulk select all icon fixed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@patternfly/react-core": "^5.2.0",
         "@patternfly/react-icons": "^5.2.0",
         "@patternfly/react-table": "^5.2.0",
-        "@redhat-cloud-services/frontend-components": "^4.2.4",
+        "@redhat-cloud-services/frontend-components": "^4.2.8",
         "@redhat-cloud-services/frontend-components-notifications": "^4.1.0",
         "@redhat-cloud-services/frontend-components-remediations": "^3.2.11",
         "@redhat-cloud-services/frontend-components-translations": "^3.2.7",
@@ -4893,9 +4893,9 @@
       "dev": true
     },
     "node_modules/@redhat-cloud-services/frontend-components": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-4.2.5.tgz",
-      "integrity": "sha512-lTVew1R6LccTMqDoaevtk6WBbH0VoiNPspPMSuEYT+/JIQLjs5NgpBNWTGImyp/4/JFwMiQq0ewtimQLq0E3Ig==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-4.2.8.tgz",
+      "integrity": "sha512-h9Zdl8JfS0X4EpUORAue6SR50M8xX0LOKMdnp7L9S34qix47YaJ+SydqloHQkmLhGicv6ZmI6ttbbDbEv0guLA==",
       "dependencies": {
         "@patternfly/react-component-groups": "^5.0.0",
         "@redhat-cloud-services/frontend-components-utilities": "^4.0.0",
@@ -38537,9 +38537,9 @@
       "dev": true
     },
     "@redhat-cloud-services/frontend-components": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-4.2.5.tgz",
-      "integrity": "sha512-lTVew1R6LccTMqDoaevtk6WBbH0VoiNPspPMSuEYT+/JIQLjs5NgpBNWTGImyp/4/JFwMiQq0ewtimQLq0E3Ig==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-4.2.8.tgz",
+      "integrity": "sha512-h9Zdl8JfS0X4EpUORAue6SR50M8xX0LOKMdnp7L9S34qix47YaJ+SydqloHQkmLhGicv6ZmI6ttbbDbEv0guLA==",
       "requires": {
         "@patternfly/react-component-groups": "^5.0.0",
         "@redhat-cloud-services/frontend-components-utilities": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@patternfly/react-core": "^5.2.0",
     "@patternfly/react-icons": "^5.2.0",
     "@patternfly/react-table": "^5.2.0",
-    "@redhat-cloud-services/frontend-components": "^4.2.4",
+    "@redhat-cloud-services/frontend-components": "^4.2.8",
     "@redhat-cloud-services/frontend-components-notifications": "^4.1.0",
     "@redhat-cloud-services/frontend-components-remediations": "^3.2.11",
     "@redhat-cloud-services/frontend-components-translations": "^3.2.7",

--- a/src/PresentationalComponents/Header/__snapshots__/Header.test.js.snap
+++ b/src/PresentationalComponents/Header/__snapshots__/Header.test.js.snap
@@ -4,7 +4,9 @@ exports[`Header component should render with 1 breadcrumb item and last is activ
 <DocumentFragment>
   <section
     class="pf-v5-l-page-header pf-v5-c-page-header pf-v5-l-page__main-section pf-v5-c-page__main-section pf-m-light"
+    data-ouia-component-id="OUIA-Generated-RHI/Header-true-7"
     data-ouia-component-type="undefined-page-header"
+    data-ouia-safe="true"
     widget-type="InsightsPageHeader"
   >
     <nav
@@ -37,13 +39,21 @@ exports[`Header component should render with 1 breadcrumb item and last is activ
       <div
         class="pf-v5-l-split__item"
       >
-        <h1
-          class="pf-v5-c-title pf-m-2xl"
-          data-ouia-component-id="OUIA-Generated-Title-4"
-          data-ouia-component-type="PF5/Title"
-          data-ouia-safe="true"
-          widget-type="InsightsPageHeaderTitle"
-        />
+        <div
+          class="pf-v5-l-flex pf-m-justify-content-space-between"
+        >
+          <div
+            class=""
+          >
+            <h1
+              class="pf-v5-c-title pf-m-2xl"
+              data-ouia-component-id="OUIA-Generated-RHI/Header-true-8"
+              data-ouia-component-type="RHI/Header"
+              data-ouia-safe="true"
+              widget-type="InsightsPageHeaderTitle"
+            />
+          </div>
+        </div>
       </div>
       <div
         class="pf-v5-l-split__item pf-m-fill"
@@ -60,7 +70,9 @@ exports[`Header component should render with 2 breadcrumb items and last is acti
 <DocumentFragment>
   <section
     class="pf-v5-l-page-header pf-v5-c-page-header pf-v5-l-page__main-section pf-v5-c-page__main-section pf-m-light"
+    data-ouia-component-id="OUIA-Generated-RHI/Header-true-11"
     data-ouia-component-type="undefined-page-header"
+    data-ouia-safe="true"
     widget-type="InsightsPageHeader"
   >
     <nav
@@ -121,13 +133,21 @@ exports[`Header component should render with 2 breadcrumb items and last is acti
       <div
         class="pf-v5-l-split__item"
       >
-        <h1
-          class="pf-v5-c-title pf-m-2xl"
-          data-ouia-component-id="OUIA-Generated-Title-6"
-          data-ouia-component-type="PF5/Title"
-          data-ouia-safe="true"
-          widget-type="InsightsPageHeaderTitle"
-        />
+        <div
+          class="pf-v5-l-flex pf-m-justify-content-space-between"
+        >
+          <div
+            class=""
+          >
+            <h1
+              class="pf-v5-c-title pf-m-2xl"
+              data-ouia-component-id="OUIA-Generated-RHI/Header-true-12"
+              data-ouia-component-type="RHI/Header"
+              data-ouia-safe="true"
+              widget-type="InsightsPageHeaderTitle"
+            />
+          </div>
+        </div>
       </div>
       <div
         class="pf-v5-l-split__item pf-m-fill"
@@ -144,7 +164,9 @@ exports[`Header component should render with 3 breadcrumb items and last is acti
 <DocumentFragment>
   <section
     class="pf-v5-l-page-header pf-v5-c-page-header pf-v5-l-page__main-section pf-v5-c-page__main-section pf-m-light"
+    data-ouia-component-id="OUIA-Generated-RHI/Header-true-13"
     data-ouia-component-type="undefined-page-header"
+    data-ouia-safe="true"
     widget-type="InsightsPageHeader"
   >
     <nav
@@ -233,13 +255,21 @@ exports[`Header component should render with 3 breadcrumb items and last is acti
       <div
         class="pf-v5-l-split__item"
       >
-        <h1
-          class="pf-v5-c-title pf-m-2xl"
-          data-ouia-component-id="OUIA-Generated-Title-7"
-          data-ouia-component-type="PF5/Title"
-          data-ouia-safe="true"
-          widget-type="InsightsPageHeaderTitle"
-        />
+        <div
+          class="pf-v5-l-flex pf-m-justify-content-space-between"
+        >
+          <div
+            class=""
+          >
+            <h1
+              class="pf-v5-c-title pf-m-2xl"
+              data-ouia-component-id="OUIA-Generated-RHI/Header-true-14"
+              data-ouia-component-type="RHI/Header"
+              data-ouia-safe="true"
+              widget-type="InsightsPageHeaderTitle"
+            />
+          </div>
+        </div>
       </div>
       <div
         class="pf-v5-l-split__item pf-m-fill"
@@ -256,7 +286,9 @@ exports[`Header component should render with empty breadcrumb 1`] = `
 <DocumentFragment>
   <section
     class="pf-v5-l-page-header pf-v5-c-page-header pf-v5-l-page__main-section pf-v5-c-page__main-section pf-m-light"
+    data-ouia-component-id="OUIA-Generated-RHI/Header-true-5"
     data-ouia-component-type="undefined-page-header"
+    data-ouia-safe="true"
     widget-type="InsightsPageHeader"
   >
     <nav
@@ -277,13 +309,21 @@ exports[`Header component should render with empty breadcrumb 1`] = `
       <div
         class="pf-v5-l-split__item"
       >
-        <h1
-          class="pf-v5-c-title pf-m-2xl"
-          data-ouia-component-id="OUIA-Generated-Title-3"
-          data-ouia-component-type="PF5/Title"
-          data-ouia-safe="true"
-          widget-type="InsightsPageHeaderTitle"
-        />
+        <div
+          class="pf-v5-l-flex pf-m-justify-content-space-between"
+        >
+          <div
+            class=""
+          >
+            <h1
+              class="pf-v5-c-title pf-m-2xl"
+              data-ouia-component-id="OUIA-Generated-RHI/Header-true-6"
+              data-ouia-component-type="RHI/Header"
+              data-ouia-safe="true"
+              widget-type="InsightsPageHeaderTitle"
+            />
+          </div>
+        </div>
       </div>
       <div
         class="pf-v5-l-split__item pf-m-fill"
@@ -300,7 +340,9 @@ exports[`Header component should render with header Hello world 1`] = `
 <DocumentFragment>
   <section
     class="pf-v5-l-page-header pf-v5-c-page-header pf-v5-l-page__main-section pf-v5-c-page__main-section pf-m-light"
+    data-ouia-component-id="OUIA-Generated-RHI/Header-true-3"
     data-ouia-component-type="undefined-page-header"
+    data-ouia-safe="true"
     widget-type="InsightsPageHeader"
   >
     <div
@@ -309,15 +351,23 @@ exports[`Header component should render with header Hello world 1`] = `
       <div
         class="pf-v5-l-split__item"
       >
-        <h1
-          class="pf-v5-c-title pf-m-2xl"
-          data-ouia-component-id="OUIA-Generated-Title-2"
-          data-ouia-component-type="PF5/Title"
-          data-ouia-safe="true"
-          widget-type="InsightsPageHeaderTitle"
+        <div
+          class="pf-v5-l-flex pf-m-justify-content-space-between"
         >
-          Hello world
-        </h1>
+          <div
+            class=""
+          >
+            <h1
+              class="pf-v5-c-title pf-m-2xl"
+              data-ouia-component-id="OUIA-Generated-RHI/Header-true-4"
+              data-ouia-component-type="RHI/Header"
+              data-ouia-safe="true"
+              widget-type="InsightsPageHeaderTitle"
+            >
+              Hello world
+            </h1>
+          </div>
+        </div>
       </div>
       <div
         class="pf-v5-l-split__item pf-m-fill"
@@ -334,7 +384,9 @@ exports[`Header component should render with header as empty string 1`] = `
 <DocumentFragment>
   <section
     class="pf-v5-l-page-header pf-v5-c-page-header pf-v5-l-page__main-section pf-v5-c-page__main-section pf-m-light"
+    data-ouia-component-id="OUIA-Generated-RHI/Header-true-1"
     data-ouia-component-type="undefined-page-header"
+    data-ouia-safe="true"
     widget-type="InsightsPageHeader"
   >
     <div
@@ -343,13 +395,21 @@ exports[`Header component should render with header as empty string 1`] = `
       <div
         class="pf-v5-l-split__item"
       >
-        <h1
-          class="pf-v5-c-title pf-m-2xl"
-          data-ouia-component-id="OUIA-Generated-Title-1"
-          data-ouia-component-type="PF5/Title"
-          data-ouia-safe="true"
-          widget-type="InsightsPageHeaderTitle"
-        />
+        <div
+          class="pf-v5-l-flex pf-m-justify-content-space-between"
+        >
+          <div
+            class=""
+          >
+            <h1
+              class="pf-v5-c-title pf-m-2xl"
+              data-ouia-component-id="OUIA-Generated-RHI/Header-true-2"
+              data-ouia-component-type="RHI/Header"
+              data-ouia-safe="true"
+              widget-type="InsightsPageHeaderTitle"
+            />
+          </div>
+        </div>
       </div>
       <div
         class="pf-v5-l-split__item pf-m-fill"
@@ -366,7 +426,9 @@ exports[`Header component should render without to attribute 1`] = `
 <DocumentFragment>
   <section
     class="pf-v5-l-page-header pf-v5-c-page-header pf-v5-l-page__main-section pf-v5-c-page__main-section pf-m-light"
+    data-ouia-component-id="OUIA-Generated-RHI/Header-true-9"
     data-ouia-component-type="undefined-page-header"
+    data-ouia-safe="true"
     widget-type="InsightsPageHeader"
   >
     <nav
@@ -393,13 +455,21 @@ exports[`Header component should render without to attribute 1`] = `
       <div
         class="pf-v5-l-split__item"
       >
-        <h1
-          class="pf-v5-c-title pf-m-2xl"
-          data-ouia-component-id="OUIA-Generated-Title-5"
-          data-ouia-component-type="PF5/Title"
-          data-ouia-safe="true"
-          widget-type="InsightsPageHeaderTitle"
-        />
+        <div
+          class="pf-v5-l-flex pf-m-justify-content-space-between"
+        >
+          <div
+            class=""
+          >
+            <h1
+              class="pf-v5-c-title pf-m-2xl"
+              data-ouia-component-id="OUIA-Generated-RHI/Header-true-10"
+              data-ouia-component-type="RHI/Header"
+              data-ouia-safe="true"
+              widget-type="InsightsPageHeaderTitle"
+            />
+          </div>
+        </div>
       </div>
       <div
         class="pf-v5-l-split__item pf-m-fill"

--- a/src/SmartComponents/AdvisoryDetail/__snapshots__/AdvisoryDetail.test.js.snap
+++ b/src/SmartComponents/AdvisoryDetail/__snapshots__/AdvisoryDetail.test.js.snap
@@ -4,7 +4,9 @@ exports[`AdvisoryDetail.js Should match the snapshots 1`] = `
 <DocumentFragment>
   <section
     class="pf-v5-l-page-header pf-v5-c-page-header pf-v5-l-page__main-section pf-v5-c-page__main-section pf-m-light"
+    data-ouia-component-id="OUIA-Generated-RHI/Header-true-1"
     data-ouia-component-type="advisory-details-page-header"
+    data-ouia-safe="true"
     widget-type="InsightsPageHeader"
   >
     <nav
@@ -58,13 +60,21 @@ exports[`AdvisoryDetail.js Should match the snapshots 1`] = `
       <div
         class="pf-v5-l-split__item"
       >
-        <h1
-          class="pf-v5-c-title pf-m-2xl"
-          data-ouia-component-id="OUIA-Generated-Title-1"
-          data-ouia-component-type="PF5/Title"
-          data-ouia-safe="true"
-          widget-type="InsightsPageHeaderTitle"
-        />
+        <div
+          class="pf-v5-l-flex pf-m-justify-content-space-between"
+        >
+          <div
+            class=""
+          >
+            <h1
+              class="pf-v5-c-title pf-m-2xl"
+              data-ouia-component-id="OUIA-Generated-RHI/Header-true-2"
+              data-ouia-component-type="RHI/Header"
+              data-ouia-safe="true"
+              widget-type="InsightsPageHeaderTitle"
+            />
+          </div>
+        </div>
       </div>
       <div
         class="pf-v5-l-split__item pf-m-fill"

--- a/src/SmartComponents/AdvisorySystems/AdvisorySystemsTable.test.js
+++ b/src/SmartComponents/AdvisorySystems/AdvisorySystemsTable.test.js
@@ -233,7 +233,6 @@ describe('AdvisorySystemsTable.js', () => {
                     ],
                     onSelect: expect.any(Function),
                     toggleProps: {
-                        children: '     1 selected',
                         'aria-label': 'Select',
                         'data-ouia-component-type': 'bulk-select-toggle-button'
                     }

--- a/src/SmartComponents/Systems/SystemTable.test.js
+++ b/src/SmartComponents/Systems/SystemTable.test.js
@@ -262,7 +262,6 @@ describe('SystemsTable', () => {
                     ],
                     onSelect: expect.any(Function),
                     toggleProps: {
-                        children: '     1 selected',
                         'aria-label': 'Select',
                         'data-ouia-component-type': 'bulk-select-toggle-button'
                     }

--- a/src/Utilities/hooks/Hooks.js
+++ b/src/Utilities/hooks/Hooks.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, Fragment } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { SortByDirection } from '@patternfly/react-table';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux/actions/notifications';
@@ -176,17 +176,19 @@ export const useBulkSelectConfig = (selectedCount, onSelect, metadata, rows, onC
         toggleProps: {
             'data-ouia-component-type': 'bulk-select-toggle-button',
             'aria-label': 'Select',
-            // FIXME: children is ignored by PrimaryToolbar (BulkSelect) implementation, there is a reimplementation needed
-            children: isBulkLoading ? [
-                <React.Fragment key='sd'>
-                    <Spinner size="sm" />
-                    {`     ${selectedCount} selected`}
-                </React.Fragment>
-            ] : `     ${selectedCount} selected`
+            ...(isBulkLoading ? {
+                children: [
+                    <Fragment key='bulk-selection-loading-icon'>
+                        <Spinner size="md" />
+                        {`     ${selectedCount} selected`}
+                    </Fragment>
+                ]
+            } : {})
         },
+
         checked: selectedCount === 0 ? false : selectedCount === metadata.total_items ? true : null,
-        isDisabled: (metadata.total_items === 0 && selectedCount === 0)
-            || (queryParams?.filter?.status?.length === 1 && queryParams?.filter?.status?.[0] === 'Applicable'),
+        isDisabled: isBulkLoading || (metadata.total_items === 0 && selectedCount === 0)
+        || (queryParams?.filter?.status?.length === 1 && queryParams?.filter?.status?.[0] === 'Applicable'),
         count: selectedCount
     });
 };


### PR DESCRIPTION
# Description

Associated Jira ticket: #944 tps://issues.redhat.com/browse/RHINENG-9035

Fixes the loading icon in bulk select by updating the fec-config package. It also includes tiny changes to cleanup bulk select config. The icons on systems tables will be fixed by https://github.com/RedHatInsights/insights-inventory-frontend/pull/2192

# How to test the PR
1. Navigate to Advisories table
2. Select all items in the table
3. Observe that there is now the spinner icon while items are being selected and selection dropdown is disabled

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
