### PR TITLE
chore: Declarative column merging

### DIFF
--- a/src/SmartComponents/AdvisorySystems/AdvisorySystemsTable.js
+++ b/src/SmartComponents/AdvisorySystems/AdvisorySystemsTable.js
@@ -23,7 +23,7 @@ import {
 import { intl } from '../../Utilities/IntlProvider';
 import { ADVISORY_SYSTEMS_COLUMNS, systemsRowActions } from '../Systems/SystemsListAssets';
 import AsyncRemediationButton from '../Remediation/AsyncRemediationButton';
-import { systemsColumnsMerger, buildActiveFiltersConfig } from '../../Utilities/SystemsHelpers';
+import { buildActiveFiltersConfig, mergeInventoryColumns } from '../../Utilities/SystemsHelpers';
 import advisoryStatusFilter from '../../PresentationalComponents/Filters/AdvisoryStatusFilter';
 
 const AdvisorySystemsTable = ({
@@ -101,7 +101,7 @@ const AdvisorySystemsTable = ({
             initialLoading
             ignoreRefresh
             hideFilters={{ all: true, tags: false, operatingSystem: false }}
-            columns={(defaultColumns) => systemsColumnsMerger(defaultColumns, () => ADVISORY_SYSTEMS_COLUMNS)}
+            columns={(inventoryColumns) => mergeInventoryColumns(ADVISORY_SYSTEMS_COLUMNS, inventoryColumns)}
             showTags
             customFilters={{
                 patchParams: {

--- a/src/SmartComponents/PackageSystems/PackageSystems.js
+++ b/src/SmartComponents/PackageSystems/PackageSystems.js
@@ -24,6 +24,7 @@ import {
     persistantParams, remediationProviderWithPairs, removeUndefinedObjectKeys
 } from '../../Utilities/Helpers';
 import {
+    mergeInventoryColumns,
     osParamParser
 } from '../../Utilities/SystemsHelpers';
 import { useBulkSelectConfig, useGetEntities, useOnExport, useRemoveFilter,
@@ -151,12 +152,11 @@ const PackageSystems = ({ packageName }) => {
         <React.Fragment>
             {status.hasError && <ErrorHandler code={status.code} /> || (
                 <InventoryTable
-                    disableDefaultColumns={['system_profile', 'updated', 'groups']}
                     isFullView
                     autoRefresh
                     initialLoading
                     hideFilters={{ all: true, tags: false, operatingSystem: false }}
-                    columns={PACKAGE_SYSTEMS_COLUMNS}
+                    columns={(inventoryColumns) => mergeInventoryColumns(PACKAGE_SYSTEMS_COLUMNS, inventoryColumns)}
                     showTags
                     getEntities={getEntites}
                     customFilters={{

--- a/src/SmartComponents/Systems/SystemListAssets.test.js
+++ b/src/SmartComponents/Systems/SystemListAssets.test.js
@@ -20,12 +20,12 @@ jest.mock('../../Utilities/api', () => ({
 describe('SystemListAssets.js', () => {
 
     it('Should call systemsListColumns on Applicable advisories renderFunc with correct params', () => {
-        SYSTEMS_LIST_COLUMNS[2].renderFunc('testValue');
+        SYSTEMS_LIST_COLUMNS.find(c => c.key === 'applicable_advisories').renderFunc('testValue');
         expect(createAdvisoriesIcons).toHaveBeenCalledWith('testValue', 'installable');
     });
 
     it('Should call createUpgradableColumn on Status renderFunc with correct params', () => {
-        PACKAGE_SYSTEMS_COLUMNS[4].renderFunc('testValue');
+        PACKAGE_SYSTEMS_COLUMNS.find(c => c.key === 'update_status').renderFunc('testValue');
         expect(createUpgradableColumn).toHaveBeenCalledWith('testValue');
     });
 

--- a/src/SmartComponents/Systems/SystemsListAssets.js
+++ b/src/SmartComponents/Systems/SystemsListAssets.js
@@ -81,6 +81,16 @@ export const SYSTEMS_LIST_COLUMNS = [
 
 export const ADVISORY_SYSTEMS_COLUMNS = [
     {
+        key: 'display_name',
+        renderFunc: (displayName, id) => <InsightsLink to={`/systems/${id}`}>{displayName}</InsightsLink>
+    },
+    {
+        key: 'groups'
+    },
+    {
+        key: 'tags'
+    },
+    {
         key: 'os',
         title: 'OS',
         renderFunc: value => createOSColumn(value),
@@ -112,6 +122,11 @@ export const ADVISORY_SYSTEMS_COLUMNS = [
             isStatic: true
         },
         transforms: [sortable]
+    },
+    {
+        inventoryKey: 'updated',
+        key: 'last_upload',
+        sortKey: 'last_upload'
     }
 ];
 

--- a/src/SmartComponents/Systems/SystemsListAssets.js
+++ b/src/SmartComponents/Systems/SystemsListAssets.js
@@ -23,6 +23,16 @@ export const ManagedBySatelliteCell = () => (
 
 export const SYSTEMS_LIST_COLUMNS = [
     {
+        key: 'display_name',
+        renderFunc: (displayName, id) => <InsightsLink to={`/systems/${id}`}>{displayName}</InsightsLink>
+    },
+    {
+        key: 'groups'
+    },
+    {
+        key: 'tags'
+    },
+    {
         key: 'operating_system',
         title: 'OS',
         renderFunc: value => createOSColumn(value),
@@ -61,6 +71,11 @@ export const SYSTEMS_LIST_COLUMNS = [
         props: {
             width: 10
         }
+    },
+    {
+        inventoryKey: 'updated',
+        key: 'last_upload',
+        sortKey: 'last_upload'
     }
 ];
 

--- a/src/SmartComponents/Systems/SystemsListAssets.js
+++ b/src/SmartComponents/Systems/SystemsListAssets.js
@@ -132,6 +132,12 @@ export const ADVISORY_SYSTEMS_COLUMNS = [
 
 export const PACKAGE_SYSTEMS_COLUMNS = [
     {
+        key: 'display_name'
+    },
+    {
+        key: 'tags'
+    },
+    {
         key: 'os',
         title: 'OS',
         renderFunc: value => createOSColumn(value),

--- a/src/SmartComponents/Systems/SystemsTable.js
+++ b/src/SmartComponents/Systems/SystemsTable.js
@@ -15,9 +15,8 @@ import { useBulkSelectConfig, useGetEntities, useOnExport,
 } from '../../Utilities/hooks';
 import { SYSTEMS_LIST_COLUMNS, systemsRowActions } from './SystemsListAssets';
 import AsyncRemediationButton from '../Remediation/AsyncRemediationButton';
-import { buildFilterConfig, buildActiveFiltersConfig } from '../../Utilities/SystemsHelpers';
+import { buildFilterConfig, buildActiveFiltersConfig, mergeInventoryColumns } from '../../Utilities/SystemsHelpers';
 import { combineReducers } from 'redux';
-import { systemsColumnsMerger } from '../../Utilities/SystemsHelpers';
 import { usePermissionsWithContext } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
 import propTypes from 'prop-types';
 
@@ -151,7 +150,7 @@ const SystemsTable = ({
             autoRefresh
             initialLoading
             hideFilters={{ all: true, tags: false, hostGroupFilter: false, operatingSystem: false }}
-            columns={(defaultColumns) => systemsColumnsMerger(defaultColumns, () => SYSTEMS_LIST_COLUMNS)}
+            columns={(inventoryColumns) => mergeInventoryColumns(SYSTEMS_LIST_COLUMNS, inventoryColumns)}
             showTags
             customFilters={{
                 ...operatingSystemFilter ? {

--- a/src/Utilities/SystemHelpers.test.js
+++ b/src/Utilities/SystemHelpers.test.js
@@ -1,4 +1,4 @@
-import { createSystemsSortBy, systemsColumnsMerger } from './SystemsHelpers';
+import { createSystemsSortBy, mergeInventoryColumns } from './SystemsHelpers';
 
 describe('createSystemsSortBy,', () => {
     it('should translate main parameters', () => {
@@ -34,74 +34,93 @@ describe('createSystemsSortBy,', () => {
     });
 });
 
-describe('systemsColumnsMerger', () => {
-    const baseColumns = [
-        {
-            key: 'updated'
+describe('mergeInventoryColumns', () => {
+    it('should merge basic columns correctly', () => {
+        const patchColumns = [
+            {
+                key: 'display_name'
+            },
+            {
+                key: 'package_count',
+                title: 'Package count'
+            }
+        ];
+
+        const inventoryColumns = [
+            {
+                key: 'display_name',
+                title: 'Display name'
+            }
+        ];
+
+        expect(mergeInventoryColumns(patchColumns, inventoryColumns))
+        .toMatchObject([{
+            key: 'display_name',
+            title: 'Display name'
         },
         {
-            key: 'display_name'
-        }
-    ];
-
-    it('should merge basic columns correctly', () => {
-        expect(systemsColumnsMerger(baseColumns, () => []))
-        .toMatchInlineSnapshot(`
-[
-  {
-    "key": "display_name",
-    "renderFunc": [Function],
-  },
-  {
-    "key": "last_upload",
-    "sortKey": "last_upload",
-  },
-]
-`);
+            key: 'package_count',
+            title: 'Package count'
+        }]);
     });
 
-    it('should omit extra columns', () => {
-        expect(
-            systemsColumnsMerger(
-                [...baseColumns, { key: 'omitted' }],
-                () => []
-            ).map(({ key }) => key)
-        ).not.toContain('omitted');
+    it('should merge modified columns correctly', () => {
+        const patchColumns = [
+            {
+                key: 'display_name',
+                title: 'Name'
+            },
+            {
+                key: 'package_count',
+                title: 'Package count'
+            }
+        ];
+
+        const inventoryColumns = [
+            {
+                key: 'display_name',
+                title: 'Display name'
+            }
+        ];
+
+        expect(mergeInventoryColumns(patchColumns, inventoryColumns))
+        .toMatchObject([{
+            key: 'display_name',
+            title: 'Name'
+        },
+        {
+            key: 'package_count',
+            title: 'Package count'
+        }]);
     });
 
-    it('should keep group column', () => {
-        expect(systemsColumnsMerger([...baseColumns, { key: 'groups' }], () => [])).toMatchInlineSnapshot(`
-[
-  {
-    "key": "display_name",
-    "renderFunc": [Function],
-  },
-  {
-    "key": "groups",
-  },
-  {
-    "key": "last_upload",
-    "sortKey": "last_upload",
-  },
-]
-`);
-    });
+    it('should merge renamed columns correctly', () => {
+        const patchColumns = [
+            {
+                inventoryKey: 'display_name',
+                key: 'name'
+            },
+            {
+                key: 'package_count',
+                title: 'Package count'
+            }
+        ];
 
-    it('should keep tags column', () => {
-        expect(systemsColumnsMerger([...baseColumns, { key: 'tags' }], () => [])).toMatchInlineSnapshot(`
-[
-  {
-    "key": "display_name",
-    "renderFunc": [Function],
-  },
-  {
-    "key": "tags",
-  },
-  {
-    "key": "last_upload",
-    "sortKey": "last_upload",
-  },
-]
-`);
+        const inventoryColumns = [
+            {
+                key: 'display_name',
+                title: 'Display name'
+            }
+        ];
+
+        expect(mergeInventoryColumns(patchColumns, inventoryColumns))
+        .toMatchObject([{
+            key: 'name',
+            title: 'Display name'
+        },
+        {
+            key: 'package_count',
+            title: 'Package count'
+        }]);
     });
 });

--- a/src/Utilities/SystemsHelpers.js
+++ b/src/Utilities/SystemsHelpers.js
@@ -5,7 +5,6 @@ import systemsUpdatableFilter from '../PresentationalComponents/Filters/SystemsU
 import { buildFilterChips, templateDateFormat } from './Helpers';
 import { intl } from './IntlProvider';
 import messages from '../Messages';
-import { PACKAGE_SYSTEMS_COLUMNS } from '../SmartComponents/Systems/SystemsListAssets';
 import { defaultCompoundSortValues } from './constants';
 import { patchSetDetailColumns } from '../SmartComponents/PatchSetDetail/PatchSetDetailAssets';
 import { InsightsLink } from '@redhat-cloud-services/frontend-components/InsightsLink';
@@ -93,7 +92,7 @@ export const createSystemsSortBy = (orderBy, orderDirection, hasLastUpload) => {
         if (!hasLastUpload) {
             orderBy = 'last_upload';
         } else {
-            orderBy = PACKAGE_SYSTEMS_COLUMNS[0].key;
+            orderBy = 'os';
         }
     } else if (orderBy === 'group_name') {
         orderBy = 'groups'; // patch API service uses 'groups' instead of 'group_name' sort parameter

--- a/src/Utilities/SystemsHelpers.js
+++ b/src/Utilities/SystemsHelpers.js
@@ -51,6 +51,12 @@ export const buildActiveFiltersConfig = (filter, search, deleteFilters) => {
         deleteTitle: intl.formatMessage(messages.labelsFiltersReset)
     };};
 
+export const mergeInventoryColumns = (patchmanColumns, inventoryColumns) =>
+    patchmanColumns.map(column => ({
+        ...inventoryColumns.find(inventoryColumn => inventoryColumn.key === (column.inventoryKey ?? column.key)),
+        ...column
+    }));
+
 export const systemsColumnsMerger = (defaultColumns, additionalColumns) => {
     let lastSeen = defaultColumns.filter(({ key }) => key === 'updated');
     let nameColumn = defaultColumns.filter(({ key }) => key === 'display_name');


### PR DESCRIPTION
This is a necessary prerequisite for Column management implementation. This allows us to simply change properties of table columns retrieved from Inventory (display name, workspaces (groups), tags, last seen).

Obsolete function `systemsColumnsMerger` will be removed together with old template pages.