### PR TITLE
feat(RHINENG-15545): Consume last seen column from Inventory

### DIFF
--- a/src/SmartComponents/Systems/SystemsListAssets.js
+++ b/src/SmartComponents/Systems/SystemsListAssets.js
@@ -94,7 +94,6 @@ export const SYSTEMS_LIST_COLUMNS = [
         inventoryKey: 'updated',
         key: 'last_upload',
         sortKey: 'last_upload',
-        title: 'Last seen',
         isShown: true,
         isShownByDefault: true
     }
@@ -164,7 +163,6 @@ export const ADVISORY_SYSTEMS_COLUMNS = [
         inventoryKey: 'updated',
         key: 'last_upload',
         sortKey: 'last_upload',
-        title: 'Last seen',
         isShown: true,
         isShownByDefault: true
     }


### PR DESCRIPTION


https://issues.redhat.com/browse/RHINENG-15545

The tooltip was added to the Inventory last seen column, but we were overwriting the column with our title due to intl, but it's not needed anymore. The column header will have tooltip only after RedHatInsights/insights-inventory-frontend#2429 has been merged.

