### PR TITLE
tag security compliance image

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -7,6 +7,11 @@
 export COMPONENT="patchman-ui"
 # IMAGE should match the quay repo set by app.yaml in app-interface
 export IMAGE="quay.io/cloudservices/patchman-ui"
+
+if [[ "$GIT_BRANCH" == "origin/security-compliance" ]]; then
+	export IMAGE_TAG="sc-$(date +%Y%m%d)-$(git rev-parse --short=7 HEAD)"
+fi
+
 export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
 export APP_ROOT=$(pwd)
 export NODE_BUILD_VERSION=16


### PR DESCRIPTION
# Description

Adding an if-statement to build_deploy.sh to properly tag the Container Image generated when building from the Security-Compliance Branch.

```
if [[ "$GIT_BRANCH" == "origin/security-compliance" ]]; then
	export IMAGE_TAG="sc-$(date +%Y%m%d)-$(git rev-parse --short=7 HEAD)"
fi
```

# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
