### PR TITLE
chore: Update dependabot to ignore jest, pf and rh cloud services

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,31 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
-    open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps):"
+    ignore:
+      - dependency-name: "@patternfly/react-core"
+        versions: ["7.x.x"]
+      - dependency-name: "@patternfly/react-icons"
+        versions: ["7.x.x"]
+      - dependency-name: "@patternfly/react-table"
+        versions: ["7.x.x"]
+      - dependency-name: "react-router-dom"
+        versions: ["7.x.x"]
+      - dependency-name: "@redhat-cloud-services/frontend-components-utilities"
+        versions: ["8.x.x"]
+      - dependency-name: "@redhat-cloud-services/frontend-components"
+        versions: ["8.x.x"]
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "htmlparser2"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "jest"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "jest-environment-jsdom"
+        update-types: ["version-update:semver-major"]
     groups:
       fec:
         patterns:
@@ -49,3 +71,6 @@ updates:
         patterns:
           - "webpack"
           - "webpack-bundle-analyzer"
+      npm:
+        patterns:
+          - "*"


### PR DESCRIPTION
# Description

I copied the settings of [Dependabot](https://github.com/content-services/content-sources-frontend/blob/main/.github/dependabot.yml) for Content. The patternfly, react-router dom and rh cloud services use higher versions. I think this should also be updated in content, as you already migrated pf, react-router-dom and rh services to higher versions than you ignore.