### PR TITLE
fix: double icons in  display name column on package systems table

### DIFF
--- a/src/SmartComponents/Systems/SystemListAssets.test.js
+++ b/src/SmartComponents/Systems/SystemListAssets.test.js
@@ -23,7 +23,7 @@ describe('SystemListAssets.js', () => {
     });
 
     it('Should call createUpgradableColumn on Status renderFunc with correct params', () => {
-        packageSystemsColumns[6].renderFunc('testValue');
+        packageSystemsColumns[4].renderFunc('testValue');
         expect(createUpgradableColumn).toHaveBeenCalledWith('testValue');
     });
 

--- a/src/SmartComponents/Systems/SystemsListAssets.js
+++ b/src/SmartComponents/Systems/SystemsListAssets.js
@@ -96,14 +96,6 @@ export const advisorySystemsColumns = () => [
 
 export const packageSystemsColumns = [
     {
-        key: 'display_name',
-        title: 'Name',
-        composed: ['facts.os_release', 'display_name'],
-        props: {
-            width: 40
-        }
-    },
-    {
         key: 'tags',
         title: 'Tags',
         props: { width: 10, isStatic: true }

--- a/src/SmartComponents/Systems/SystemsListAssets.js
+++ b/src/SmartComponents/Systems/SystemsListAssets.js
@@ -96,11 +96,6 @@ export const advisorySystemsColumns = () => [
 
 export const packageSystemsColumns = [
     {
-        key: 'tags',
-        title: 'Tags',
-        props: { width: 10, isStatic: true }
-    },
-    {
         key: 'os',
         title: 'OS',
         renderFunc: value => createOSColumn(value),

--- a/src/Utilities/SystemHelpers.test.js
+++ b/src/Utilities/SystemHelpers.test.js
@@ -26,10 +26,10 @@ describe('createSystemsSortBy,', () => {
 
     it('should translate updated parameter while having last upload', () => {
         expect(createSystemsSortBy('updated', 'ASC', true)).toEqual(
-            'display_name'
+            'os'
         );
         expect(createSystemsSortBy('updated', 'DESC', true)).toEqual(
-            '-display_name'
+            '-os'
         );
     });
 });


### PR DESCRIPTION
# Description

Associated Jira ticket: No ticket needed

A small fix for the double icons on the package systems page. As the page completely uses the inventory table and also there were extra column definition, double icons appeared. Removing the extra one fixes it.

I am not sure even if this icon should be displayed in package systems table. I will consult it with the ux.

# How to test the PR

Please include steps to test your PR.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
