### PR TITLE
fix(RHINENG-19711): display Not available when missing advisory date

### DIFF
--- a/src/Utilities/DataMappers.js
+++ b/src/Utilities/DataMappers.js
@@ -49,7 +49,7 @@ export const createAdvisoriesRows = (rows, expandedRows, selectedRows) => {
                                 intl.formatMessage(messages.labelsRebootRequired)
                                 || intl.formatMessage(messages.labelsRebootNotRequired)
                         },
-                        { title: processDate(row.attributes.public_date) }
+                        { title: row.attributes.public_date ? processDate(row.attributes.public_date) : 'Not Available' }
                     ]
                 },
                 {


### PR DESCRIPTION
# Description

Associated Jira ticket: [RHINENG-19711](https://issues.redhat.com/browse/RHINENG-19711)

Display Not available instead of 1.1.1970 when missing date in an advisory


# How to test the PR

1. filter advisories by type other
2. date should show Not available instead of 1.1.1970

# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
