### PR TITLE
feat(RHINENG-21359): Pass down new remediation prop

### DIFF
--- a/src/PresentationalComponents/TableView/TableView.js
+++ b/src/PresentationalComponents/TableView/TableView.js
@@ -118,6 +118,7 @@ const TableView = ({
                                         || isRemediationLoading
                                     }
                                     isLoading={isRemediationLoading}
+                                    hasSelected={Object.values(selectedRows).filter(isSelected => isSelected).length > 0}
                                 />
                             ),
                             ...hasColumnManagement ? [{

--- a/src/SmartComponents/AdvisorySystems/AdvisorySystemsTable.js
+++ b/src/SmartComponents/AdvisorySystems/AdvisorySystemsTable.js
@@ -161,6 +161,7 @@ const AdvisorySystemsTable = ({
                         isDisabled={
                             arrayFromObj(selectedRows).length === 0
                         }
+                        hasSelected={arrayFromObj(selectedRows).length > 0}
                     />
                 )}
 

--- a/src/SmartComponents/PackageSystems/PackageSystems.js
+++ b/src/SmartComponents/PackageSystems/PackageSystems.js
@@ -219,6 +219,7 @@ const PackageSystems = ({ packageName }) => {
                         <AsyncRemediationButton
                             remediationProvider={remediationDataProvider}
                             isDisabled={arrayFromObj(selectedRows).length === 0}
+                            hasSelected={arrayFromObj(selectedRows).length !== 0}
                         />
                     )}
                 />

--- a/src/SmartComponents/Remediation/AsyncRemediationButton.js
+++ b/src/SmartComponents/Remediation/AsyncRemediationButton.js
@@ -7,9 +7,8 @@ import { Spinner } from '@patternfly/react-core';
 import { intl } from '../../Utilities/IntlProvider';
 import messages from '../../Messages';
 
-const AsyncRemediationButton = ({ remediationProvider, isDisabled, isLoading, patchNoAdvisoryText }) => {
+const AsyncRemediationButton = ({ remediationProvider, isDisabled, isLoading, patchNoAdvisoryText, hasSelected }) => {
     const dispatch = useDispatch();
-
     const handleRemediationSuccess = res => {
         dispatch(addNotification(res.getNotification()));
     };
@@ -24,6 +23,7 @@ const AsyncRemediationButton = ({ remediationProvider, isDisabled, isLoading, pa
             isDisabled={isDisabled}
             buttonProps={{ isLoading }}
             patchNoAdvisoryText={patchNoAdvisoryText}
+            hasSelected={hasSelected}
         >
             {intl.formatMessage(messages.labelsRemediate)}
         </AsyncComponent>
@@ -34,7 +34,8 @@ AsyncRemediationButton.propTypes = {
     remediationProvider: propTypes.func,
     isDisabled: propTypes.bool,
     isLoading: propTypes.bool,
-    patchNoAdvisoryText: propTypes.string
+    patchNoAdvisoryText: propTypes.string,
+    hasSelected: propTypes.bool
 };
 
 export default AsyncRemediationButton;

--- a/src/SmartComponents/Systems/SystemsTable.js
+++ b/src/SmartComponents/Systems/SystemsTable.js
@@ -221,6 +221,7 @@ const SystemsTable = ({
                             }
                             isLoading={isRemediationLoading}
                             patchNoAdvisoryText={NO_ADVISORIES_TEXT}
+                            hasSelected={arrayFromObj(selectedRows).length > 0}
                         />,
                         {
                             label: 'Manage columns',


### PR DESCRIPTION
This just adds in a new boolean to the button so that if the user has perms but nothing is selected, the button is still disabled and prompts the user to select more items. 
Cannot be merged until https://github.com/RedHatInsights/insights-remediations-frontend/pull/668 is merged 
https://issues.redhat.com/browse/RHINENG-20641