### PR TITLE
Fixes 5033: Expose old patch templates UI via feature flag

### DIFF
--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -55,8 +55,6 @@ jest.mock('../src/Utilities/hooks/useRemediationDataProvider', () => ({
     useRemediationDataProvider: () => () => jest.fn()
 }));
 
-jest.mock('../src/Utilities/hooks/useFeatureFlag', () => ({
-    useFeatureFlag: () => () => jest.fn()
-}));
+jest.mock('../src/Utilities/hooks/useFeatureFlag', () => jest.fn());
 
 global.React = React;

--- a/src/SmartComponents/AdvisorySystems/AdvisorySystemsTable.js
+++ b/src/SmartComponents/AdvisorySystems/AdvisorySystemsTable.js
@@ -25,6 +25,7 @@ import { advisorySystemsColumns, systemsRowActions } from '../Systems/SystemsLis
 import AsyncRemediationButton from '../Remediation/AsyncRemediationButton';
 import { systemsColumnsMerger, buildActiveFiltersConfig } from '../../Utilities/SystemsHelpers';
 import advisoryStatusFilter from '../../PresentationalComponents/Filters/AdvisoryStatusFilter';
+import useFeatureFlag from '../../Utilities/hooks/useFeatureFlag';
 
 const AdvisorySystemsTable = ({
     advisoryName,
@@ -35,6 +36,7 @@ const AdvisorySystemsTable = ({
 }) => {
     const dispatch = useDispatch();
     const store = useStore();
+    const templateUpdateEnabled = useFeatureFlag('patchman-ui.template-update.enabled');
 
     const systems = useSelector(({ entities }) => entities?.rows || [], shallowEqual);
     const totalItems = useSelector(
@@ -101,7 +103,7 @@ const AdvisorySystemsTable = ({
             initialLoading
             ignoreRefresh
             hideFilters={{ all: true, tags: false, operatingSystem: false }}
-            columns={(defaultColumns) => systemsColumnsMerger(defaultColumns, advisorySystemsColumns)}
+            columns={(defaultColumns) => systemsColumnsMerger(defaultColumns, ()=>advisorySystemsColumns(templateUpdateEnabled))}
             showTags
             customFilters={{
                 patchParams: {
@@ -118,14 +120,14 @@ const AdvisorySystemsTable = ({
                 store.replaceReducer(combineReducers({
                     ...defaultReducers,
                     ...mergeWithEntities(
-                        inventoryEntitiesReducer(advisorySystemsColumns(false), modifyAdvisorySystems),
+                        inventoryEntitiesReducer(advisorySystemsColumns(templateUpdateEnabled), modifyAdvisorySystems),
                         persistantParams({ page, perPage, sort, search }, decodedParams)
                     )
                 }));
             }}
             getEntities={getEntites}
             tableProps={{
-                actionResolver: (row) => systemsRowActions(activateRemediationModal, row),
+                actionResolver: (row) => systemsRowActions(activateRemediationModal, undefined, undefined, row),
                 canSelectAll: false,
                 variant: TableVariant.compact, className: 'patchCompactInventory', isStickyHeader: true
             }}

--- a/src/SmartComponents/Modals/Helpers.js
+++ b/src/SmartComponents/Modals/Helpers.js
@@ -25,8 +25,8 @@ const filterChosenSystems = (urlFilter, systemsIDs, fetchBatched, totalItems) =>
     });
 };
 
-export const filterSystemsWithoutSets = (systemsIDs, fetchBatched, totalItems) =>  {
-    const urlFilter = { 'filter[template_name]': 'neq:' };
+export const filterSystemsWithoutSets = (systemsIDs, fetchBatched, totalItems, templateUpdateEnabled = false) =>  {
+    const urlFilter = { [`filter[${templateUpdateEnabled ? 'template_name' : 'baseline_name'}]`]: 'neq:' };
     return filterChosenSystems(urlFilter, systemsIDs, fetchBatched, totalItems);
 };
 

--- a/src/SmartComponents/Modals/UnassignSystemsModal.js
+++ b/src/SmartComponents/Modals/UnassignSystemsModal.js
@@ -7,12 +7,14 @@ import messages from '../../Messages';
 import { useUnassignSystemsHook } from './useUnassignSystemsHook';
 import { renderUnassignModalMessages, filterSystemsWithoutSets } from './Helpers';
 import { useFetchBatched } from '../../Utilities/hooks';
+import useFeatureFlag from '../../Utilities/hooks/useFeatureFlag';
 
 const UnassignSystemsModal = ({ unassignSystemsModalState = {}, setUnassignSystemsModalOpen, intl, totalItems }) => {
     const { systemsIDs, isUnassignSystemsModalOpen } = unassignSystemsModalState;
     const [systemsWithPatchSet, setSystemWithPatchSet] = useState([]);
     const [systemsLoading, setSystemsLoading] = useState(true);
     const { fetchBatched } = useFetchBatched();
+    const templateUpdateEnabled = useFeatureFlag('patchman-ui.template-update.enabled');
 
     const handleModalToggle = (shouldRefresh) => {
         setUnassignSystemsModalOpen({
@@ -34,7 +36,8 @@ const UnassignSystemsModal = ({ unassignSystemsModalState = {}, setUnassignSyste
         filterSystemsWithoutSets(
             systemsIDs,
             fetchBatched,
-            totalItems
+            totalItems,
+            templateUpdateEnabled
         )
         .then(result => {
             setSystemWithPatchSet(result);

--- a/src/SmartComponents/PackageSystems/PackageSystems.js
+++ b/src/SmartComponents/PackageSystems/PackageSystems.js
@@ -32,8 +32,11 @@ import { intl } from '../../Utilities/IntlProvider';
 import AsyncRemediationButton from '../Remediation/AsyncRemediationButton';
 import { packageSystemsColumns } from '../Systems/SystemsListAssets';
 import { combineReducers } from 'redux';
+import useFeatureFlag from '../../Utilities/hooks/useFeatureFlag';
 
 const PackageSystems = ({ packageName }) => {
+    const templateUpdateEnabled = useFeatureFlag('patchman-ui.template-update.enabled');
+
     const dispatch = useDispatch();
     const store = useStore();
     const [packageVersions, setPackageVersions] = React.useState([]);
@@ -156,7 +159,7 @@ const PackageSystems = ({ packageName }) => {
                     autoRefresh
                     initialLoading
                     hideFilters={{ all: true, tags: false, operatingSystem: false }}
-                    columns={packageSystemsColumns}
+                    columns={packageSystemsColumns(templateUpdateEnabled)}
                     showTags
                     getEntities={getEntites}
                     customFilters={{
@@ -174,7 +177,7 @@ const PackageSystems = ({ packageName }) => {
                         store.replaceReducer(combineReducers({
                             ...defaultReducers,
                             ...mergeWithEntities(
-                                inventoryEntitiesReducer(packageSystemsColumns, modifyPackageSystems),
+                                inventoryEntitiesReducer(packageSystemsColumns(templateUpdateEnabled), modifyPackageSystems),
                                 persistantParams({ page, perPage, sort, search }, decodedParams)
                             )
                         }));

--- a/src/SmartComponents/PatchSetDetail/PatchSetDetail.js
+++ b/src/SmartComponents/PatchSetDetail/PatchSetDetail.js
@@ -61,6 +61,7 @@ import { processDate } from '@redhat-cloud-services/frontend-components-utilitie
 import { ID_API_ENDPOINTS, useOnSelect } from '../../Utilities/hooks';
 import { systemSelectAction } from '../../store/Actions/Actions';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
+import useFeatureFlag from '../../Utilities/hooks/useFeatureFlag';
 
 const PatchSetDetail = () => {
     const intl = useIntl();
@@ -68,6 +69,7 @@ const PatchSetDetail = () => {
     const chrome = useChrome();
     const [searchParams, setSearchParams] = useSearchParams();
     const navigate = useNavigate();
+    const templateUpdateEnabled = useFeatureFlag('patchman-ui.template-update.enabled');
 
     const store = useStore();
     const inventory = useRef(null);
@@ -399,7 +401,8 @@ const PatchSetDetail = () => {
                                         store.replaceReducer(combineReducers({
                                             ...defaultReducers,
                                             ...mergeWithEntities(
-                                                inventoryEntitiesReducer(systemsListColumns(true), modifyTemplateDetailSystems),
+                                                inventoryEntitiesReducer(systemsListColumns(templateUpdateEnabled),
+                                                    modifyTemplateDetailSystems),
                                                 persistantParams({ page, perPage, sort, search }, decodedParams)
                                             )
                                         }));

--- a/src/SmartComponents/PatchSetWizard/WizardAssets.js
+++ b/src/SmartComponents/PatchSetWizard/WizardAssets.js
@@ -8,7 +8,7 @@ import { sortable } from '@patternfly/react-table/dist/js';
 import React, { Fragment } from 'react';
 import { useFetchBatched } from '../../Utilities/hooks';
 
-export const reviewSystemColumns = [{
+export const reviewSystemColumns = (templateUpdateEnabled = false)=> [{
     key: 'display_name',
     title: 'Name',
     props: {
@@ -25,7 +25,7 @@ export const reviewSystemColumns = [{
     transforms: [sortable]
 },
 {
-    key: 'template_name',
+    key: templateUpdateEnabled ? 'template_name' : 'baseline_name',
     title: 'Template',
     props: {
         width: 20

--- a/src/SmartComponents/PatchSetWizard/steps/ReviewSystems.js
+++ b/src/SmartComponents/PatchSetWizard/steps/ReviewSystems.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import propTypes from 'prop-types';
 import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
 import searchFilter from '../../../PresentationalComponents/Filters/SearchFilter';
@@ -18,12 +18,14 @@ import { intl } from '../../../Utilities/IntlProvider';
 import { systemsListDefaultFilters } from '../../../Utilities/constants';
 import useOsVersionFilter from '../../../PresentationalComponents/Filters/OsVersionFilter';
 import { useFetchAllTemplateData } from '../WizardAssets';
+import useFeatureFlag from '../../../Utilities/hooks/useFeatureFlag';
 
 export const ReviewSystems = ({ systemsIDs = [], patchSetID, ...props }) => {
     const { input } = useFieldApi(props);
     const formOptions = useFormApi();
     const { values } = formOptions.getState();
     const defaultSelectedSystems = buildSelectedSystemsObj(systemsIDs, values?.systems);
+    const templateUpdateEnabled = useFeatureFlag('patchman-ui.template-update.enabled');
 
     const [isLoading, setLoading] = useState(true);
     const [rawData, setRawData] = useState([]);
@@ -107,10 +109,12 @@ export const ReviewSystems = ({ systemsIDs = [], patchSetID, ...props }) => {
         }));
     };
 
+    const reviewSysColumns = useMemo(()=>reviewSystemColumns(templateUpdateEnabled), [templateUpdateEnabled]);
+
     const osFilterConfig = useOsVersionFilter(queryParams.filter.os, apply);
-    const onSort = useSortColumn(reviewSystemColumns, apply, 1);
+    const onSort = useSortColumn(reviewSysColumns, apply, 1);
     const sortBy = React.useMemo(
-        () => createSortBy(reviewSystemColumns, metadata.sort, 1),
+        () => createSortBy(reviewSysColumns, metadata.sort, 1),
         [metadata.sort]
     );
 
@@ -166,7 +170,7 @@ export const ReviewSystems = ({ systemsIDs = [], patchSetID, ...props }) => {
             <Alert variant="warning" title={intl.formatMessage(messages.templateAlertSystems)} isInline />
             <StackItem>
                 <TableView
-                    columns={reviewSystemColumns}
+                    columns={reviewSysColumns}
                     compact
                     onSetPage={onSetPage}
                     onPerPageSelect={onPerPageSelect}

--- a/src/SmartComponents/SystemDetail/InventoryDetail.js
+++ b/src/SmartComponents/SystemDetail/InventoryDetail.js
@@ -17,21 +17,28 @@ import { useParams } from 'react-router-dom';
 import SystemDetail from './SystemDetail';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import { InsightsLink } from '@redhat-cloud-services/frontend-components/InsightsLink';
+import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+import useFeatureFlag from '../../Utilities/hooks/useFeatureFlag';
 
 const InventoryDetail = () => {
     const { inventoryId } = useParams();
     const store = useStore();
     const dispatch = useDispatch();
+    const templateUpdateEnabled = useFeatureFlag('patchman-ui.template-update.enabled');
 
-    const { hasThirdPartyRepo, satelliteManaged, patchSetName, templateUUID } = useSelector(
+    const { hasThirdPartyRepo, satelliteManaged,
+        patchSetName: patchSetOldName,
+        patchSetId, templateName, templateUUID } = useSelector(
         ({ SystemDetailStore }) => SystemDetailStore
     );
+
+    const patchSetName = templateUpdateEnabled ?  templateName : patchSetOldName;
 
     const { display_name: displayName } = useSelector(
         ({ entityDetails }) => entityDetails?.entity ?? {}
     );
 
-    const { patchSetState, setPatchSetState /*,openAssignSystemsModal, openUnassignSystemsModal */ } = usePatchSetState();
+    const { patchSetState, setPatchSetState, openAssignSystemsModal, openUnassignSystemsModal } = usePatchSetState();
 
     useEffect(() => {
         dispatch(fetchSystemDetailsAction(inventoryId));
@@ -52,10 +59,10 @@ const InventoryDetail = () => {
         displayName && chrome.updateDocumentTitle(`${displayName} - Systems - Patch | RHEL`, true);
     }, [chrome, displayName]);
 
-    // const { hasAccess: hasTemplateAccess } = usePermissionsWithContext([
-    //     'patch:*:*',
-    //     'patch:template:write'
-    // ]);
+    const { hasAccess: hasTemplateAccess } = usePermissionsWithContext([
+        'patch:*:*',
+        'patch:template:write'
+    ]);
 
     return (
         <DetailWrapper
@@ -87,20 +94,19 @@ const InventoryDetail = () => {
                     hideBack
                     showTags
                     inventoryId={inventoryId}
-                    actions={[
-                        // {
-                        //     title: intl.formatMessage(messages.titlesTemplateAssign),
-                        //     key: 'assign-to-template',
-                        //     isDisabled: !hasTemplateAccess || satelliteManaged,
-                        //     onClick: () => openAssignSystemsModal({ [inventoryId]: true })
-                        // },
-                        // {
-                        //     title: intl.formatMessage(messages.titlesTemplateRemoveMultipleButton),
-                        //     key: 'remove-from-template',
-                        //     isDisabled: !hasTemplateAccess || !patchSetName || satelliteManaged,
-                        //     onClick: () => openUnassignSystemsModal([inventoryId])
-                        // }
-                    ]}
+                    actions={templateUpdateEnabled ? [] : [
+                        {
+                            title: intl.formatMessage(messages.titlesTemplateAssign),
+                            key: 'assign-to-template',
+                            isDisabled: !hasTemplateAccess || satelliteManaged,
+                            onClick: () => openAssignSystemsModal({ [inventoryId]: true })
+                        },
+                        {
+                            title: intl.formatMessage(messages.titlesTemplateRemoveMultipleButton),
+                            key: 'remove-from-template',
+                            isDisabled: !hasTemplateAccess || !patchSetName || satelliteManaged,
+                            onClick: () => openUnassignSystemsModal([inventoryId])
+                        }]}
                     //FIXME: remove this prop after inventory detail gets rid of activeApps in redux
                     appList={[]}
                 >
@@ -108,8 +114,13 @@ const InventoryDetail = () => {
                         {patchSetName && <GridItem>
                             <TextContent>
                                 <Text>
-                                    {intl.formatMessage(messages.labelsColumnsTemplate)}:{' '}
-                                    <InsightsLink app="content" to={{ pathname: `/templates/${templateUUID}/details` }}>
+                                    {intl.formatMessage(messages.labelsColumnsTemplate)}:
+                                    <InsightsLink
+                                        app={templateUpdateEnabled ? 'content' : undefined}
+                                        to={templateUpdateEnabled ?
+                                            `/templates/${templateUUID}/details` :
+                                            `/templates/${patchSetId}`}
+                                        className="pf-v5-u-ml-xs">
                                         {patchSetName}
                                     </InsightsLink>
                                 </Text>

--- a/src/SmartComponents/Systems/SystemListAssets.test.js
+++ b/src/SmartComponents/Systems/SystemListAssets.test.js
@@ -23,7 +23,7 @@ describe('SystemListAssets.js', () => {
     });
 
     it('Should call createUpgradableColumn on Status renderFunc with correct params', () => {
-        packageSystemsColumns[4].renderFunc('testValue');
+        packageSystemsColumns()[4].renderFunc('testValue');
         expect(createUpgradableColumn).toHaveBeenCalledWith('testValue');
     });
 
@@ -67,7 +67,7 @@ describe('SystemListAssets.js', () => {
         });
         it('Should disable "Apply all applicable advisories" action when there is no applicable advisories ', () => {
             const testRow = { applicable_advisories: [0, 0, 0, 0] };
-            const actions = systemsRowActions(null, testRow);
+            const actions = systemsRowActions(null, null, null, testRow);
             expect(actions).toEqual(
                 [{ isDisabled: true, onClick: expect.any(Function), title: 'Apply all applicable advisories' }]
             );

--- a/src/SmartComponents/Systems/SystemTable.test.js
+++ b/src/SmartComponents/Systems/SystemTable.test.js
@@ -181,36 +181,36 @@ describe('SystemsTable', () => {
         ));
     });
 
-    // it('should provide actions config', async () => {
-    //     await renderComponent(mockState);
-    //     expect(InventoryTable).toHaveBeenCalledWith(
-    //         expect.objectContaining({
-    //             actionsConfig: {
-    //                 actions: [
-    //                     //Remdiation button
-    //                     expect.anything(),
-    //                     {
-    //                         key: 'assign-multiple-systems',
-    //                         label: 'Assign to a template',
-    //                         onClick: expect.any(Function),
-    //                         props: {
-    //                             isDisabled: true
-    //                         }
-    //                     },
-    //                     {
-    //                         key: 'remove-multiple-systems',
-    //                         label: 'Remove from a template',
-    //                         onClick: expect.any(Function),
-    //                         props: {
-    //                             isDisabled: true
-    //                         }
-    //                     }
-    //                 ]
-    //             }
-    //         }),
-    //         {}
-    //     );
-    // });
+    it('should provide actions config', async () => {
+        await renderComponent(mockState);
+        expect(InventoryTable).toHaveBeenCalledWith(
+            expect.objectContaining({
+                actionsConfig: {
+                    actions: [
+                        //Remdiation button
+                        expect.anything(),
+                        {
+                            key: 'assign-multiple-systems',
+                            label: 'Assign to a template',
+                            onClick: expect.any(Function),
+                            props: {
+                                isDisabled: true
+                            }
+                        },
+                        {
+                            key: 'remove-multiple-systems',
+                            label: 'Remove from a template',
+                            onClick: expect.any(Function),
+                            props: {
+                                isDisabled: true
+                            }
+                        }
+                    ]
+                }
+            }),
+            {}
+        );
+    });
 
     it('should provide activeFilters config', async () => {
         await renderComponent(mockState);

--- a/src/SmartComponents/Systems/SystemsListAssets.js
+++ b/src/SmartComponents/Systems/SystemsListAssets.js
@@ -21,7 +21,7 @@ export const ManagedBySatelliteCell = () => (
     </Tooltip>
 );
 
-export const systemsListColumns = () => [
+export const systemsListColumns = (templateUpdateEnabled = false) => [
     {
         key: 'operating_system',
         title: 'OS',
@@ -31,15 +31,18 @@ export const systemsListColumns = () => [
         }
     },
     {
-        key: 'template_name',
+        key: templateUpdateEnabled ? 'template_name' : 'baseline_name',
         title: 'Template',
         renderFunc: (value, _, row) =>
             row.satellite_managed
                 ? <ManagedBySatelliteCell />
                 : value
-                    ? <InsightsLink app="content" to={{ pathname: `/templates/${row.template_uuid}/details` }}>
-                        {value}
-                    </InsightsLink>
+                    ? <InsightsLink
+                        app={templateUpdateEnabled ? 'content' : undefined}
+                        to={{ pathname: templateUpdateEnabled ?
+                            `/templates/${row.template_uuid}/details` :
+                            `/templates/${row.baseline_id}` }}
+                    >{value}</InsightsLink>
                     : 'No template',
         props: {
             width: 5
@@ -63,7 +66,7 @@ export const systemsListColumns = () => [
     }
 ];
 
-export const advisorySystemsColumns = () => [
+export const advisorySystemsColumns = (templateUpdateEnabled = false) => [
     {
         key: 'os',
         title: 'OS',
@@ -73,15 +76,18 @@ export const advisorySystemsColumns = () => [
         }
     },
     {
-        key: 'template_name',
+        key: templateUpdateEnabled ? 'template_name' : 'baseline_name',
         title: 'Template',
         renderFunc: (value, _, row) =>
             row.satellite_managed
                 ? <ManagedBySatelliteCell />
                 : value
-                    ? <InsightsLink app="content" to={{ pathname: `/templates/${row.template_uuid}/details` }}>
-                        {value}
-                    </InsightsLink>
+                    ? <InsightsLink
+                        app={templateUpdateEnabled ? 'content' : undefined}
+                        to={{ pathname: templateUpdateEnabled ?
+                            `/templates/${row.template_uuid}/details` :
+                            `/templates/${row.baseline_id}` }}
+                    >{value}</InsightsLink>
                     : 'No template',
         props: {
             width: 5
@@ -98,7 +104,7 @@ export const advisorySystemsColumns = () => [
     }
 ];
 
-export const packageSystemsColumns = [
+export const packageSystemsColumns = (templateUpdateEnabled = false) => [
     {
         key: 'os',
         title: 'OS',
@@ -108,15 +114,18 @@ export const packageSystemsColumns = [
         }
     },
     {
-        key: 'template_name',
+        key: templateUpdateEnabled ? 'template_name' : 'baseline_name',
         title: 'Template',
         renderFunc: (value, _, row) =>
             row.satellite_managed
                 ? <ManagedBySatelliteCell />
                 : value
-                    ?  <InsightsLink app="content" to={{ pathname: `/templates/${row.template_uuid}/details` }}>
-                        {value}
-                    </InsightsLink>
+                    ? <InsightsLink
+                        app={templateUpdateEnabled ? 'content' : undefined}
+                        to={{ pathname: templateUpdateEnabled ?
+                            `/templates/${row.template_uuid}/details` :
+                            `/templates/${row.baseline_id}` }}
+                    >{value}</InsightsLink>
                     : 'No template',
         props: {
             width: 5
@@ -153,10 +162,10 @@ const isRemediationDisabled = (row) => {
     return (applicableAdvisories && applicableAdvisories.every(typeSum => typeSum === 0)) || (status === 'Applicable');
 };
 
-// const isPatchSetRemovalDisabled = (row) => {
-//     const { template_name: templateName } = row || {};
-//     return !templateName || (typeof templateName === 'string' && templateName === '');
-// };
+const isPatchSetRemovalDisabled = (row) => {
+    const { baseline_name: baselineName } = row || {};
+    return !baselineName || (typeof baselineName === 'string' && baselineName === '');
+};
 
 export const useActivateRemediationModal = (setRemediationIssues, setRemediationOpen) => {
     const { fetchBatched } = useFetchBatched();
@@ -196,10 +205,10 @@ export const useActivateRemediationModal = (setRemediationIssues, setRemediation
 
 export const systemsRowActions = (
     activateRemediationModal,
-    // showTemplateAssignSystemsModal,
-    // openUnassignSystemsModal,
-    row
-    // hasTemplateAccess
+    showTemplateAssignSystemsModal,
+    openUnassignSystemsModal,
+    row,
+    hasTemplateAccess
 ) => {
     return [
         {
@@ -208,22 +217,22 @@ export const systemsRowActions = (
             onClick: (event, rowId, rowData) => {
                 activateRemediationModal(rowData);
             }
+        },
+        ...(showTemplateAssignSystemsModal ? [{
+            title: 'Assign to a template',
+            isDisabled: !hasTemplateAccess || row.satellite_managed,
+            onClick: (event, rowId, rowData) => {
+                showTemplateAssignSystemsModal({ [rowData.id]: true });
+            }
+        },
+        {
+            title: 'Remove from a template',
+            isDisabled: !hasTemplateAccess || isPatchSetRemovalDisabled(row) || row.satellite_managed,
+            onClick: (event, rowId, rowData) => {
+                openUnassignSystemsModal([rowData.id]);
+            }
         }
-        // ...(showTemplateAssignSystemsModal ? [{
-        //     title: 'Assign to a template',
-        //     isDisabled: !hasTemplateAccess || row.satellite_managed,
-        //     onClick: (event, rowId, rowData) => {
-        //         showTemplateAssignSystemsModal({ [rowData.id]: true });
-        //     }
-        // },
-        // {
-        //     title: 'Remove from a template',
-        //     isDisabled: !hasTemplateAccess || isPatchSetRemovalDisabled(row) || row.satellite_managed,
-        //     onClick: (event, rowId, rowData) => {
-        //         openUnassignSystemsModal([rowData.id]);
-        //     }
-        // }
-        // ] : [])
+        ] : [])
     ];
 };
 

--- a/src/SmartComponents/Systems/SystemsMainContent.js
+++ b/src/SmartComponents/Systems/SystemsMainContent.js
@@ -43,7 +43,7 @@ const SystemsMainContent = () => {
     }, []);
 
     const {
-        patchSetState, setPatchSetState// openUnassignSystemsModal, openAssignSystemsModal
+        patchSetState, setPatchSetState, openUnassignSystemsModal, openAssignSystemsModal
     } = usePatchSetState(selectedRows);
 
     const activateRemediationModal = useActivateRemediationModal(
@@ -75,8 +75,8 @@ const SystemsMainContent = () => {
                 <SystemsTable
                     apply={apply}
                     patchSetState={patchSetState}
-                    // openAssignSystemsModal={openAssignSystemsModal}
-                    // openUnassignSystemsModal={openUnassignSystemsModal}
+                    openAssignSystemsModal={openAssignSystemsModal}
+                    openUnassignSystemsModal={openUnassignSystemsModal}
                     setSearchParams={setSearchParams}
                     activateRemediationModal={activateRemediationModal}
                     decodedParams={decodeQueryparams}

--- a/src/SmartComponents/Systems/SystemsMainContent.test.js
+++ b/src/SmartComponents/Systems/SystemsMainContent.test.js
@@ -134,17 +134,17 @@ describe('SystemsTable', () => {
         ).toBeTruthy();
     });
 
-    // it('Should display assign systems modal', async () => {
-    //     renderComponent(mockState);
-    //     await user.click(screen.getByTestId('open-assign-modal'));
-    //     await waitFor(() => expect(screen.getByTestId('assign-systems-modal')).toBeVisible());
-    // });
+    it('Should display assign systems modal', async () => {
+        renderComponent(mockState);
+        await user.click(screen.getByTestId('open-assign-modal'));
+        await waitFor(() => expect(screen.getByTestId('assign-systems-modal')).toBeVisible());
+    });
 
-    // it('Should display unassign systems modal', async () => {
-    //     renderComponent(mockState);
-    //     await user.click(screen.getByTestId('open-unasssign-modal'));
-    //     await waitFor(() => expect(screen.getByTestId('unassign-systems-modal')).toBeVisible());
-    // });
+    it('Should display unassign systems modal', async () => {
+        renderComponent(mockState);
+        await user.click(screen.getByTestId('open-unasssign-modal'));
+        await waitFor(() => expect(screen.getByTestId('unassign-systems-modal')).toBeVisible());
+    });
 
     it('Should display remediation wizard', async () => {
         renderComponent(mockState);

--- a/src/Utilities/DataMappers.js
+++ b/src/Utilities/DataMappers.js
@@ -199,6 +199,7 @@ export const createPackageSystemsRows = (rows, selectedRows = {}) => {
                     osName: row.os?.osName || row.os || 'N/A',
                     rhsm: row.rhsm
                 },
+                baseline_name: row.baseline_name, //ToBeDeprecated
                 template_name: row.template_name,
                 template_uuid: row.template_uuid,
                 baseline_id: row.baseline_id,
@@ -370,7 +371,7 @@ export const createSystemsRowsReview = (rows, selectedRows) => {
                     {
                         title: attributes.satellite_managed
                             ? <ManagedBySatelliteCell />
-                            : attributes.template_name || 'No template'
+                            : attributes.baseline_name || 'No template'
                     },
                     {
                         title: processDate(attributes.last_upload)

--- a/src/Utilities/SystemsHelpers.js
+++ b/src/Utilities/SystemsHelpers.js
@@ -87,7 +87,7 @@ export const createSystemsSortBy = (orderBy, orderDirection, hasLastUpload) => {
         if (!hasLastUpload) {
             orderBy = 'last_upload';
         } else {
-            orderBy = packageSystemsColumns[0].key;
+            orderBy = packageSystemsColumns()[0].key;
         }
     } else if (orderBy === 'group_name') {
         orderBy = 'groups'; // patch API service uses 'groups' instead of 'group_name' sort parameter

--- a/src/store/Reducers/SystemDetailStore.js
+++ b/src/store/Reducers/SystemDetailStore.js
@@ -10,8 +10,9 @@ export const SystemDetailStore = (state = initialState, { type, payload }) => {
                 ...state,
                 hasThirdPartyRepo: payload.data?.attributes.third_party,
                 satelliteManaged: payload.data?.attributes.satellite_managed,
-                patchSetName: payload.data?.attributes.template_name,
+                patchSetName: payload.data?.attributes.baseline_name,
                 patchSetId: payload.data?.attributes.baseline_id,
+                templateName: payload.data?.attributes.template_name,
                 templateUUID: payload.data?.attributes.template_uuid
             };
         case 'LOAD_ENTITY_PENDING':


### PR DESCRIPTION
# Description

Associated Jira ticket: [HMS-5033](https://issues.redhat.com/browse/HMS-5033)

Goal: 

[This](https://issues.redhat.com/browse/RHINENG-7807)  caused all of the patch template UI to be removed, and all systems list references to either be removed or to start using the new content template data
All of this now should been controlled with a feature flag  🫤 

Acceptance Criteria:

Old UI for patch and patch templates exists in stable
Patch uses the new content templates in preview, old patch templates are not available
Stable patch UI can be flipped from the old  templates to new templates in the future easily


# How to test the PR

Run with proxy against prod, test changes by toggling preview on and off on various screens.
Original list of changes can be found [here](https://issues.redhat.com/browse/RHINENG-7807).

Alternatively, one can use the feature flag for [stage](https://insights-stage.unleash.devshift.net/projects/default/features/patchman-ui.template-update.enabled) or [prod](https://insights.unleash.devshift.net/projects/default/features/patchman-ui.template-update.enabled) 
To test functionality directly.

# Before the change
All environments would show new UI implementation.

# After the change
Prod (non-preview) will now show the old ui, until the unleashed feature flag "patchman-ui.template-update.enabled" is enabled for that environment.

# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [ ] Screenshots before and after the change are added
