### PR TITLE
RHINENG-18569: add severity column and filter

### DIFF
--- a/src/Messages.js
+++ b/src/Messages.js
@@ -1,11 +1,9 @@
-
 /* eslint-disable max-len */
 /* eslint sort-keys: ["error", "asc", {minKeys: 4}] */
 
 import { defineMessages } from 'react-intl';
 
 export default defineMessages({
-
     generalAppName: {
         id: 'generalAppName',
         description: 'regsiter page title',
@@ -179,7 +177,8 @@ export default defineMessages({
     labelsCvesButton: {
         id: 'labelsCvesButton',
         description: 'label for cves button',
-        defaultMessage: '{cvesCount, plural, one {# CVE} other {# CVEs}} associated with this patch'
+        defaultMessage:
+            '{cvesCount, plural, one {# CVE} other {# CVEs}} associated with this patch'
     },
     labelsDate: {
         id: 'labelsDate',
@@ -311,6 +310,16 @@ export default defineMessages({
         description: 'Label for search filter placeholder',
         defaultMessage: 'Template'
     },
+    labelsFiltersSeverity: {
+        id: 'labelsFiltersSeverity',
+        description: 'Label for severity filter',
+        defaultMessage: 'Severity'
+    },
+    labelsFiltersSeverityPlaceholder: {
+        id: 'labelsFiltersSeverity',
+        description: 'Label for severity filter placeholder',
+        defaultMessage: 'Filter by severity'
+    },
     labelsFiltersStale: {
         id: 'labelsFiltersStale',
         description: 'Label for stale filter title',
@@ -363,12 +372,15 @@ export default defineMessages({
     },
     labelsNotAuthorizedDescription: {
         id: 'notAuthorizedDescription',
-        description: 'Description for component which shows up when user doesn\'t have permission to view content',
-        defaultMessage: 'Contact your organization administrator(s) for more information.'
+        description:
+            'Description for component which shows up when user doesn\'t have permission to view content',
+        defaultMessage:
+            'Contact your organization administrator(s) for more information.'
     },
     labelsNotAuthorizedTitle: {
         id: 'notAuthorizedTitle',
-        description: 'Title for component which shows up when user doesn\'t have permission to view content',
+        description:
+            'Title for component which shows up when user doesn\'t have permission to view content',
         defaultMessage: 'You do not have permissions to view or manage Patch'
     },
     labelsPublicDate: {
@@ -434,7 +446,8 @@ export default defineMessages({
     labelsSystem: {
         id: 'labelsSystem',
         description: 'Generic pluralized systems label',
-        defaultMessage: '{systemsCount, plural, one { # system } other { # systems }}'
+        defaultMessage:
+            '{systemsCount, plural, one { # system } other { # systems }}'
     },
     labelsTemplateNoSystems: {
         id: 'labelsTemplateNoSystems',
@@ -474,7 +487,8 @@ export default defineMessages({
     statesMinimumPatchPermissionsRequired: {
         id: 'statesMinimumPatchPermissionsRequired',
         description: 'No access page body',
-        defaultMessage: 'To view the content of this page, you must be granted a minimum of Patch permissions from your Organisation Administratior'
+        defaultMessage:
+            'To view the content of this page, you must be granted a minimum of Patch permissions from your Organisation Administratior'
     },
     statesNoApplicableAdvisories: {
         id: 'statesNoApplicableAdvisories',
@@ -514,7 +528,8 @@ export default defineMessages({
     statesNoTemplateBody: {
         id: 'statesNoTemplateBody',
         description: 'Label',
-        defaultMessage: 'Control the scope of package and advisory updates to be installed on selected systems with templates. To get started, create a template.'
+        defaultMessage:
+            'Control the scope of package and advisory updates to be installed on selected systems with templates. To get started, create a template.'
     },
     statesNoTemplateLink: {
         id: 'statesNoTemplateLink',
@@ -529,12 +544,14 @@ export default defineMessages({
     statesSystemUpToDate: {
         id: 'statesSystemUpToDate',
         description: 'system up to date page body',
-        defaultMessage: 'This system is up to date, based on package information submitted at the most recent system check-in'
+        defaultMessage:
+            'This system is up to date, based on package information submitted at the most recent system check-in'
     },
     templateAlertSystems: {
         id: 'templateAlertSystems',
         description: 'Template wizard alert',
-        defaultMessage: 'A system can have only one content template, therefore if you apply a new content template to the system, it will be overwritten.'
+        defaultMessage:
+            'A system can have only one content template, therefore if you apply a new content template to the system, it will be overwritten.'
     },
     templateApply: {
         id: 'templateApply',
@@ -549,7 +566,8 @@ export default defineMessages({
     templateContentStepExpandable: {
         id: 'templateContentStepExpandable',
         description: 'template wizard template expandable text',
-        defaultMessage: 'You have a system with 10 applicable RHEL advisories, the most recent of which was published today. You apply a template with a date of yesterday to that system. After re-evaluation, the advisory published today will not be considered installable on the system, but will be considered applicable.'
+        defaultMessage:
+            'You have a system with 10 applicable RHEL advisories, the most recent of which was published today. You apply a template with a date of yesterday to that system. After re-evaluation, the advisory published today will not be considered installable on the system, but will be considered applicable.'
     },
     templateContentStepExpandableTitle: {
         id: 'templateContentStepExpandableTitle',
@@ -564,7 +582,8 @@ export default defineMessages({
     templateContentStepText: {
         id: 'templateContentStepText',
         description: 'template wizard template text',
-        defaultMessage: 'Templates provide you with consistent content across environments and time by allowing you to control the scope of package and advisory updates to be installed on selected systems.'
+        defaultMessage:
+            'Templates provide you with consistent content across environments and time by allowing you to control the scope of package and advisory updates to be installed on selected systems.'
     },
     templateContentStepTitle: {
         id: 'templateContentStepTitle',
@@ -589,7 +608,8 @@ export default defineMessages({
     templateDescription: {
         id: 'templateDescription',
         description: 'description of the patch template wizard',
-        defaultMessage: 'Prepare for your next patching cycle with a content template.'
+        defaultMessage:
+            'Prepare for your next patching cycle with a content template.'
     },
     templateDetailHeaderBreadcrumb: {
         id: 'templateDetailHeaderBreadcrumb',
@@ -649,7 +669,8 @@ export default defineMessages({
     templateError: {
         id: 'templateError',
         description: 'error text for the patch template wizard',
-        defaultMessage: 'There was a problem processing the patch template. Please try again. If the problem persists, contact <a>Red Hat support</a>'
+        defaultMessage:
+            'There was a problem processing the patch template. Please try again. If the problem persists, contact <a>Red Hat support</a>'
     },
     templateNew: {
         id: 'templateNew',
@@ -658,18 +679,21 @@ export default defineMessages({
     },
     templateNoAppliedSystemsButton: {
         id: 'templateNoAppliedSystemsButton',
-        description: 'button in the empty state in template assigned systems table',
+        description:
+            'button in the empty state in template assigned systems table',
         defaultMessage: 'Apply to systems'
     },
     templateNoAppliedSystemsTitle: {
         id: 'templateNoAppliedSystemsTitle',
-        description: 'title of the empty state in template assigned systems table',
+        description:
+            'title of the empty state in template assigned systems table',
         defaultMessage: 'Not applied to any systems'
     },
     templateNoSystemSelected: {
         id: 'templateNoSystemSelected',
         description: 'validation text of the patch template wizard',
-        defaultMessage: 'At least one system must be selected. Actions must be associated to a system to be added to a playbook.'
+        defaultMessage:
+            'At least one system must be selected. Actions must be associated to a system to be added to a playbook.'
     },
     templateOr: {
         id: 'templateOr',
@@ -679,7 +703,8 @@ export default defineMessages({
     templatePopoverBody: {
         id: 'templatePopoverBody',
         description: 'Template page header popover body',
-        defaultMessage: 'Templates allow you to control the scope of package and advisory updates to be installed on selected systems.'
+        defaultMessage:
+            'Templates allow you to control the scope of package and advisory updates to be installed on selected systems.'
     },
     templatePopoverHeader: {
         id: 'templatePopoverHeader',
@@ -694,7 +719,8 @@ export default defineMessages({
     templateSelect: {
         id: 'templateSelect',
         description: 'title with capital letters',
-        defaultMessage: 'Select a template to apply to the selected {systemCount, plural, one {<b>#</b> system} other {<b>#</b> systems}}.'
+        defaultMessage:
+            'Select a template to apply to the selected {systemCount, plural, one {<b>#</b> system} other {<b>#</b> systems}}.'
     },
     templateSelectExisting: {
         id: 'templateSelectExisting',
@@ -704,7 +730,8 @@ export default defineMessages({
     templateSelectSatellite: {
         id: 'templateSelectSatellite',
         description: 'title with capital letters',
-        defaultMessage: '<b>{systemCount}</b> of the selected systems content is Managed by Satellite therefore Template is not applicable.'
+        defaultMessage:
+            '<b>{systemCount}</b> of the selected systems content is Managed by Satellite therefore Template is not applicable.'
     },
     templateStepSystems: {
         id: 'templateStepSystems',
@@ -739,7 +766,8 @@ export default defineMessages({
     textEmptyStateBody: {
         id: 'textEmptyStateBody',
         description: 'text for the Empty state body',
-        defaultMessage: 'To continue, edit your filter settings and search again.'
+        defaultMessage:
+            'To continue, edit your filter settings and search again.'
     },
     textErrorSomethingWrong: {
         id: 'textErrorSomethingWrong',
@@ -769,7 +797,8 @@ export default defineMessages({
     textPatchTemplatePending: {
         id: 'textPatchTemplatePending',
         description: 'text for the patch template',
-        defaultMessage: 'Please allow a few minutes to set up a patch template. You will receive a notification when finished.'
+        defaultMessage:
+            'Please allow a few minutes to set up a patch template. You will receive a notification when finished.'
     },
     textPatchTemplateReview: {
         id: 'textPatchTemplateReview',
@@ -814,12 +843,14 @@ export default defineMessages({
     textTemplateSelectedSystems: {
         id: 'textTemplateSelectedSystems',
         description: 'text for patch template wizard',
-        defaultMessage: 'You selected {systemsCount, plural, one {<b> # </b> system } other {<b> # </b> systems }}'
+        defaultMessage:
+            'You selected {systemsCount, plural, one {<b> # </b> system } other {<b> # </b> systems }}'
     },
     textUnassignSystemsNoAssignedSystems: {
         id: 'textUnassignSystemsNoAssignedSystems',
         description: 'text about systems being removed',
-        defaultMessage: 'None of the systems you have selected are assigned to existing Patch template.'
+        defaultMessage:
+            'None of the systems you have selected are assigned to existing Patch template.'
     },
     textUnassignSystemsShortTitle: {
         id: 'textUnassignSystemsShortTitle',
@@ -829,7 +860,8 @@ export default defineMessages({
     textUnassignSystemsStatement: {
         id: 'textUnassignSystemsStatement',
         description: 'text about systems being removed',
-        defaultMessage: 'Do you want to remove the {systemsCount, plural, one {<b> # </b> selected system } other {<b> # </b> selected systems }} from assigned Patch templates?'
+        defaultMessage:
+            'Do you want to remove the {systemsCount, plural, one {<b> # </b> selected system } other {<b> # </b> selected systems }} from assigned Patch templates?'
     },
     textUnassignSystemsTitle: {
         id: 'textUnassignSystemsTitle',
@@ -839,7 +871,8 @@ export default defineMessages({
     textUnassignSystemsWarning: {
         id: 'textUnassignSystemsWarning',
         description: 'warning about systems without patch template assigned',
-        defaultMessage: 'There {systemsCount, plural, one {is <b> # </b>  system } other { are <b> # </b>  systems }} you are trying to remove that {systemsCount, plural, one {is} other {are}} not assigned to any existing Patch template. This action will not affect {systemsCount, plural, one {it} other {them}}.'
+        defaultMessage:
+            'There {systemsCount, plural, one {is <b> # </b>  system } other { are <b> # </b>  systems }} you are trying to remove that {systemsCount, plural, one {is} other {are}} not assigned to any existing Patch template. This action will not affect {systemsCount, plural, one {it} other {them}}.'
     },
     titlesAdvisories: {
         id: 'titlesAdvisories',
@@ -904,7 +937,8 @@ export default defineMessages({
     titlesTemplateDeleteModalText: {
         id: 'titlesTemplateDeleteModalText',
         description: 'page title with capital letter',
-        defaultMessage: '<b>{templateName}</b> and all its data will be permanently deleted. Associated systems will be removed from the template but will not be deleted.'
+        defaultMessage:
+            '<b>{templateName}</b> and all its data will be permanently deleted. Associated systems will be removed from the template but will not be deleted.'
     },
     titlesTemplateDeleteModalTitle: {
         id: 'titlesTemplateDeleteModalTitle',
@@ -924,7 +958,8 @@ export default defineMessages({
     titlesTemplateRemoveFromSystems: {
         id: 'titlesTemplateRemoveMultipleButton',
         description: 'title with capital letters',
-        defaultMessage: 'Remove from {systemsCount, plural, one {system} other {systems}}'
+        defaultMessage:
+            'Remove from {systemsCount, plural, one {system} other {systems}}'
     },
     titlesTemplateRemoveMultipleButton: {
         id: 'titlesTemplateRemoveMultipleButton',

--- a/src/PresentationalComponents/AdvisoryHeader/AdvisoryHeader.js
+++ b/src/PresentationalComponents/AdvisoryHeader/AdvisoryHeader.js
@@ -1,12 +1,23 @@
 import {
-    Button, Grid, GridItem, Stack, StackItem, Content, FlexItem, ContentVariants, Flex, Split, SplitItem, Title
+    Button,
+    Content,
+    ContentVariants,
+    Flex,
+    FlexItem,
+    Grid,
+    GridItem,
+    Split,
+    SplitItem,
+    Stack,
+    StackItem,
+    Title
 } from '@patternfly/react-core';
 import { processDate } from '@redhat-cloud-services/frontend-components-utilities/helpers';
 import propTypes from 'prop-types';
-import React, { useState, lazy, Suspense, Fragment } from 'react';
+import React, { Fragment, lazy, Suspense, useState } from 'react';
 import messages from '../../Messages';
 import WithLoader, { WithLoaderVariants } from '../../PresentationalComponents/WithLoader/WithLoader';
-import { getSeverityById, isRHAdvisory, truncateDescription } from '../../Utilities/Helpers';
+import { getSeverityByValue, isRHAdvisory, truncateDescription } from '../../Utilities/Helpers';
 import { intl } from '../../Utilities/IntlProvider';
 import RebootRequired from '../Snippets/RebootRequired';
 import AdvisorySeverityInfo from '../Snippets/AdvisorySeverityInfo';
@@ -22,11 +33,11 @@ const CvesModal = lazy(() =>
 const AdvisoryHeader = ({ attributes, isLoading }) => {
     const [CvesInfoModal, setCvesModal] = useState(() => () => null);
     const [wordLength, setWordLength] = useState(1000);
-    const severityObject = getSeverityById(attributes.severity);
+    const severityObject = getSeverityByValue(attributes?.severity);
     const cves = attributes.cves;
 
     const showCvesModal = () => {
-        setCvesModal(() => () => <CvesModal cveIds={cves} />);
+        setCvesModal(() => () => <CvesModal cveIds={cves}/>);
     };
 
     return (
@@ -38,7 +49,7 @@ const AdvisoryHeader = ({ attributes, isLoading }) => {
                     centered
                 >
                     <Stack hasGutter>
-                        <StackItem />
+                        <StackItem/>
                         <StackItem style={{ whiteSpace: 'pre-line' }}>
                             {
                                 attributes.description && truncateDescription(attributes.description, wordLength, setWordLength)
@@ -52,7 +63,7 @@ const AdvisoryHeader = ({ attributes, isLoading }) => {
                                             attributes.public_date
                                         )
                                     })}
-                                    <br />
+                                    <br/>
                                 </React.Fragment>
                             )}
                             {attributes.modified_date && (
@@ -68,7 +79,7 @@ const AdvisoryHeader = ({ attributes, isLoading }) => {
                         {isRHAdvisory(attributes.id) &&
                             <StackItem>
                                 <ExternalLink link={`https://access.redhat.com/errata/${attributes.id}`}
-                                    text={intl.formatMessage(messages.linksViewPackagesAndErrata)} />
+                                    text={intl.formatMessage(messages.linksViewPackagesAndErrata)}/>
                             </StackItem>
                         }
                     </Stack>
@@ -95,12 +106,12 @@ const AdvisoryHeader = ({ attributes, isLoading }) => {
                         </Split>
                     </FlexItem>
                     )}
-                    {severityObject.value !== 0 && (<FlexItem>
+                    {severityObject.value === null ? null : (<FlexItem>
                         <AdvisorySeverityInfo severity={severityObject}/>
                     </FlexItem>
                     )}
                     {attributes.reboot_required && (<FlexItem spacer={{ default: 'spacerMd' }}>
-                        <RebootRequired />
+                        <RebootRequired/>
                     </FlexItem>)}
                 </Flex>
             </GridItem>
@@ -110,14 +121,14 @@ const AdvisoryHeader = ({ attributes, isLoading }) => {
                         <Content component={ContentVariants.h3}>
                             {intl.formatMessage(messages.labelsCves)}
                         </Content>
-                        <Button variant='link' style={{ padding: 0 }} onClick={showCvesModal} >
+                        <Button variant='link' style={{ padding: 0 }} onClick={showCvesModal}>
                             {intl.formatMessage(messages.labelsCvesButton, { cvesCount: cves.length })}
                         </Button>
                     </Content>
                 </GridItem>
             )}
             <Suspense fallback={<Fragment/>}>
-                <CvesInfoModal />
+                <CvesInfoModal/>
             </Suspense>
         </Grid>
     );

--- a/src/PresentationalComponents/AdvisorySeverity/AdvisorySeverity.js
+++ b/src/PresentationalComponents/AdvisorySeverity/AdvisorySeverity.js
@@ -1,0 +1,24 @@
+import { Content, ContentVariants, Icon } from '@patternfly/react-core';
+import { SecurityIcon } from '@patternfly/react-icons';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const AdvisorySeverity = ({ severity: { label, color } = {} }) => (
+    <Content>
+        <Content component={ContentVariants.dd}>
+            <Icon size="sm">
+                <SecurityIcon color={color}/>
+            </Icon>
+            &nbsp;{label}
+        </Content>
+    </Content>
+);
+
+AdvisorySeverity.propTypes = {
+    severity: PropTypes.shape({
+        label: PropTypes.string,
+        color: PropTypes.string
+    })
+};
+
+export default AdvisorySeverity;

--- a/src/PresentationalComponents/AdvisorySeverity/AdvisorySeverity.test.js
+++ b/src/PresentationalComponents/AdvisorySeverity/AdvisorySeverity.test.js
@@ -1,0 +1,12 @@
+import { render } from '@testing-library/react';
+import AdvisorySeverity from './AdvisorySeverity';
+
+describe('AdvisorySeverity', () => {
+    it('Should match the snapshots', () => {
+        const { asFragment } = render(
+            <AdvisorySeverity
+                severity={{ label: 'Moderate', color: 'var(--pf-t--global--icon--color--severity--moderate--default)' }}/>
+        );
+        expect(asFragment()).toMatchSnapshot();
+    });
+});

--- a/src/PresentationalComponents/AdvisorySeverity/__snapshots__/AdvisorySeverity.test.js.snap
+++ b/src/PresentationalComponents/AdvisorySeverity/__snapshots__/AdvisorySeverity.test.js.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AdvisorySeverity Should match the snapshots 1`] = `
+<DocumentFragment>
+  <div
+    class="pf-v6-c-content"
+    data-ouia-component-id="OUIA-Generated-Content-1"
+    data-ouia-component-type="PF6/Content"
+    data-ouia-safe="true"
+    data-pf-content="true"
+  >
+    <dd
+      class="pf-v6-c-content--dd"
+      data-ouia-component-id="OUIA-Generated-Content-2"
+      data-ouia-component-type="PF6/Content"
+      data-ouia-safe="true"
+      data-pf-content="true"
+    >
+      <span
+        class="pf-v6-c-icon pf-m-sm"
+      >
+        <span
+          class="pf-v6-c-icon__content"
+        >
+          <svg
+            aria-hidden="true"
+            class="pf-v6-svg"
+            color="var(--pf-t--global--icon--color--severity--moderate--default)"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 896 1024"
+            width="1em"
+          >
+            <path
+              d="M861.5,0 L34.5,0 C15.4,0 0,14.3 0,32 L0,452.1 C0,768 387.7,1024 448.5,1024 C509.3,1024 896,768 896,452.2 L896,32 C896,14.3 880.6,0 861.5,0 Z M490.7,768 L405.3,768 C393.5,767.8 384.2,757.5 384,744.7 L384,663.3 C384.2,650.5 393.6,640.3 405.3,640 L490.7,640 C502.5,640.2 511.8,650.5 512,663.3 L512,744.7 L512.1,744.7 C511.8,757.5 502.4,767.8 490.7,768 Z M543.9,162.7 L517.2,514.4 C515.8,530.9 502,544 485.3,544 L410.6,544 C394,544 380.1,531.2 378.7,514.7 L352.1,163 C350.5,144.3 365.3,128.3 384,128.3 L512,128 C530.7,128 545.4,144 543.9,162.7 Z"
+            />
+          </svg>
+        </span>
+      </span>
+       Moderate
+    </dd>
+  </div>
+</DocumentFragment>
+`;

--- a/src/PresentationalComponents/Filters/SeverityFilter.js
+++ b/src/PresentationalComponents/Filters/SeverityFilter.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import { advisorySeverities } from '../../Utilities/constants';
+import { intl } from '../../Utilities/IntlProvider';
+import messages from '../../Messages';
+import { conditionalFilterType } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
+
+// Backend note: Patch handles `filter[severity]=null` as an `IS NULL` predicate and ignores `IN (...)` lists
+// that contain NULL. We keep the UI state as arrays for PatternFly (ConditionalFilter checkbox) but collapse
+// `[null]` to bare `null` before dispatching so the API stays on the supported code path
+
+const severityFilter = (apply, currentFilter = {}) => {
+    const advisorySeverityMap = React.useMemo(
+        () =>
+            advisorySeverities.map(({ value, label }) => ({
+                label,
+                value: String(value)
+            })),
+        []
+    );
+
+    const currentSeverityValue = (() => {
+        const { severity } = currentFilter ?? {};
+
+        if (severity === undefined) {
+            return undefined;
+        }
+
+        // Treat "None" as an array too (for consistency in the UI), even though the API requires it to be `null`
+        if (severity === null) {
+            return ['null'];
+        }
+
+        const severityArray = Array.isArray(severity) ? severity : [severity];
+
+        return severityArray.map((value) => String(value));
+    })();
+
+    const filterBySeverity = (severityStrings = []) => {
+        if (severityStrings.length === 0) {
+            apply({ filter: { severity: undefined } });
+            return;
+        }
+
+        // Convert each string into its respective raw value before passing it to the API
+        // The engine expects a scalar `null` for the "None" case and integer arrays for actual severities
+        const mappedSeverities = severityStrings.map((item) =>
+            item === 'null' ? null : parseInt(item, 10)
+        );
+
+        // Send a bare `null` so we use the API's `IS NULL` path instead of an unsupported `IN (NULL)` clause
+        if (mappedSeverities.length === 1 && mappedSeverities[0] === null) {
+            apply({ filter: { severity: null } });
+            return;
+        }
+
+        apply({ filter: { severity: mappedSeverities } });
+    };
+
+    return {
+        label: intl.formatMessage(messages.labelsFiltersSeverity),
+        type: conditionalFilterType.checkbox,
+        filterValues: {
+            onChange: (event, value) => {
+                filterBySeverity(value);
+            },
+            items: advisorySeverityMap,
+            value: currentSeverityValue,
+            placeholder: intl.formatMessage(
+                messages.labelsFiltersSeverityPlaceholder
+            )
+        }
+    };
+};
+
+export default severityFilter;

--- a/src/PresentationalComponents/Filters/SeverityFilter.test.js
+++ b/src/PresentationalComponents/Filters/SeverityFilter.test.js
@@ -1,0 +1,62 @@
+import severityFilter from './SeverityFilter';
+
+jest.mock('react', () => ({
+    ...jest.requireActual('react'),
+    useMemo: jest.fn((callback) => callback())
+}));
+
+const currentFilterInteger = { severity: [2] };
+const currentFilterEmpty = { severity: [] };
+
+let apply;
+const renderFilter = (filter = {}) => severityFilter(apply, filter);
+const rehydrateFilter = (value) =>
+    severityFilter(apply, value === undefined ? {} : { severity: value });
+
+describe('SeverityFilter', () => {
+    beforeEach(() => {
+        apply = jest.fn();
+    });
+
+    it('returns checkbox metadata seeded from existing severities', () => {
+        const response = renderFilter(currentFilterInteger);
+        expect(response.filterValues.value).toEqual(['2']);
+        expect(response.label).toEqual('Severity');
+        expect(response.type).toEqual('checkbox');
+    });
+
+    it('converts selected integer severities into raw values before dispatch', () => {
+        const response = renderFilter(currentFilterInteger);
+        response.filterValues.onChange('event', ['2']);
+        expect(apply).toHaveBeenCalledWith({ filter: { severity: [2] } });
+        // Rehydrate with the store snapshot that would come back after dispatching `[2]`
+        const rehydratedResponse = rehydrateFilter([2]);
+        // ConditionalFilter checkboxes compare option ids as strings
+        expect(rehydratedResponse.filterValues.value).toEqual(['2']);
+    });
+
+    it('converts the "None" selection into a null severity', () => {
+        const response = renderFilter(currentFilterEmpty);
+        response.filterValues.onChange('event', ['null']);
+        expect(apply).toHaveBeenCalledWith({ filter: { severity: null } });
+        // Rehydrate with the store snapshot that would come back after dispatching `null`
+        const rehydratedResponse = rehydrateFilter(null);
+        expect(rehydratedResponse.filterValues.value).toEqual(['null']);
+    });
+
+    it('dispatches undefined severity when onChange receives no payload', () => {
+        const response = renderFilter(currentFilterEmpty);
+        response.filterValues.onChange();
+        expect(apply).toHaveBeenCalledWith({ filter: { severity: undefined } });
+        const rehydratedResponse = rehydrateFilter(undefined);
+        expect(rehydratedResponse.filterValues.value).toBeUndefined();
+    });
+
+    it('dispatches undefined severity when the selection is cleared explicitly', () => {
+        const response = renderFilter(currentFilterEmpty);
+        response.filterValues.onChange('event', []); // Clear the filter
+        expect(apply).toHaveBeenCalledWith({ filter: { severity: undefined } });
+        const rehydratedResponse = rehydrateFilter(undefined);
+        expect(rehydratedResponse.filterValues.value).toBeUndefined();
+    });
+});

--- a/src/PresentationalComponents/Snippets/DescriptionWithLink.js
+++ b/src/PresentationalComponents/Snippets/DescriptionWithLink.js
@@ -1,20 +1,17 @@
-import {
-    Icon,
-    Content, ContentVariants
-} from '@patternfly/react-core';
+import { Content, ContentVariants, Icon } from '@patternfly/react-core';
 import { SecurityIcon } from '@patternfly/react-icons';
 import propTypes from 'prop-types';
 import React from 'react';
 import messages from '../../Messages';
 import { entityTypes } from '../../Utilities/constants';
-import { getSeverityById, handlePatchLink, isRHAdvisory, truncate } from '../../Utilities/Helpers';
+import { getSeverityByValue, handlePatchLink, isRHAdvisory, truncate } from '../../Utilities/Helpers';
 import { intl } from '../../Utilities/IntlProvider';
 import ExternalLink from './ExternalLink';
 import Label from './Label';
 import RebootRequired from '../Snippets/RebootRequired';
 
 export const DescriptionWithLink = ({ row }) => {
-    const severityObject = getSeverityById(row.attributes.severity);
+    const severityObject = getSeverityByValue(row.attributes?.severity);
     return (
         <Content className='patch-advisory-description'>
             {
@@ -25,8 +22,8 @@ export const DescriptionWithLink = ({ row }) => {
                     </Content>
                     <Content component={ContentVariants.dd}>
                         <Icon size="sm">
-                            <SecurityIcon color={severityObject.color} />
-                        </Icon>  {severityObject.label}
+                            <SecurityIcon color={severityObject.color}/>
+                        </Icon> {severityObject.label}
                     </Content>
                     <Content component={ContentVariants.dt}>
                         {intl.formatMessage(messages.labelsCves)}
@@ -47,7 +44,7 @@ export const DescriptionWithLink = ({ row }) => {
                 row.attributes.reboot_required && <RebootRequired/>
             }
             {isRHAdvisory(row.id) && <ExternalLink link={`https://access.redhat.com/errata/${row.id}`}
-                text={intl.formatMessage(messages.linksViewPackagesAndErrata)} />}
+                text={intl.formatMessage(messages.linksViewPackagesAndErrata)}/>}
         </Content>);
 };
 

--- a/src/PresentationalComponents/TableView/TableViewAssets.js
+++ b/src/PresentationalComponents/TableView/TableViewAssets.js
@@ -27,6 +27,13 @@ export const advisoriesColumns = [
         isShownByDefault: true
     },
     {
+        title: intl.formatMessage(messages.labelsColumnsSeverity),
+        transforms: [sortable, cellWidth(10)],
+        key: 'severity',
+        isShown: true,
+        isShownByDefault: true
+    },
+    {
         title: intl.formatMessage(messages.labelsColumnsAffectedSystems),
         transforms: [sortable, cellWidth(15)],
         key: 'applicable_systems',
@@ -77,6 +84,13 @@ export const systemAdvisoriesColumns = [
         title: intl.formatMessage(messages.labelsColumnsType),
         transforms: [sortable, cellWidth(10)],
         key: 'advisory_type_name',
+        isShown: true,
+        isShownByDefault: true
+    },
+    {
+        title: intl.formatMessage(messages.labelsColumnsSeverity),
+        transforms: [sortable, cellWidth(10)],
+        key: 'severity',
         isShown: true,
         isShownByDefault: true
     },

--- a/src/SmartComponents/Advisories/Advisories.js
+++ b/src/SmartComponents/Advisories/Advisories.js
@@ -10,17 +10,22 @@ import Header from '../../PresentationalComponents/Header/Header';
 import TableView from '../../PresentationalComponents/TableView/TableView';
 import { advisoriesColumns } from '../../PresentationalComponents/TableView/TableViewAssets';
 import {
-    changeAdvisoryListParams, expandAdvisoryRow,
-    fetchApplicableAdvisories, selectAdvisoryRow
+    changeAdvisoryListParams,
+    expandAdvisoryRow,
+    fetchApplicableAdvisories,
+    selectAdvisoryRow
 } from '../../store/Actions/Actions';
 import { exportAdvisoriesCSV, exportAdvisoriesJSON } from '../../Utilities/api';
 import { createAdvisoriesRows } from '../../Utilities/DataMappers';
+import { createSortBy, decodeQueryparams, encodeURLParams, getRowIdByIndexExpandable } from '../../Utilities/Helpers';
 import {
-    createSortBy, decodeQueryparams,
-    encodeURLParams, getRowIdByIndexExpandable
-} from '../../Utilities/Helpers';
-import { useOnExport, useRemediationDataProvider, useOnSelect, ID_API_ENDPOINTS,
-    usePerPageSelect, useSetPage, useSortColumn
+    ID_API_ENDPOINTS,
+    useOnExport,
+    useOnSelect,
+    usePerPageSelect,
+    useRemediationDataProvider,
+    useSetPage,
+    useSortColumn
 } from '../../Utilities/hooks';
 import { intl } from '../../Utilities/IntlProvider';
 import { clearNotifications } from '@redhat-cloud-services/frontend-components-notifications/redux';
@@ -28,9 +33,10 @@ import AdvisoriesStatusReport from '../../PresentationalComponents/StatusReports
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
-import { Flex, Icon, Popover, Content, ContentVariants } from '@patternfly/react-core';
+import { Content, ContentVariants, Flex, Icon, Popover } from '@patternfly/react-core';
 import ExternalLink from '../../PresentationalComponents/Snippets/ExternalLink';
 import useFeatureFlag from '../../Utilities/hooks/useFeatureFlag';
+import severityFilter from '../../PresentationalComponents/Filters/SeverityFilter';
 
 const Advisories = () => {
     const navigate = useNavigate();
@@ -38,7 +44,7 @@ const Advisories = () => {
     const chrome = useChrome();
     const isLightspeedEnabled = useFeatureFlag('platform.lightspeed-rebrand');
 
-    useEffect(()=>{
+    useEffect(() => {
         chrome.updateDocumentTitle(`Advisories - Content | RHEL`, true);
     }, [chrome]);
 
@@ -150,7 +156,7 @@ const Advisories = () => {
                                         <Content component={ContentVariants.p}>
                                             <ExternalLink
                                                 link={'https://docs.redhat.com/en/documentation/red_hat_insights/1-latest'
-                                                + '/html/system_patching_using_remediation_playbooks'}
+                                                    + '/html/system_patching_using_remediation_playbooks'}
                                                 text="System Patching Using Remediation Playbooks"
                                             />
                                         </Content>
@@ -196,6 +202,7 @@ const Advisories = () => {
                                 intl.formatMessage(messages.labelsFiltersSearchAdvisoriesPlaceholder)
                             ),
                             typeFilter(apply, queryParams?.filter),
+                            severityFilter(apply, queryParams?.filter),
                             publishDateFilter(apply, queryParams?.filter),
                             rebootFilter(apply, queryParams?.filter)
                         ]

--- a/src/SmartComponents/Advisories/Advisories.test.js
+++ b/src/SmartComponents/Advisories/Advisories.test.js
@@ -32,8 +32,8 @@ jest.mock('../../Utilities/constants', () => ({
     ...jest.requireActual('../../Utilities/constants'),
     publicDateOptions: jest.fn().mockReturnValue([]),
     advisorySeverities: [{
-        value: 0,
-        label: 'N/A',
+        value: null,
+        label: 'None',
         color: 'var(--pf-t--global--icon--color--severity--minor--default'
     }]
 }));
@@ -46,7 +46,8 @@ jest.mock('../Remediation/AsyncRemediationButton', () => ({
     ))
 }));
 
-const mockState = { ...storeListDefaults,
+const mockState = {
+    ...storeListDefaults,
     rows: advisoryRows,
     status: { isLoading: false, code: 200, hasError: false },
     metadata: {
@@ -58,7 +59,7 @@ const mockState = { ...storeListDefaults,
 
 const initStore = (state) => {
     const mockStore = configureStore([]);
-    return mockStore({  AdvisoryListStore: state });
+    return mockStore({ AdvisoryListStore: state });
 };
 
 let store = initStore(mockState);
@@ -107,7 +108,7 @@ describe('Advisories.js', () => {
         const tempStore = initStore(selectedState);
         render(
             <ComponentWithContext renderOptions={{ store: tempStore }}>
-                <Advisories />
+                <Advisories/>
             </ComponentWithContext>
         );
 

--- a/src/SmartComponents/SystemAdvisories/SystemAdvisories.js
+++ b/src/SmartComponents/SystemAdvisories/SystemAdvisories.js
@@ -1,5 +1,5 @@
 import propTypes from 'prop-types';
-import React, { useMemo, useCallback, useState, useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom';
 import publishDateFilter from '../../PresentationalComponents/Filters/PublishDateFilter';
@@ -10,17 +10,27 @@ import advisoryStatusFilter from '../../PresentationalComponents/Filters/Advisor
 import { Unavailable } from '@redhat-cloud-services/frontend-components/Unavailable';
 import TableView from '../../PresentationalComponents/TableView/TableView';
 import { systemAdvisoriesColumns } from '../../PresentationalComponents/TableView/TableViewAssets';
-import { changeSystemAdvisoryListParams, clearSystemAdvisoriesStore, expandSystemAdvisoryRow,
-    fetchApplicableSystemAdvisories, selectSystemAdvisoryRow } from '../../store/Actions/Actions';
+import {
+    changeSystemAdvisoryListParams,
+    clearSystemAdvisoriesStore,
+    expandSystemAdvisoryRow,
+    fetchApplicableSystemAdvisories,
+    selectSystemAdvisoryRow
+} from '../../store/Actions/Actions';
 import { exportSystemAdvisoriesCSV, exportSystemAdvisoriesJSON } from '../../Utilities/api';
 import { remediationIdentifiers } from '../../Utilities/constants';
 import { createSystemAdvisoriesRows } from '../../Utilities/DataMappers';
-import { arrayFromObj, createSortBy, decodeQueryparams,
-    getRowIdByIndexExpandable, remediationProvider, encodeURLParams } from '../../Utilities/Helpers';
-import { usePerPageSelect, useSetPage, useSortColumn, useOnExport,
-    useOnSelect, ID_API_ENDPOINTS } from '../../Utilities/hooks';
+import {
+    arrayFromObj, createSortBy, decodeQueryparams,
+    getRowIdByIndexExpandable, remediationProvider, encodeURLParams
+} from '../../Utilities/Helpers';
+import {
+    usePerPageSelect, useSetPage, useSortColumn, useOnExport,
+    useOnSelect, ID_API_ENDPOINTS
+} from '../../Utilities/hooks';
 import { intl } from '../../Utilities/IntlProvider';
 import messages from '../../Messages';
+import severityFilter from '../../PresentationalComponents/Filters/SeverityFilter';
 
 const SystemAdvisories = ({ handleNoSystemData, inventoryId, shouldRefresh }) => {
     const dispatch = useDispatch();
@@ -148,6 +158,7 @@ const SystemAdvisories = ({ handleNoSystemData, inventoryId, shouldRefresh }) =>
                             intl.formatMessage(messages.labelsFiltersSearchAdvisoriesPlaceholder)
                         ),
                         typeFilter(apply, queryParams.filter),
+                        severityFilter(apply, queryParams?.filter),
                         publishDateFilter(apply, queryParams.filter),
                         rebootFilter(apply, queryParams.filter),
                         advisoryStatusFilter(apply, queryParams.filter)

--- a/src/SmartComponents/SystemDetail/__snapshots__/SystemDetail.test.js.snap
+++ b/src/SmartComponents/SystemDetail/__snapshots__/SystemDetail.test.js.snap
@@ -689,6 +689,45 @@ exports[`SystemDetail.js Should match the snapshot when Package tab is active by
           <th
             class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-10"
             data-key="6"
+            data-label="Severity"
+            scope="col"
+            tabindex="-1"
+          >
+            <button
+              class="pf-v6-c-table__button"
+              type="button"
+            >
+              <div
+                class="pf-v6-c-table__button-content"
+              >
+                <span
+                  class="pf-v6-c-table__text"
+                >
+                  Severity
+                </span>
+                <span
+                  class="pf-v6-c-table__sort-indicator"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                    />
+                  </svg>
+                </span>
+              </div>
+            </button>
+          </th>
+          <th
+            class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-10"
+            data-key="7"
             data-label="Reboot"
             scope="col"
             tabindex="-1"
@@ -727,7 +766,7 @@ exports[`SystemDetail.js Should match the snapshot when Package tab is active by
           </th>
           <th
             class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-10"
-            data-key="7"
+            data-key="8"
             data-label="Publish date"
             scope="col"
             tabindex="-1"
@@ -906,6 +945,52 @@ exports[`SystemDetail.js Should match the snapshot when Package tab is active by
           <td
             class="pf-v6-c-table__td"
             data-key="6"
+            data-label="Severity"
+            tabindex="-1"
+          >
+            <div
+              class="pf-v6-c-content"
+              data-ouia-component-id="OUIA-Generated-Content-5"
+              data-ouia-component-type="PF6/Content"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              <dd
+                class="pf-v6-c-content--dd"
+                data-ouia-component-id="OUIA-Generated-Content-6"
+                data-ouia-component-type="PF6/Content"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              >
+                <span
+                  class="pf-v6-c-icon pf-m-sm"
+                >
+                  <span
+                    class="pf-v6-c-icon__content"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      color="var(--pf-t--global--icon--color--severity--important--default)"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 896 1024"
+                      width="1em"
+                    >
+                      <path
+                        d="M861.5,0 L34.5,0 C15.4,0 0,14.3 0,32 L0,452.1 C0,768 387.7,1024 448.5,1024 C509.3,1024 896,768 896,452.2 L896,32 C896,14.3 880.6,0 861.5,0 Z M490.7,768 L405.3,768 C393.5,767.8 384.2,757.5 384,744.7 L384,663.3 C384.2,650.5 393.6,640.3 405.3,640 L490.7,640 C502.5,640.2 511.8,650.5 512,663.3 L512,744.7 L512.1,744.7 C511.8,757.5 502.4,767.8 490.7,768 Z M543.9,162.7 L517.2,514.4 C515.8,530.9 502,544 485.3,544 L410.6,544 C394,544 380.1,531.2 378.7,514.7 L352.1,163 C350.5,144.3 365.3,128.3 384,128.3 L512,128 C530.7,128 545.4,144 543.9,162.7 Z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+                 Important
+              </dd>
+            </div>
+          </td>
+          <td
+            class="pf-v6-c-table__td"
+            data-key="7"
             data-label="Reboot"
             tabindex="-1"
           >
@@ -913,7 +998,7 @@ exports[`SystemDetail.js Should match the snapshot when Package tab is active by
           </td>
           <td
             class="pf-v6-c-table__td"
-            data-key="7"
+            data-key="8"
             data-label="Publish date"
             tabindex="-1"
           >
@@ -939,7 +1024,7 @@ exports[`SystemDetail.js Should match the snapshot when Package tab is active by
           />
           <td
             class="pf-v6-c-table__td"
-            colspan="6"
+            colspan="7"
             data-key="2"
             id="expanded-content1-2"
             tabindex="-1"
@@ -949,7 +1034,7 @@ exports[`SystemDetail.js Should match the snapshot when Package tab is active by
             >
               <div
                 class="pf-v6-c-content patch-advisory-description"
-                data-ouia-component-id="OUIA-Generated-Content-3"
+                data-ouia-component-id="OUIA-Generated-Content-7"
                 data-ouia-component-type="PF6/Content"
                 data-ouia-safe="true"
                 data-pf-content="true"
@@ -961,7 +1046,7 @@ exports[`SystemDetail.js Should match the snapshot when Package tab is active by
                 </span>
                 <p
                   class="pf-v6-c-content--p"
-                  data-ouia-component-id="OUIA-Generated-Content-4"
+                  data-ouia-component-id="OUIA-Generated-Content-8"
                   data-ouia-component-type="PF6/Content"
                   data-ouia-safe="true"
                   data-pf-content="true"
@@ -2377,6 +2462,45 @@ exports[`SystemDetail.js Should match the snapshots 1`] = `
           <th
             class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-10"
             data-key="6"
+            data-label="Severity"
+            scope="col"
+            tabindex="-1"
+          >
+            <button
+              class="pf-v6-c-table__button"
+              type="button"
+            >
+              <div
+                class="pf-v6-c-table__button-content"
+              >
+                <span
+                  class="pf-v6-c-table__text"
+                >
+                  Severity
+                </span>
+                <span
+                  class="pf-v6-c-table__sort-indicator"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                    />
+                  </svg>
+                </span>
+              </div>
+            </button>
+          </th>
+          <th
+            class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-10"
+            data-key="7"
             data-label="Reboot"
             scope="col"
             tabindex="-1"
@@ -2415,7 +2539,7 @@ exports[`SystemDetail.js Should match the snapshots 1`] = `
           </th>
           <th
             class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-10"
-            data-key="7"
+            data-key="8"
             data-label="Publish date"
             scope="col"
             tabindex="-1"
@@ -2594,6 +2718,52 @@ exports[`SystemDetail.js Should match the snapshots 1`] = `
           <td
             class="pf-v6-c-table__td"
             data-key="6"
+            data-label="Severity"
+            tabindex="-1"
+          >
+            <div
+              class="pf-v6-c-content"
+              data-ouia-component-id="OUIA-Generated-Content-1"
+              data-ouia-component-type="PF6/Content"
+              data-ouia-safe="true"
+              data-pf-content="true"
+            >
+              <dd
+                class="pf-v6-c-content--dd"
+                data-ouia-component-id="OUIA-Generated-Content-2"
+                data-ouia-component-type="PF6/Content"
+                data-ouia-safe="true"
+                data-pf-content="true"
+              >
+                <span
+                  class="pf-v6-c-icon pf-m-sm"
+                >
+                  <span
+                    class="pf-v6-c-icon__content"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      color="var(--pf-t--global--icon--color--severity--important--default)"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 896 1024"
+                      width="1em"
+                    >
+                      <path
+                        d="M861.5,0 L34.5,0 C15.4,0 0,14.3 0,32 L0,452.1 C0,768 387.7,1024 448.5,1024 C509.3,1024 896,768 896,452.2 L896,32 C896,14.3 880.6,0 861.5,0 Z M490.7,768 L405.3,768 C393.5,767.8 384.2,757.5 384,744.7 L384,663.3 C384.2,650.5 393.6,640.3 405.3,640 L490.7,640 C502.5,640.2 511.8,650.5 512,663.3 L512,744.7 L512.1,744.7 C511.8,757.5 502.4,767.8 490.7,768 Z M543.9,162.7 L517.2,514.4 C515.8,530.9 502,544 485.3,544 L410.6,544 C394,544 380.1,531.2 378.7,514.7 L352.1,163 C350.5,144.3 365.3,128.3 384,128.3 L512,128 C530.7,128 545.4,144 543.9,162.7 Z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+                 Important
+              </dd>
+            </div>
+          </td>
+          <td
+            class="pf-v6-c-table__td"
+            data-key="7"
             data-label="Reboot"
             tabindex="-1"
           >
@@ -2601,7 +2771,7 @@ exports[`SystemDetail.js Should match the snapshots 1`] = `
           </td>
           <td
             class="pf-v6-c-table__td"
-            data-key="7"
+            data-key="8"
             data-label="Publish date"
             tabindex="-1"
           >
@@ -2627,7 +2797,7 @@ exports[`SystemDetail.js Should match the snapshots 1`] = `
           />
           <td
             class="pf-v6-c-table__td"
-            colspan="6"
+            colspan="7"
             data-key="2"
             id="expanded-content1-2"
             tabindex="-1"
@@ -2637,7 +2807,7 @@ exports[`SystemDetail.js Should match the snapshots 1`] = `
             >
               <div
                 class="pf-v6-c-content patch-advisory-description"
-                data-ouia-component-id="OUIA-Generated-Content-1"
+                data-ouia-component-id="OUIA-Generated-Content-3"
                 data-ouia-component-type="PF6/Content"
                 data-ouia-safe="true"
                 data-pf-content="true"
@@ -2649,7 +2819,7 @@ exports[`SystemDetail.js Should match the snapshots 1`] = `
                 </span>
                 <p
                   class="pf-v6-c-content--p"
-                  data-ouia-component-id="OUIA-Generated-Content-2"
+                  data-ouia-component-id="OUIA-Generated-Content-4"
                   data-ouia-component-type="PF6/Content"
                   data-ouia-safe="true"
                   data-pf-content="true"

--- a/src/Utilities/DataMappers.js
+++ b/src/Utilities/DataMappers.js
@@ -1,5 +1,3 @@
-import { Icon, Content, ContentVariants } from '@patternfly/react-core';
-import { SecurityIcon } from '@patternfly/react-icons';
 import { processDate } from '@redhat-cloud-services/frontend-components-utilities/helpers';
 import { flatMap } from 'lodash';
 import React from 'react';
@@ -7,8 +5,11 @@ import messages from '../Messages';
 import AdvisoryType from '../PresentationalComponents/AdvisoryType/AdvisoryType';
 import { DescriptionWithLink } from '../PresentationalComponents/Snippets/DescriptionWithLink';
 import {
-    EmptyAdvisoryList, EmptyCvesList, EmptyPackagesList,
-    EmptyPatchSetList, EmptySystemsList
+    EmptyAdvisoryList,
+    EmptyCvesList,
+    EmptyPackagesList,
+    EmptyPatchSetList,
+    EmptySystemsList
 } from '../PresentationalComponents/Snippets/EmptyStates';
 import { SystemUpToDate } from '../PresentationalComponents/Snippets/SystemUpToDate';
 import { advisorySeverities, entityTypes } from './constants';
@@ -16,17 +17,25 @@ import { createUpgradableColumn, handleLongSynopsis, handlePatchLink } from './H
 import { intl } from './IntlProvider';
 import { InsightsLink } from '@redhat-cloud-services/frontend-components/InsightsLink';
 import { ManagedBySatelliteCell } from '../SmartComponents/Systems/SystemsListAssets';
+import AdvisorySeverity from '../PresentationalComponents/AdvisorySeverity/AdvisorySeverity';
 
 export const createAdvisoriesRows = (rows, expandedRows, selectedRows) => {
     if (rows.length !== 0) {
         return flatMap(rows, (row, index) => {
+            // Bugfixes and enhancements lack the severity property, so we default to "None"
+            const severityObject = row.attributes?.severity ? advisorySeverities[row.attributes.severity] : advisorySeverities[0];
             return [
                 {
                     id: row.id,
                     isOpen: expandedRows[row.id] === true,
                     selected: selectedRows[row.id] !== undefined,
                     cells: [
-                        { title: handlePatchLink(entityTypes.advisories, row.id) },
+                        {
+                            title: handlePatchLink(
+                                entityTypes.advisories,
+                                row.id
+                            )
+                        },
                         {
                             title: handleLongSynopsis(row.attributes.synopsis)
                         },
@@ -38,6 +47,9 @@ export const createAdvisoriesRows = (rows, expandedRows, selectedRows) => {
                             )
                         },
                         {
+                            title: (<AdvisorySeverity severity={severityObject}/>)
+                        },
+                        {
                             title: handlePatchLink(
                                 entityTypes.advisories,
                                 row.id,
@@ -45,17 +57,26 @@ export const createAdvisoriesRows = (rows, expandedRows, selectedRows) => {
                             )
                         },
                         {
-                            title: row.attributes.reboot_required &&
-                                intl.formatMessage(messages.labelsRebootRequired)
-                                || intl.formatMessage(messages.labelsRebootNotRequired)
+                            title:
+                                (row.attributes.reboot_required &&
+                                    intl.formatMessage(
+                                        messages.labelsRebootRequired
+                                    )) ||
+                                intl.formatMessage(
+                                    messages.labelsRebootNotRequired
+                                )
                         },
-                        { title: row.attributes.public_date ? processDate(row.attributes.public_date) : 'Not Available' }
+                        {
+                            title: row.attributes.public_date
+                                ? processDate(row.attributes.public_date)
+                                : 'Not Available'
+                        }
                     ]
                 },
                 {
                     cells: [
                         {
-                            title: <DescriptionWithLink row={row} />
+                            title: <DescriptionWithLink row={row}/>
                         }
                     ],
                     parent: index * 2,
@@ -70,7 +91,7 @@ export const createAdvisoriesRows = (rows, expandedRows, selectedRows) => {
                 cells: [
                     {
                         props: { colSpan: 5 },
-                        title: <EmptyAdvisoryList />
+                        title: <EmptyAdvisoryList/>
                     }
                 ]
             }
@@ -86,6 +107,7 @@ export const createSystemAdvisoriesRows = (
 ) => {
     if (rows.length !== 0) {
         return flatMap(rows, (row, index) => {
+            const severityObject = row.attributes?.severity ? advisorySeverities[row.attributes.severity] : advisorySeverities[0];
             return [
                 {
                     id: row.id,
@@ -93,7 +115,12 @@ export const createSystemAdvisoriesRows = (
                     selected: selectedRows[row.id] !== undefined,
                     disableSelection: row.attributes.status !== 'Installable',
                     cells: [
-                        { title: handlePatchLink(entityTypes.advisories, row.id) },
+                        {
+                            title: handlePatchLink(
+                                entityTypes.advisories,
+                                row.id
+                            )
+                        },
                         {
                             title: handleLongSynopsis(row.attributes.synopsis)
                         },
@@ -108,9 +135,17 @@ export const createSystemAdvisoriesRows = (
                             )
                         },
                         {
-                            title: row.attributes.reboot_required &&
-                                intl.formatMessage(messages.labelsRebootRequired)
-                                || intl.formatMessage(messages.labelsRebootNotRequired)
+                            title: (<AdvisorySeverity severity={severityObject}/>)
+                        },
+                        {
+                            title:
+                                (row.attributes.reboot_required &&
+                                    intl.formatMessage(
+                                        messages.labelsRebootRequired
+                                    )) ||
+                                intl.formatMessage(
+                                    messages.labelsRebootNotRequired
+                                )
                         },
                         { title: processDate(row.attributes.public_date) }
                     ]
@@ -118,7 +153,7 @@ export const createSystemAdvisoriesRows = (
                 {
                     cells: [
                         {
-                            title: <DescriptionWithLink row={row} />
+                            title: <DescriptionWithLink row={row}/>
                         }
                     ],
                     parent: index * 2,
@@ -133,9 +168,11 @@ export const createSystemAdvisoriesRows = (
                 cells: [
                     {
                         props: { colSpan: 6 },
-                        title: !metadata.search && (metadata.filter && Object.keys(metadata.filter).length === 0)
-                            && <SystemUpToDate />
-                            || <EmptyAdvisoryList />
+                        title: (!metadata.search &&
+                            metadata.filter &&
+                            Object.keys(metadata.filter).length === 0 && (
+                            <SystemUpToDate/>
+                        )) || <EmptyAdvisoryList/>
                     }
                 ]
             }
@@ -144,52 +181,53 @@ export const createSystemAdvisoriesRows = (
 };
 
 export const createSystemsRows = (rows, selectedRows = {}) => {
-    const data =
-        rows.map(({ id, ...rest }) => {
-            const {
-                packages_installed: installedPckg,
-                rhba_count: rhba,
-                rhsa_count: rhsa,
-                rhea_count: rhea,
-                other_count: other,
-                os,
-                rhsm,
-                tags,
-                last_upload: lastUpload
-            } = rest;
-            return {
-                id,
-                ...rest,
-                key: Math.random().toString() + id,
-                packages_installed: installedPckg,
-                applicable_advisories: [
-                    rhea || 0,
-                    rhba || 0,
-                    rhsa || 0,
-                    other || 0
-                ],
-                operating_system: {
-                    osName: os || 'N/A',
-                    rhsm
-                },
-                selected: selectedRows[id] !== undefined,
-                tags,
-                updated: lastUpload
-            };
-        });
+    const data = rows.map(({ id, ...rest }) => {
+        const {
+            packages_installed: installedPckg,
+            rhba_count: rhba,
+            rhsa_count: rhsa,
+            rhea_count: rhea,
+            other_count: other,
+            os,
+            rhsm,
+            tags,
+            last_upload: lastUpload
+        } = rest;
+        return {
+            id,
+            ...rest,
+            key: Math.random().toString() + id,
+            packages_installed: installedPckg,
+            applicable_advisories: [
+                rhea || 0,
+                rhba || 0,
+                rhsa || 0,
+                other || 0
+            ],
+            operating_system: {
+                osName: os || 'N/A',
+                rhsm
+            },
+            selected: selectedRows[id] !== undefined,
+            tags,
+            updated: lastUpload
+        };
+    });
     return data || [];
 };
 
 export const createPackageSystemsRows = (rows, selectedRows = {}) => {
     const data =
         rows &&
-        rows.map(row => {
+        rows.map((row) => {
             return {
                 id: row.id,
                 key: Math.random().toString() + row.id,
                 display_name: row.display_name,
                 installed_evra: row.installed_evra,
-                available_evra: row.updatable ? row.available_evra : row.installed_evra,
+                available_evra: row.updatable
+                    ? row.available_evra
+                    : row.installed_evra,
                 disableSelection: !row.updatable,
                 updatable: row.updatable,
                 update_status: row.update_status,
@@ -210,41 +248,42 @@ export const createPackageSystemsRows = (rows, selectedRows = {}) => {
 };
 
 export const createAdvisorySystemsRows = (rows, selectedRows = {}) => {
-    const data =
-        rows.map(({ id, ...rest }) => {
-            const {
-                packages_installed: installedPckg,
-                os,
-                rhsm,
-                tags,
-                last_upload: lastUpload,
-                status
-            } = rest;
-            return {
-                id,
-                ...rest,
-                key: Math.random().toString() + id,
-                packages_installed: installedPckg,
-                os: {
-                    osName: os.osName || os || 'N/A',
-                    rhsm
-                },
-                selected: selectedRows[id] !== undefined,
-                tags,
-                updated: lastUpload,
-                disableSelection: status !== 'Installable'
-            };
-        });
+    const data = rows.map(({ id, ...rest }) => {
+        const {
+            packages_installed: installedPckg,
+            os,
+            rhsm,
+            tags,
+            last_upload: lastUpload,
+            status
+        } = rest;
+        return {
+            id,
+            ...rest,
+            key: Math.random().toString() + id,
+            packages_installed: installedPckg,
+            os: {
+                osName: os.osName || os || 'N/A',
+                rhsm
+            },
+            selected: selectedRows[id] !== undefined,
+            tags,
+            updated: lastUpload,
+            disableSelection: status !== 'Installable'
+        };
+    });
     return data || [];
 };
 
 export const createSystemPackagesRows = (rows, selectedRows = {}) => {
     if (rows && rows.length !== 0) {
-        return rows.map(pkg => {
+        return rows.map((pkg) => {
             const pkgNEVRA = `${pkg.name}-${pkg.evra}`;
             const pkgUpdates = pkg.updates || [];
             const latestApplicable = pkgUpdates[pkgUpdates.length - 1];
-            const latestInstallable = pkgUpdates.filter(version => version.status === 'Installable').pop();
+            const latestInstallable = pkgUpdates
+            .filter((version) => version.status === 'Installable')
+            .pop();
 
             return {
                 id: pkgNEVRA,
@@ -268,7 +307,7 @@ export const createSystemPackagesRows = (rows, selectedRows = {}) => {
                 cells: [
                     {
                         props: { colSpan: 7 },
-                        title: <EmptyPackagesList />
+                        title: <EmptyPackagesList/>
                     }
                 ]
             }
@@ -278,7 +317,7 @@ export const createSystemPackagesRows = (rows, selectedRows = {}) => {
 
 export const createPackagesRows = (rows) => {
     if (rows && rows.length !== 0) {
-        return rows.map(pkg => {
+        return rows.map((pkg) => {
             return {
                 id: pkg.name,
                 key: pkg.name,
@@ -298,7 +337,7 @@ export const createPackagesRows = (rows) => {
                 cells: [
                     {
                         props: { colSpan: 7 },
-                        title: <EmptyPackagesList />
+                        title: <EmptyPackagesList/>
                     }
                 ]
             }
@@ -308,9 +347,11 @@ export const createPackagesRows = (rows) => {
 
 export const createCvesRows = (rows) => {
     if (rows.length !== 0) {
-        return rows.map(cve => {
+        return rows.map((cve) => {
             const { attributes, id } = cve;
-            const severityObject = advisorySeverities.filter(severity => severity.label === attributes.impact)[0];
+            const severityObject = advisorySeverities.filter(
+                (severity) => severity.label === attributes.impact
+            )[0];
 
             return {
                 id,
@@ -318,19 +359,15 @@ export const createCvesRows = (rows) => {
                 cells: [
                     {
                         title: (
-                            <a href={`${document.baseURI}insights/vulnerability/cves/${attributes.synopsis}`}>
+                            <a
+                                href={`${document.baseURI}insights/vulnerability/cves/${attributes.synopsis}`}
+                            >
                                 {attributes.synopsis}
-                            </a>)
+                            </a>
+                        )
                     },
                     {
-                        title: (<Content>
-                            <Content component={ContentVariants.dd}>
-                                <Icon size="sm" >
-                                    <SecurityIcon color={severityObject.color}/>
-                                </Icon>
-                                &nbsp;{severityObject.label}
-                            </Content>
-                        </Content>),
+                        title: <AdvisorySeverity severity={severityObject}/>,
                         value: severityObject.label
                     },
                     { title: parseFloat(attributes.cvss_score).toFixed(1) }
@@ -344,7 +381,7 @@ export const createCvesRows = (rows) => {
                 cells: [
                     {
                         props: { colSpan: 4 },
-                        title: <EmptyCvesList />
+                        title: <EmptyCvesList/>
                     }
                 ]
             }
@@ -354,7 +391,7 @@ export const createCvesRows = (rows) => {
 
 export const createSystemsRowsReview = (rows, selectedRows) => {
     if (rows.length !== 0) {
-        return rows.map(system => {
+        return rows.map((system) => {
             const { attributes, id } = system;
 
             return {
@@ -369,9 +406,11 @@ export const createSystemsRowsReview = (rows, selectedRows) => {
                         title: attributes.os || 'N/A'
                     },
                     {
-                        title: attributes.satellite_managed
-                            ? <ManagedBySatelliteCell />
-                            : attributes.baseline_name || 'No template'
+                        title: attributes.satellite_managed ? (
+                            <ManagedBySatelliteCell/>
+                        ) : (
+                            attributes.baseline_name || 'No template'
+                        )
                     },
                     {
                         title: processDate(attributes.last_upload)
@@ -386,7 +425,7 @@ export const createSystemsRowsReview = (rows, selectedRows) => {
                 cells: [
                     {
                         props: { colSpan: 4 },
-                        title: <EmptySystemsList />
+                        title: <EmptySystemsList/>
                     }
                 ]
             }
@@ -395,10 +434,9 @@ export const createSystemsRowsReview = (rows, selectedRows) => {
 };
 
 export const createPatchSetRows = (rows, selectedRows = {}, filters) => {
-
     const data =
         rows &&
-        rows.map(row => {
+        rows.map((row) => {
             return {
                 id: row.id,
                 displayName: row.name,
@@ -412,7 +450,13 @@ export const createPatchSetRows = (rows, selectedRows = {}, filters) => {
                             </InsightsLink>
                         )
                     },
-                    { title: row.systems || intl.formatMessage(messages.labelsTemplateNoSystems) },
+                    {
+                        title:
+                            row.systems ||
+                            intl.formatMessage(
+                                messages.labelsTemplateNoSystems
+                            )
+                    },
                     { title: processDate(row.last_edited) },
                     { title: processDate(row.published) },
                     { title: row.creator }
@@ -420,25 +464,27 @@ export const createPatchSetRows = (rows, selectedRows = {}, filters) => {
             };
         });
 
-    return data?.length > 0 ? data :
-        (filters.search || Object.keys(filters.filter).length) ?
-            [
+    return data?.length > 0
+        ? data
+        : filters.search || Object.keys(filters.filter).length
+            ? [
                 {
                     heightAuto: true,
                     cells: [
                         {
                             props: { colSpan: 6 },
-                            title: <EmptyPatchSetList />
+                            title: <EmptyPatchSetList/>
                         }
                     ]
                 }
-            ] : [];
+            ]
+            : [];
 };
 
 export const createPatchSetDetailRows = (rows) => {
     const data =
         rows &&
-        rows.map(row => {
+        rows.map((row) => {
             row = { ...row, ...row.attributes };
 
             return {

--- a/src/Utilities/DataMappers.test.js
+++ b/src/Utilities/DataMappers.test.js
@@ -1,6 +1,11 @@
 import { processDate } from '@redhat-cloud-services/frontend-components-utilities/helpers';
 import { EmptyAdvisoryList } from '../PresentationalComponents/Snippets/EmptyStates';
-import { createAdvisoriesRows, createSystemAdvisoriesRows, createSystemPackagesRows, createSystemsRows } from './DataMappers';
+import {
+    createAdvisoriesRows,
+    createSystemAdvisoriesRows,
+    createSystemPackagesRows,
+    createSystemsRows
+} from './DataMappers';
 import { handlePatchLink } from './Helpers';
 import { advisoryRows, systemAdvisoryRows, systemPackages, systemRows } from './RawDataForTesting';
 import { SystemUpToDate } from '../PresentationalComponents/Snippets/SystemUpToDate';
@@ -14,10 +19,11 @@ describe('DataMappers', () => {
         expect(firstRow.isOpen).toEqual(false);
         expect(firstRow.selected).toEqual(false);
         expect(firstRow.cells[0].title).toEqual(handlePatchLink('advisories', advisoryRows[0].id));
-        expect(firstRow.cells[4].title).toEqual(intl.formatMessage(messages.labelsRebootRequired));
-        expect(firstRow.cells[5].title).toEqual(processDate(advisoryRows[0].attributes.public_date));
+        expect(firstRow.cells[5].title).toEqual(intl.formatMessage(messages.labelsRebootRequired));
+        expect(firstRow.cells[6].title).toEqual(processDate(advisoryRows[0].attributes.public_date));
         expect(firstRow.cells[2].title.props.type).toEqual(advisoryRows[0].attributes.advisory_type_name);
-        expect(firstRow.cells[3].title).toEqual(
+        expect(firstRow.cells[3].title.props.severity.value).toEqual(advisoryRows[0].attributes.severity);
+        expect(firstRow.cells[4].title).toEqual(
             handlePatchLink('advisories', advisoryRows[0].id, advisoryRows[0].attributes.applicable_systems)
         );
         expect(firstRow.cells[1]).toBeTruthy();
@@ -38,9 +44,10 @@ describe('DataMappers', () => {
         expect(firstRow.id).toEqual(systemAdvisoryRows[0].id);
         expect(firstRow.isOpen).toEqual(false);
         expect(firstRow.selected).toEqual(false);
-        expect(firstRow.cells[5].title).toEqual(processDate(systemAdvisoryRows[0].attributes.public_date));
-        expect(firstRow.cells[4].title).toEqual('Required');
+        expect(firstRow.cells[6].title).toEqual(processDate(systemAdvisoryRows[0].attributes.public_date));
+        expect(firstRow.cells[5].title).toEqual('Required');
         expect(firstRow.cells[3].title.props.type).toEqual(systemAdvisoryRows[0].attributes.advisory_type_name);
+        expect(firstRow.cells[4].title.props.severity.value).toEqual(advisoryRows[0].attributes.severity);
         expect(firstRow.cells[1]).toBeTruthy();
         expect(firstRow.cells[0].title).toEqual(handlePatchLink('advisories', systemAdvisoryRows[0].id));
         const portalAdvisoryLink = secondRow.cells[0].title;
@@ -134,7 +141,7 @@ describe('DataMappers', () => {
             selected: false,
             disableSelection: false,
             cells: [
-                { title: expect.anything()  }, // FIXME!
+                { title: expect.anything() }, // FIXME!
                 { title: 'test-evra' },
                 { title: 'testEvra' },
                 { title: expect.anything() },

--- a/src/Utilities/Helpers.js
+++ b/src/Utilities/Helpers.js
@@ -1,7 +1,11 @@
 /* eslint-disable camelcase */
 import { Flex, FlexItem, Tooltip } from '@patternfly/react-core';
 import {
-    BugIcon, FlagIcon, EnhancementIcon, InfoCircleIcon, SecurityIcon
+    BugIcon,
+    EnhancementIcon,
+    FlagIcon,
+    InfoCircleIcon,
+    SecurityIcon
 } from '@patternfly/react-icons';
 import { SortByDirection } from '@patternfly/react-table';
 import flatten from 'lodash/flatten';
@@ -24,7 +28,9 @@ import { InsightsLink } from '@redhat-cloud-services/frontend-components/Insight
 
 export const removeUndefinedObjectItems = (originalObject) => {
     const newObject = JSON.parse(JSON.stringify(originalObject));
-    Object.keys(newObject).forEach(key => newObject[key] === undefined && delete newObject[key]);
+    Object.keys(newObject).forEach(
+        (key) => newObject[key] === undefined && delete newObject[key]
+    );
     return newObject;
 };
 
@@ -49,14 +55,19 @@ export const transformPairs = (input, remediationIdentifier) => {
     return { issues };
 };
 
-export const createSortBy = (header, values, offset, compoundSortValues = defaultCompoundSortValues) => {
+export const createSortBy = (
+    header,
+    values,
+    offset,
+    compoundSortValues = defaultCompoundSortValues
+) => {
     if (values) {
         let [column] = values;
         let multiple = values.join();
         let direction =
             column[0] === '-' ? SortByDirection.desc : SortByDirection.asc;
-        Object.keys(compoundSortValues).forEach(col => {
-            Object.keys(compoundSortValues[col]).forEach(dir => {
+        Object.keys(compoundSortValues).forEach((col) => {
+            Object.keys(compoundSortValues[col]).forEach((dir) => {
                 if (compoundSortValues[col][dir] === multiple) {
                     column = col;
                     direction = dir;
@@ -65,7 +76,7 @@ export const createSortBy = (header, values, offset, compoundSortValues = defaul
         });
 
         column = column.replace(/^(-|\+)/, '');
-        const index = findIndex(header, item => item.key === column);
+        const index = findIndex(header, (item) => item.key === column);
         let sort = {
             index: index + offset,
             direction
@@ -86,13 +97,12 @@ export const addOrRemoveItemFromSet = (targetObj, inputArr) => {
 };
 
 export const getNewSelectedItems = (selectedItems, currentItems) => {
-    let payload = [].concat(selectedItems).map(item => ({ rowId: item.id, value: item.selected }));
-    const mergedSelection = addOrRemoveItemFromSet(
-        currentItems,
-        payload
-    );
+    let payload = []
+    .concat(selectedItems)
+    .map((item) => ({ rowId: item.id, value: item.selected }));
+    const mergedSelection = addOrRemoveItemFromSet(currentItems, payload);
 
-    return pickBy(mergedSelection, v => !!v);
+    return pickBy(mergedSelection, (v) => !!v);
 };
 
 // for expandable rows only
@@ -104,7 +114,7 @@ export const getOffsetFromPageLimit = (page, limit) => {
     return page * limit - limit;
 };
 
-export const getLimitFromPageSize = limit => {
+export const getLimitFromPageSize = (limit) => {
     return limit;
 };
 
@@ -114,44 +124,73 @@ export function truncate(str, max, end) {
             {str.substring(0, max - 1)}
             ...&nbsp;{end}
         </React.Fragment>
-    ) : str;
+    ) : (
+        str
+    );
 }
 
 const findBullets = (description) => {
     let substringIndex = description.search(/:/);
     // + 2 accounts for the 2 new lines to separate the sentence from the start of the bullets
     return substringIndex > 0
-        ? description.slice(0, substringIndex + 2) + preserveNewlines(description.substring(substringIndex + 2)) : description;
+        ? description.slice(0, substringIndex + 2) +
+        preserveNewlines(description.substring(substringIndex + 2))
+        : description;
 };
 
-export const truncateDescription = (description, wordLength, setWordLength) => (
-    truncate(findBullets(description), wordLength,
+export const truncateDescription = (description, wordLength, setWordLength) =>
+    truncate(
+        findBullets(description),
+        wordLength,
         <a onClick={() => setWordLength(description.length)}>
             {intl.formatMessage(messages.linksReadMore)}
-        </a>)
-);
+        </a>
+    );
 
-export function createAdvisoriesIcons([rhea, rhba, rhsa, other], type = 'applicable') {
+export function createAdvisoriesIcons(
+    [rhea, rhba, rhsa, other],
+    type = 'applicable'
+) {
     return (
         <Flex flex={{ default: 'inlineFlex' }} style={{ flexWrap: 'nowrap' }}>
-            {[rhea, rhba, rhsa].every(item => item === 0) &&
+            {[rhea, rhba, rhsa].every((item) => item === 0) &&
                 `No ${type} advisories`}
             {rhsa !== 0 && (
                 <FlexItem spacer={{ default: 'spacerXs' }}>
-                    <AdvisoriesIcon tooltipText={'Security advisories'} count={rhsa} Icon={SecurityIcon} />
-                </FlexItem>)}
+                    <AdvisoriesIcon
+                        tooltipText={'Security advisories'}
+                        count={rhsa}
+                        Icon={SecurityIcon}
+                    />
+                </FlexItem>
+            )}
             {rhba !== 0 && (
                 <FlexItem spacer={{ default: 'spacerXs' }}>
-                    <AdvisoriesIcon tooltipText={'Bug fixes'} count={rhba} Icon={BugIcon} />
-                </FlexItem>)}
+                    <AdvisoriesIcon
+                        tooltipText={'Bug fixes'}
+                        count={rhba}
+                        Icon={BugIcon}
+                    />
+                </FlexItem>
+            )}
             {rhea !== 0 && (
                 <FlexItem spacer={{ default: 'spacerXs' }}>
-                    <AdvisoriesIcon tooltipText={'Enhancements'} count={rhea} Icon={EnhancementIcon} />
-                </FlexItem>)}
+                    <AdvisoriesIcon
+                        tooltipText={'Enhancements'}
+                        count={rhea}
+                        Icon={EnhancementIcon}
+                    />
+                </FlexItem>
+            )}
             {other !== 0 && (
                 <FlexItem spacer={{ default: 'spacerXs' }}>
-                    <AdvisoriesIcon tooltipText={'Other'} count={other} Icon={FlagIcon} />
-                </FlexItem>)}
+                    <AdvisoriesIcon
+                        tooltipText={'Other'}
+                        count={other}
+                        Icon={FlagIcon}
+                    />
+                </FlexItem>
+            )}
         </Flex>
     );
 }
@@ -167,18 +206,23 @@ export function createUpgradableColumn(updatableStatus) {
     }
 }
 
-export function getSeverityById(id) {
+export function getSeverityByValue(value) {
+    // Convert `undefined` to `null`, as utility functions rely on `null` to signify no severity
+    const severityValue = value === undefined ? null : value;
+
     return (
-        advisorySeverities.find(item => item.value === id) ||
+        advisorySeverities.find((item) => item.value === severityValue) ||
         advisorySeverities[0]
     );
 }
 
 export const createPackagesColumn = (packageCount, systemID) => (
-    <InsightsLink to={{
-        pathname: `/systems/${systemID}`,
-        state: { tab: 'packages' }
-    }}>
+    <InsightsLink
+        to={{
+            pathname: `/systems/${systemID}`,
+            state: { tab: 'packages' }
+        }}
+    >
         {packageCount}
     </InsightsLink>
 );
@@ -199,15 +243,15 @@ export function handlePatchLink(type, name, body) {
     }
 }
 
-export const arrayFromObj = items =>
-    Object.values(items).filter(value => value);
+export const arrayFromObj = (items) =>
+    Object.values(items).filter((value) => value);
 
 export const remediationProvider = (issues, systems, remediationIdentifier) => {
     issues = [].concat(issues);
     systems = [].concat(systems);
     return issues.length && systems.length
         ? {
-            issues: issues.map(item => ({
+            issues: issues.map((item) => ({
                 id: `${remediationIdentifier}:${item}`,
                 description: item
             })),
@@ -216,14 +260,21 @@ export const remediationProvider = (issues, systems, remediationIdentifier) => {
         : false;
 };
 
-export const remediationProviderWithPairs = (issuePairs, transformFunc, remediationIdentifier) => {
-    return issuePairs ? transformFunc(issuePairs, remediationIdentifier) : false;
+export const remediationProviderWithPairs = (
+    issuePairs,
+    transformFunc,
+    remediationIdentifier
+) => {
+    return issuePairs
+        ? transformFunc(issuePairs, remediationIdentifier)
+        : false;
 };
 
 export const getFilterValue = (category, key) => {
     const filterCategory = filterCategories[category];
     if (filterCategory) {
-        const filterOption = /* some filters don't have constant values */
+        const filterOption =
+            /* some filters don't have constant values */
             (filterCategory?.values || []).find((item) => item.value === key);
         return filterOption || { apiValue: key };
     } else {
@@ -234,40 +285,60 @@ export const getFilterValue = (category, key) => {
 export const encodeParams = (parameters, shouldTranslateKeys) => {
     const calculateWorkloads = ({ sap_sids, ...restOfProfile }) => {
         let result = '';
-        Object.entries(generateFilter({ system_profile: restOfProfile })).forEach(entry => {
+        Object.entries(
+            generateFilter({ system_profile: restOfProfile })
+        ).forEach((entry) => {
             const [key, value] = entry;
             result = `${result}&${key}=${value}`;
         });
 
-        const SIDsFilter = sap_sids?.map(sid => `filter[system_profile][sap_sids][in]=${sid}`).join('&');
+        const SIDsFilter = sap_sids
+        ?.map((sid) => `filter[system_profile][sap_sids][in]=${sid}`)
+        .join('&');
 
-        return result.concat(sap_sids ? `&${SIDsFilter}#SIDs=${sap_sids.join(',')}` : '');
+        return result.concat(
+            sap_sids ? `&${SIDsFilter}#SIDs=${sap_sids.join(',')}` : ''
+        );
     };
 
-    const flattenFilters = filter => {
+    const flattenFilters = (filter) => {
         let result = {};
         filter &&
-            Object.entries(filter).forEach(item => {
-                let [key, value] = item;
-                value = shouldTranslateKeys && getFilterValue(key, value).apiValue || value;
-                const operator = ([].concat(value).length > 1 || multiValueFilters.includes(key)) ? 'in:' : '';
-                result = {
-                    ...result,
-                    [`filter[${key}]`]: `${operator}${value.toString()}`
-                };
-            });
+        Object.entries(filter).forEach((item) => {
+            let [key, value] = item;
+            value =
+                (shouldTranslateKeys &&
+                    getFilterValue(key, value).apiValue) ||
+                value;
+            const operator =
+                [].concat(value).length > 1 ||
+                multiValueFilters.includes(key)
+                    ? 'in:'
+                    : '';
+            result = {
+                ...result,
+                [`filter[${key}]`]: `${operator}${String(value)}`
+            };
+        });
         return result;
     };
 
     let { filter, systemProfile = {}, group_name, ...allParams } = parameters;
 
-    allParams = { ...allParams, ...flattenFilters({ ...filter, ...(group_name ? { group_name } : {}) }) };
+    allParams = {
+        ...allParams,
+        ...flattenFilters({ ...filter, ...(group_name ? { group_name } : {}) })
+    };
     let params = [];
-    Object.keys(allParams).forEach(key => {
+    Object.keys(allParams).forEach((key) => {
         const argKey = encodeURIComponent(key);
         const argValue = encodeURIComponent(allParams[key]);
 
-        if (!['', undefined, null].some(value => [argValue, key].includes(value))) {
+        if (
+            !['', undefined, null].some((value) =>
+                [argValue, key].includes(value)
+            )
+        ) {
             if (!['selectedTags', 'systemProfile'].includes(key)) {
                 params.push(argKey.concat('=').concat(argValue));
             } else if (key === 'selectedTags') {
@@ -276,17 +347,19 @@ export const encodeParams = (parameters, shouldTranslateKeys) => {
         }
     });
 
-    const workloadsFilter = (Object.keys(systemProfile).length > 0)
-        && calculateWorkloads(systemProfile) || '';
+    const workloadsFilter =
+        (Object.keys(systemProfile).length > 0 &&
+            calculateWorkloads(systemProfile)) ||
+        '';
 
     return '?'.concat(params.join('&')).concat(workloadsFilter);
 };
 
-export const encodeApiParams = parameters => {
+export const encodeApiParams = (parameters) => {
     return encodeParams(parameters, true);
 };
 
-export const encodeURLParams = parameters => {
+export const encodeURLParams = (parameters) => {
     delete parameters.id;
     let urlParams = { ...parameters };
     delete urlParams.selectedTags;
@@ -296,7 +369,10 @@ export const encodeURLParams = parameters => {
 export const decomposeFilterValue = (filterValue, parser) => {
     if (parser) {
         return parser(filterValue);
-    } else if (typeof(filterValue) === 'string' && filterValue.startsWith('in:')) {
+    } else if (
+        typeof filterValue === 'string' &&
+        filterValue.startsWith('in:')
+    ) {
         const values = filterValue.slice(3);
         return values.split(',');
     } else {
@@ -304,21 +380,39 @@ export const decomposeFilterValue = (filterValue, parser) => {
     }
 };
 
+const getApiValueFromFilterString = (value) => {
+    if (Array.isArray(value)) {
+        return value.map(getApiValueFromFilterString);
+    }
+
+    return value === 'null' ? null : value;
+};
+
 export const decodeQueryparams = (queryString, parsers = {}) => {
     const parsed = qs.parse(queryString);
     const res = {};
-    Object.keys(parsed).forEach(key => {
+    Object.keys(parsed).forEach((key) => {
         if (!key.startsWith('filter[system_profile]')) {
             const convertedToInt = parseInt(parsed[key], 10);
-            const typeHandledParam = isNaN(convertedToInt) ? parsed[key] : convertedToInt;
+            const typeHandledParam = isNaN(convertedToInt)
+                ? parsed[key]
+                : convertedToInt;
             const bracketIndex = key.search(/\[.*\]/);
             if (bracketIndex > 0) {
                 const objParent = key.slice(0, bracketIndex);
                 const objKey = key.slice(bracketIndex + 1, -1);
                 const parser = parsers[objKey];
+                const decomposedValue = decomposeFilterValue(
+                    typeHandledParam,
+                    parser
+                );
+                const normalizedValue =
+                    objParent === 'filter'
+                        ? getApiValueFromFilterString(decomposedValue)
+                        : decomposedValue;
                 res[objParent] = {
                     ...res[objParent],
-                    [objKey]: decomposeFilterValue(typeHandledParam, parser)
+                    [objKey]: normalizedValue
                 };
             } else {
                 res[key] = typeHandledParam;
@@ -328,16 +422,28 @@ export const decodeQueryparams = (queryString, parsers = {}) => {
     return res;
 };
 
-export const buildFilterChips = (filters, search, searchChipLabel = 'Search', parsers = {}) => {
+const getFilterStringFromApi = (value) =>
+    value === null ? 'null' : String(value);
 
+export const buildFilterChips = (
+    filters,
+    search,
+    searchChipLabel = 'Search',
+    parsers = {}
+) => {
     let filterConfig = [];
     const buildChips = (filters, category) => {
         if (parsers[category]) {
             return parsers[category](filters[category]);
         } else if (multiValueFilters.includes(category)) {
-            const filterValues = filters[category] && (typeof(filters[category]) === 'string' && filters[category].split(',')
-                || filters[category]) || [];
-            return filterValues.map(value => ({
+            const filterValues =
+                (filters[category] &&
+                    ((typeof filters[category] === 'string' &&
+                            filters[category].split(',')) ||
+                        filters[category])) ||
+                [];
+            // Leave the raw value intact (including `null`) so chips render and removal logic works
+            return filterValues.map((value) => ({
                 name: value,
                 id: category,
                 value
@@ -345,14 +451,16 @@ export const buildFilterChips = (filters, search, searchChipLabel = 'Search', pa
         } else {
             const { values } = filterCategories[category];
 
-            if (!filters[category]) {
+            // Previously we dropped truthy-but-falsy values like `null`, which hid the severity chip
+            if (filters[category] === undefined || filters[category] === '') {
                 return [];
             }
 
-            return [].concat(filters[category]).map(filterValue => {
+            return [].concat(filters[category]).map((filterValue) => {
                 const match = values.find(
-                    item =>
-                        item.value.toString() === filterValue.toString()
+                    (item) =>
+                        getFilterStringFromApi(item.value) ===
+                        getFilterStringFromApi(filterValue)
                 );
                 return {
                     name: match.label,
@@ -365,12 +473,14 @@ export const buildFilterChips = (filters, search, searchChipLabel = 'Search', pa
 
     const processFilters = () => {
         let categories = Object.keys(filters).filter(
-            item =>
+            (item) =>
                 filters[item] !== '' && [].concat(filters[item]).length !== 0
         );
         filterConfig = filterConfig.concat(
-            categories.map(category => {
-                const label = category === 'installed_evra' && 'Package version' || filterCategories[category].label;
+            categories.map((category) => {
+                const label =
+                    (category === 'installed_evra' && 'Package version') ||
+                    filterCategories[category].label;
                 return {
                     category: label,
                     id: category,
@@ -402,34 +512,45 @@ export const buildFilterChips = (filters, search, searchChipLabel = 'Search', pa
 };
 
 export const buildOsFilter = (osFilter = {}) => {
-    const osVersions = Object.entries(osFilter).reduce((acc, [, osGroupValues]) => {
-        return [
-            ...acc,
-            ...Object.entries(osGroupValues).filter(([, value]) => (value === true)).map(([key]) => {
-                const keyParts = key.split('-');
-                return keyParts.slice(0, keyParts.length - 2) + ' ' + keyParts[keyParts.length - 1];
-            })
-        ];
-    }, []);
+    const osVersions = Object.entries(osFilter).reduce(
+        (acc, [, osGroupValues]) => {
+            return [
+                ...acc,
+                ...Object.entries(osGroupValues)
+                .filter(([, value]) => value === true)
+                .map(([key]) => {
+                    const keyParts = key.split('-');
+                    return (
+                        keyParts.slice(0, keyParts.length - 2) +
+                            ' ' +
+                            keyParts[keyParts.length - 1]
+                    );
+                })
+            ];
+        },
+        []
+    );
 
-    return osVersions.length > 0 ? {
-        os: osVersions.join(',')
-    } : {};
+    return osVersions.length > 0
+        ? {
+            os: osVersions.join(',')
+        }
+        : {};
 };
 
-export const buildApiFilters = (patchFilters, inventoryFilters) => (
-    {
-        ...patchFilters,
-        ...(Array.isArray(inventoryFilters.hostGroupFilter) && inventoryFilters.hostGroupFilter.length > 0
-            ? { group_name: inventoryFilters.hostGroupFilter }
-            : {}),
-        ...buildOsFilter(inventoryFilters?.osFilter)
-    });
+export const buildApiFilters = (patchFilters, inventoryFilters) => ({
+    ...patchFilters,
+    ...(Array.isArray(inventoryFilters.hostGroupFilter) &&
+    inventoryFilters.hostGroupFilter.length > 0
+        ? { group_name: inventoryFilters.hostGroupFilter }
+        : {}),
+    ...buildOsFilter(inventoryFilters?.osFilter)
+});
 
 export const changeListParams = (oldParams, newParams) => {
     const newState = { ...oldParams, ...newParams };
     const offsetResetParams = ['filter', 'search', 'limit', 'selectedTags'];
-    if (offsetResetParams.some(item => newParams.hasOwnProperty(item))) {
+    if (offsetResetParams.some((item) => newParams.hasOwnProperty(item))) {
         newState.offset = 0;
     }
 
@@ -459,53 +580,61 @@ export function subtractDate(days) {
 }
 
 export function preserveNewlines(input) {
-    return input && input.replace(
-        new RegExp('\\n\\n(?=.*[\\n\\n])', 'g'),
-        '\n'
+    return (
+        input && input.replace(new RegExp('\\n\\n(?=.*[\\n\\n])', 'g'), '\n')
     );
 }
 
 export function sortCves(cves, index, direction) {
+    const sortedCves = cves.sort(({ cells: aCells }, { cells: bCells }) => {
+        const aCell = aCells[index].value || aCells[index].title;
+        const bCell = bCells[index].value || bCells[index].title;
 
-    const sortedCves = cves.sort(
-        ({ cells: aCells }, { cells: bCells }) => {
-            const aCell = aCells[index].value || aCells[index].title;
-            const bCell = bCells[index].value || bCells[index].title;
+        const stringA = aCell.toString().toUpperCase();
+        const stringB = bCell.toString().toUpperCase();
 
-            const stringA = aCell.toString().toUpperCase();
-            const stringB = bCell.toString().toUpperCase();
-
-            return stringA.localeCompare(stringB);
-        }
-    );
+        return stringA.localeCompare(stringB);
+    });
 
     return {
         sortBy: { index, direction },
-        sortedCves: direction === SortByDirection.asc ? sortedCves : sortedCves.reverse()
+        sortedCves:
+            direction === SortByDirection.asc
+                ? sortedCves
+                : sortedCves.reverse()
     };
-
 }
 
-export const createOSColumn = ({ osName, rhsm }) => !rhsm ? osName : (
-    <Tooltip
-        content={
-            intl.formatMessage(messages.textLockVersionTooltip, { lockedVersion: rhsm })
-        }
-    >
-        <Flex flex={{ default: 'inlineFlex' }}>
-            <FlexItem spacer={{ default: 'spacerSm' }}>{osName}</FlexItem>
-            <FlexItem spacer={{ default: 'spacerSm' }}>
-                <InfoCircleIcon size="sm" color={'var(--pf-t--global--color--status--info--100)'} />
-            </FlexItem>
-        </Flex>
-    </Tooltip>
-);
+export const createOSColumn = ({ osName, rhsm }) =>
+    !rhsm ? (
+        osName
+    ) : (
+        <Tooltip
+            content={intl.formatMessage(messages.textLockVersionTooltip, {
+                lockedVersion: rhsm
+            })}
+        >
+            <Flex flex={{ default: 'inlineFlex' }}>
+                <FlexItem spacer={{ default: 'spacerSm' }}>{osName}</FlexItem>
+                <FlexItem spacer={{ default: 'spacerSm' }}>
+                    <InfoCircleIcon
+                        size="sm"
+                        color={'var(--pf-t--global--color--status--info--100)'}
+                    />
+                </FlexItem>
+            </Flex>
+        </Tooltip>
+    );
 
-export const removeUndefinedObjectKeys = (selectedRows) => Object.keys(selectedRows).filter(row => selectedRows[row]);
+export const removeUndefinedObjectKeys = (selectedRows) =>
+    Object.keys(selectedRows).filter((row) => selectedRows[row]);
 
 export const prepareEntitiesParams = (parameters) => {
-    const offset = parameters.offset || getOffsetFromPageLimit(parameters.page || 1, parameters.perPage || 20);
-    const limit = parameters.limit || getLimitFromPageSize(parameters.perPage || 20);
+    const offset =
+        parameters.offset ||
+        getOffsetFromPageLimit(parameters.page || 1, parameters.perPage || 20);
+    const limit =
+        parameters.limit || getLimitFromPageSize(parameters.perPage || 20);
 
     const apiParams = { ...parameters, offset, limit };
 
@@ -513,8 +642,8 @@ export const prepareEntitiesParams = (parameters) => {
     return removeUndefinedObjectItems(apiParams);
 };
 
-export const filterRemediatableSystems = result => ({
-    data: result?.data.filter(system => {
+export const filterRemediatableSystems = (result) => ({
+    data: result?.data.filter((system) => {
         const {
             packages_installed: installedPckg,
             packages_updatable: updatablePckg,
@@ -523,44 +652,52 @@ export const filterRemediatableSystems = result => ({
             rhea_count: rhea
         } = system.attributes || {};
 
-        const isDisabled = updatablePckg === 0 || [installedPckg, rhba, rhsa, rhea].every(count => count === 0);
+        const isDisabled =
+            updatablePckg === 0 ||
+            [installedPckg, rhba, rhsa, rhea].every((count) => count === 0);
 
         return !isDisabled;
     })
 });
 
-export const filterRemediatablePackageSystems = result => ({ data: result.data.filter(system => system.updatable) });
+export const filterRemediatablePackageSystems = (result) => ({
+    data: result.data.filter((system) => system.updatable)
+});
 
 export const persistantParams = (patchParams, decodedParams) => {
     const persistantParams = { ...patchParams, ...decodedParams };
 
-    if (typeof persistantParams.sort === 'string' && persistantParams.sort.match(/-?groups/)) {
+    if (
+        typeof persistantParams.sort === 'string' &&
+        persistantParams.sort.match(/-?groups/)
+    ) {
         // "group_name" is the sort key used by Inventory (requires translation between Patch and Inventory)
-        persistantParams.sort = persistantParams.sort.replace('groups', 'group_name');
+        persistantParams.sort = persistantParams.sort.replace(
+            'groups',
+            'group_name'
+        );
     }
 
-    return (
-        {
-            page: Number(persistantParams.page || 1),
-            perPage: Number(persistantParams.perPage || 20),
-            ...(persistantParams.sort && {
-                sortBy: {
-                    key: persistantParams.sort.replace(/^-/, ''),
-                    direction: persistantParams.sort.match(/^-/) ? 'desc' : 'asc'
-                }
-            })
-        }
-    );
+    return {
+        page: Number(persistantParams.page || 1),
+        perPage: Number(persistantParams.perPage || 20),
+        ...(persistantParams.sort && {
+            sortBy: {
+                key: persistantParams.sort.replace(/^-/, ''),
+                direction: persistantParams.sort.match(/^-/) ? 'desc' : 'asc'
+            }
+        })
+    };
 };
 
 export const handleLongSynopsis = (synopsis) => {
     return (
         <LinesEllipsis
             text={synopsis}
-            maxLine='1'
-            ellipsis='(...)'
+            maxLine="1"
+            ellipsis="(...)"
             trimRight
-            basedOn='letters'
+            basedOn="letters"
         />
     );
 };
@@ -575,33 +712,39 @@ export const buildTagString = (tag) => {
 
 export const mapGlobalFilters = (tags, SIDs, workloads = {}) => {
     let tagsInUrlFormat = [];
-    tags && tags.forEach((tag, index) => {
+    tags &&
+    tags.forEach((tag, index) => {
         let tagGruop = tag;
         if (typeof tag === 'object') {
-            tagGruop = tag?.values.map(value => `tags=${encodeURIComponent(`${tag.category}/${value.tagKey}=${value.value}`)}`);
-            tagsInUrlFormat[index] = Array.isArray(tagGruop) && flatten(tagGruop) || tagGruop;
-        }
-        else {
+            tagGruop = tag?.values.map(
+                (value) =>
+                    `tags=${encodeURIComponent(
+                        `${tag.category}/${value.tagKey}=${value.value}`
+                    )}`
+            );
+            tagsInUrlFormat[index] =
+                (Array.isArray(tagGruop) && flatten(tagGruop)) || tagGruop;
+        } else {
             tagsInUrlFormat[index] = `tags=${encodeURIComponent(tagGruop)}`;
         }
-
     });
 
     const globalFilterConfig = { selectedTags: [], systemProfile: {} };
 
     globalFilterConfig.systemProfile = {
-        ...workloads?.SAP?.isSelected && { sap_system: true },
-        ...workloads?.['Ansible Automation Platform']?.isSelected
-        && { ansible: { controller_version: 'not_nil' } },
-        ...workloads?.['Microsoft SQL']?.isSelected
-        && { mssql: { version: 'not_nil' } },
-        ...SIDs?.length > 0 && { sap_sids: SIDs }
+        ...(workloads?.SAP?.isSelected && { sap_system: true }),
+        ...(workloads?.['Ansible Automation Platform']?.isSelected && {
+            ansible: { controller_version: 'not_nil' }
+        }),
+        ...(workloads?.['Microsoft SQL']?.isSelected && {
+            mssql: { version: 'not_nil' }
+        }),
+        ...(SIDs?.length > 0 && { sap_sids: SIDs })
     };
 
     tagsInUrlFormat && (globalFilterConfig.selectedTags = tagsInUrlFormat);
 
     return globalFilterConfig;
-
 };
 
 export const convertIsoToDate = (isoDate) => {
@@ -610,8 +753,12 @@ export const convertIsoToDate = (isoDate) => {
     }
 
     const dateObject = new Date(isoDate);
-    return `${dateObject.getFullYear()}-${(dateObject.getMonth() + 1).toString().padStart(2, '0')}` +
-        `-${dateObject.getDate().toString().padStart(2, '0')}`;
+    return (
+        `${dateObject.getFullYear()}-${(dateObject.getMonth() + 1)
+        .toString()
+        .padStart(2, '0')}` +
+        `-${dateObject.getDate().toString().padStart(2, '0')}`
+    );
 };
 
 // 2023-03-05 -> 05 Mar 2023
@@ -623,11 +770,24 @@ export const templateDateFormat = (dateString) => {
 
     // handle ISO format - convert timezone to GMT and slice off the time
     if (dateString.includes('T')) {
-        const gmtTime = (new Date(dateString)).toISOString();
+        const gmtTime = new Date(dateString).toISOString();
         [dateString] = gmtTime.split('T');
     }
 
-    const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'June', 'July', 'Aug', 'Sept', 'Oct', 'Nov', 'Dec'];
+    const MONTHS = [
+        'Jan',
+        'Feb',
+        'Mar',
+        'Apr',
+        'May',
+        'June',
+        'July',
+        'Aug',
+        'Sept',
+        'Oct',
+        'Nov',
+        'Dec'
+    ];
     const [year, month, day] = dateString.split('-');
 
     return `${day} ${MONTHS[parseInt(month) - 1]} ${year}`;
@@ -647,8 +807,10 @@ export const filterSelectedActiveSystemIDs = (selectedSystemsObject) => {
 };
 
 export const buildSelectedSystemsObj = (systemsIDs, formValueSystems) => {
-
-    const mergedSystems = [...systemsIDs, ...filterSelectedActiveSystemIDs(formValueSystems)];
+    const mergedSystems = [
+        ...systemsIDs,
+        ...filterSelectedActiveSystemIDs(formValueSystems)
+    ];
 
     const assignedSystemsObject = mergedSystems?.reduce((object, system) => {
         object[system] = true;
@@ -665,10 +827,12 @@ export const objUndefinedToFalse = (object) =>
     }, {});
 
 export const objOnlyWithTrue = (object) =>
-    Object.keys(Object.fromEntries(Object.entries(object).filter(([, v]) => v === true)));
+    Object.keys(
+        Object.fromEntries(Object.entries(object).filter(([, v]) => v === true))
+    );
 
 export const isObject = (variable) => {
-    return (typeof variable === 'object' && variable !== null) ? true : false;
+    return typeof variable === 'object' && variable !== null ? true : false;
 };
 
 export const findFilterData = (optionName, options) => {

--- a/src/Utilities/Helpers.test.js
+++ b/src/Utilities/Helpers.test.js
@@ -1,21 +1,41 @@
 /* eslint-disable */
-import { SortByDirection } from '@patternfly/react-table';
-import { publicDateOptions, remediationIdentifiers } from '../Utilities/constants';
+import {SortByDirection} from '@patternfly/react-table';
+import {publicDateOptions, remediationIdentifiers} from '../Utilities/constants';
 import {
-    addOrRemoveItemFromSet, arrayFromObj, buildFilterChips, changeListParams, convertLimitOffset,
-    createAdvisoriesIcons, createSortBy, decodeQueryparams, encodeApiParams, encodeParams, encodeURLParams,
-    getFilterValue, getLimitFromPageSize, getNewSelectedItems, getOffsetFromPageLimit, getRowIdByIndexExpandable,
-    getSeverityById, handlePatchLink, remediationProvider, mapGlobalFilters, transformPairs, templateDateFormat, persistantParams, buildApiFilters
+    addOrRemoveItemFromSet,
+    arrayFromObj,
+    buildApiFilters,
+    buildFilterChips,
+    changeListParams,
+    convertLimitOffset,
+    createAdvisoriesIcons,
+    createSortBy,
+    decodeQueryparams,
+    encodeApiParams,
+    encodeParams,
+    encodeURLParams,
+    getFilterValue,
+    getLimitFromPageSize,
+    getNewSelectedItems,
+    getOffsetFromPageLimit,
+    getRowIdByIndexExpandable,
+    getSeverityByValue,
+    handlePatchLink,
+    mapGlobalFilters,
+    persistantParams,
+    remediationProvider,
+    templateDateFormat,
+    transformPairs
 } from './Helpers';
-import { render } from '@testing-library/react';
+import {render} from '@testing-library/react';
 
-const TestHook = ({ callback }) => {
+const TestHook = ({callback}) => {
     callback();
     return null;
 };
 
 export const testHook = callback => {
-    mount(<TestHook callback={callback} />);
+    mount(<TestHook callback={callback}/>);
 };
 
 describe('Helpers tests', () => {
@@ -35,8 +55,8 @@ describe('Helpers tests', () => {
     ];
     it.each`
     header      | value         | offset    | result
-    ${header}   | ${['-a']}     | ${0}      | ${{ index: 0, direction: SortByDirection.desc }}
-    ${header}   | ${['c']}      | ${1}      | ${{ index: 3, direction: SortByDirection.asc }}
+    ${header}   | ${['-a']}     | ${0}      | ${{index: 0, direction: SortByDirection.desc}}
+    ${header}   | ${['c']}      | ${1}      | ${{index: 3, direction: SortByDirection.asc}}
     ${undefined}   | ${undefined}      | ${undefined}      | ${{}}
     `('createSortBy: Should create correct sort for $value and offset $offset', ({header, value, offset, result}) => {
         let ret = createSortBy(header, value, offset);
@@ -63,8 +83,8 @@ describe('Helpers tests', () => {
     ${2}     | ${"Moderate"}
     ${3}     | ${"Important"}
     ${4}     | ${"Critical"}
-    `('getSeverityById: Should match $severity to value $result', ({severity, result}) => {
-        expect(getSeverityById(severity).label).toEqual(result);
+    `('getSeverityByValue: Should match $severity to value $result', ({severity, result}) => {
+        expect(getSeverityByValue(severity).label).toEqual(result);
     });
 
     it('addOrRemoveItemFromSet: Should create correct object  ', () => {
@@ -90,8 +110,8 @@ describe('Helpers tests', () => {
                 value: undefined
             }
         ];
-        let targetObj = { '4': 'e' };
-        let expected = { '0': 'a', '1': 'b', '2': 'c', '3': 'd', '4': 'e' };
+        let targetObj = {'4': 'e'};
+        let expected = {'0': 'a', '1': 'b', '2': 'c', '3': 'd', '4': 'e'};
         let ret = addOrRemoveItemFromSet(targetObj, inputArr);
 
         expect(ret).toEqual(expected);
@@ -137,9 +157,9 @@ describe('Helpers tests', () => {
         const host = document.baseURI;
         let advisoryName = 'ABCD';
         const expected = `${host}insights/patch/advisories/${advisoryName}`;
-        let result = handlePatchLink('advisories',advisoryName);
+        let result = handlePatchLink('advisories', advisoryName);
         let {
-            props: { href, children }
+            props: {href, children}
         } = result;
         expect(href).toEqual(expected);
         expect(children).toEqual(advisoryName);
@@ -153,9 +173,9 @@ describe('Helpers tests', () => {
         const host = document.baseURI;
         let advisoryName = 'ABCD';
         const expected = `${host}insights/patch/advisories/${advisoryName}`;
-        let result = handlePatchLink('advisories',advisoryName, 'custom text');
+        let result = handlePatchLink('advisories', advisoryName, 'custom text');
         let {
-            props: { href, children }
+            props: {href, children}
         } = result;
         expect(href).toEqual(expected);
         expect(children).toEqual('custom text');
@@ -168,9 +188,9 @@ describe('Helpers tests', () => {
         };
         let advisoryName = 'ABCD';
         const expected = `/advisories/${advisoryName}`;
-        let result = handlePatchLink('advisories',advisoryName);
+        let result = handlePatchLink('advisories', advisoryName);
         let {
-            props: { to, children }
+            props: {to, children}
         } = result;
         expect(to).toEqual(expected);
         expect(children).toEqual(advisoryName);
@@ -183,9 +203,9 @@ describe('Helpers tests', () => {
         };
         let advisoryName = 'ABCD';
         const expected = `/advisories/${advisoryName}`;
-        let result = handlePatchLink('advisories',advisoryName, 'custom text');
+        let result = handlePatchLink('advisories', advisoryName, 'custom text');
         let {
-            props: { to, children }
+            props: {to, children}
         } = result;
         expect(to).toEqual(expected);
         expect(children).toEqual('custom text');
@@ -213,20 +233,35 @@ describe('Helpers tests', () => {
 
     it.each`
     issues         | systems            |  identifier                        | result
-    ${["issue-1"]} | ${["system-1"]}    | ${remediationIdentifiers.advisory} | ${{issues: [{id: "patch-advisory:issue-1", description: "issue-1"}],systems: ["system-1"]}}
-    ${"issue-1"}   | ${"system-1"}      | ${remediationIdentifiers.package}  | ${{issues: [{id: "patch-package:issue-1", description: "issue-1"}],systems: ["system-1"]}}
+    ${["issue-1"]} | ${["system-1"]}    | ${remediationIdentifiers.advisory} | ${{
+        issues: [{
+            id: "patch-advisory:issue-1",
+            description: "issue-1"
+        }], systems: ["system-1"]
+    }}
+    ${"issue-1"}   | ${"system-1"}      | ${remediationIdentifiers.package}  | ${{
+        issues: [{
+            id: "patch-package:issue-1",
+            description: "issue-1"
+        }], systems: ["system-1"]
+    }}
     ${[]}          | ${["system-1"]}    | ${remediationIdentifiers.package}  | ${false}
-    `('remediationProvider: Should create correct remediation object for $issues $systems', ({issues, systems, identifier, result}) => {
-        expect(remediationProvider(issues,systems, identifier)).toEqual(result);
+    `('remediationProvider: Should create correct remediation object for $issues $systems', ({
+                                                                                                                                                                                              issues,
+                                                                                                                                                                                              systems,
+                                                                                                                                                                                              identifier,
+                                                                                                                                                                                              result
+                                                                                                                                                                                          }) => {
+        expect(remediationProvider(issues, systems, identifier)).toEqual(result);
     });
 
     it.each`
     category         | key                  | result
     ${"public_date"} | ${"last7"}           | ${publicDateOptions[0]}
     ${"public_date"} | ${"random value"}    | ${{apiValue: "random value"}}
-    ${undefined}     | ${"last7"}           | ${{ "apiValue": "last7" }}
+    ${undefined}     | ${"last7"}           | ${{"apiValue": "last7"}}
     `('getFilterValue: Should create object for $category', ({category, key, result}) => {
-        expect(getFilterValue(category,key)).toEqual(result);
+        expect(getFilterValue(category, key)).toEqual(result);
     });
 
     it.each`
@@ -234,25 +269,36 @@ describe('Helpers tests', () => {
     ${{search: "trolo"}}                               | ${true}           | ${"?search=trolo"}
     ${{search: ""}}                                    | ${true}           | ${"?"}
     ${{filter: {advisory_type: 2}}}                    | ${false}          | ${"?filter%5Badvisory_type%5D=2"}
-    ${{filter: {advisory_type: [1,2]}}}                | ${true}           | ${"?filter%5Badvisory_type%5D=in%3A1%2C2"}
-    ${{filter: {advisory_type: [1,2]}, param: "text"}} | ${true}           | ${"?param=text&filter%5Badvisory_type%5D=in%3A1%2C2"}
+    ${{filter: {advisory_type: [1, 2]}}}                | ${true}           | ${"?filter%5Badvisory_type%5D=in%3A1%2C2"}
+    ${{
+        filter: {advisory_type: [1, 2]},
+        param: "text"
+    }} | ${true}           | ${"?param=text&filter%5Badvisory_type%5D=in%3A1%2C2"}
     `('encodeParams: Should encode parameters $parameters', ({parameters, shouldTranslate, result}) => {
-        expect(encodeParams(parameters,shouldTranslate)).toEqual(result);
+        expect(encodeParams(parameters, shouldTranslate)).toEqual(result);
     });
 
     it.each`
     parameters                                              | result
     ${"search=trolo"}                                       | ${{search: "trolo"}}
     ${"filter%5Badvisory_type%5D=2"}                        | ${{filter: {advisory_type: 2}}}
-    ${"param=text&filter%5Badvisory_type%5D=in%3A1%2C2"}    | ${{filter: {advisory_type: ["1","2"]}, param: "text"}}
+    ${"param=text&filter%5Badvisory_type%5D=in%3A1%2C2"}    | ${{filter: {advisory_type: ["1", "2"]}, param: "text"}}
     `('decodeQueryparams: Should decodeQueryParams $parameters', ({parameters, result}) => {
         expect(decodeQueryparams(parameters)).toEqual(result);
     });
 
     it.each`
     filters               | search       | result
-    ${{advisory_type_name: 'bugfix'}} | ${undefined} | ${[{"category": "Advisory type", "chips": [{"id": 'bugfix', "name": "Bugfix", "value": 'bugfix'}], "id": "advisory_type_name"}]}
-    ${undefined}          | ${"firefox"} | ${[{"category": "Search", "chips": [{"name": "firefox", "value": "firefox"}], "id": "search"}]}
+    ${{advisory_type_name: 'bugfix'}} | ${undefined} | ${[{
+        "category": "Advisory type",
+        "chips": [{"id": 'bugfix', "name": "Bugfix", "value": 'bugfix'}],
+        "id": "advisory_type_name"
+    }]}
+    ${undefined}          | ${"firefox"} | ${[{
+        "category": "Search",
+        "chips": [{"name": "firefox", "value": "firefox"}],
+        "id": "search"
+    }]}
      `('buildFilterChips: Should build correct filter chip, $filters, $search ', ({filters, search, result}) => {
         expect(buildFilterChips(filters, search)).toEqual(result);
     });
@@ -260,8 +306,13 @@ describe('Helpers tests', () => {
     it.each`
     oldParams               | newParams       | result
     ${{param: "Hey!"}}      | ${{param: "Yo!"}} | ${{param: "Yo!"}}
-    ${{offset: 15}} | ${{limit:100}} | ${{"limit": 100, "offset": 0}}
-    ${{filter: {advisory_type: 2}}} | ${{filter: {public_date: "last7" }}} | ${{filter:{advisory_type: 2, public_date: "last7"}, offset: 0}}
+    ${{offset: 15}} | ${{limit: 100}} | ${{"limit": 100, "offset": 0}}
+    ${{filter: {advisory_type: 2}}} | ${{filter: {public_date: "last7"}}} | ${{
+        filter: {
+            advisory_type: 2,
+            public_date: "last7"
+        }, offset: 0
+    }}
      `('changeListParams: Should return correct parameters', ({oldParams, newParams, result}) => {
         expect(changeListParams(oldParams, newParams)).toEqual(result);
     });
@@ -284,26 +335,31 @@ describe('Helpers tests', () => {
 
     it.each`
     selectedItems                   | currentItems                  | result
-    ${{ id: "a", selected: true}}   | ${{c: true, d: false}}        | ${{"a": true, "c": true}}
-    ${{ id: "a", selected: true }}  | ${{ c: undefined, d: true }}  | ${{ "a": true, "d": true }}
-    ${{ id: "a", selected: true }}  | ${{ c: '', d: true }}         | ${{ "a": true, "d": true }}
-     `('getNewSelectedItems: Should return new set of selected items', ({selectedItems, currentItems,result}) => {
+    ${{id: "a", selected: true}}   | ${{c: true, d: false}}        | ${{"a": true, "c": true}}
+    ${{id: "a", selected: true}}  | ${{c: undefined, d: true}}  | ${{"a": true, "d": true}}
+    ${{id: "a", selected: true}}  | ${{c: '', d: true}}         | ${{"a": true, "d": true}}
+     `('getNewSelectedItems: Should return new set of selected items', ({selectedItems, currentItems, result}) => {
         expect(getNewSelectedItems(selectedItems, currentItems)).toEqual(result);
     });
 
     it('Should return "false" when there is no issues available', () => {
-        const resultWhenParams = transformPairs({ data: {} });
-        expect(resultWhenParams).toEqual({ "issues": [] });
+        const resultWhenParams = transformPairs({data: {}});
+        expect(resultWhenParams).toEqual({"issues": []});
 
         const resultWhenNoParams = transformPairs();
-        expect(resultWhenNoParams).toEqual({ "issues": [] });
+        expect(resultWhenNoParams).toEqual({"issues": []});
     });
     it('Should return transformed issues', () => {
-        const resultWhenParams = transformPairs({ data: { testAdvisory1: ['test-system-1'], testAdvisory2: ['test-system-2'] } }, 'test-identifier');
+        const resultWhenParams = transformPairs({
+            data: {
+                testAdvisory1: ['test-system-1'],
+                testAdvisory2: ['test-system-2']
+            }
+        }, 'test-identifier');
         expect(resultWhenParams).toEqual({
             issues: [
-                { description: 'testAdvisory1', id: 'test-identifier:testAdvisory1', systems: ['test-system-1'] },
-                { description: 'testAdvisory2', id: 'test-identifier:testAdvisory2', systems: ['test-system-2'] }
+                {description: 'testAdvisory1', id: 'test-identifier:testAdvisory1', systems: ['test-system-1']},
+                {description: 'testAdvisory2', id: 'test-identifier:testAdvisory2', systems: ['test-system-2']}
             ]
         });
     });
@@ -321,14 +377,40 @@ describe('Test global filters', () => {
 
     it.each`
     tags                               | SIDs               | workloads                                                                 | result
-    ${[]}                              | ${[]}              | ${{ 'Ansible Automation Platform': { isSelected: true } }}                | ${{ selectedTags: [], systemProfile: { ansible: { controller_version: 'not_nil' } } }}
-    ${[]}                              | ${[]}              | ${{ 'Microsoft SQL': { isSelected: true } }}                              | ${{ selectedTags: [], systemProfile: { mssql: { version: 'not_nil' } }  }}
-    ${[]}                              | ${[]}              | ${{ SAP: { isSelected: true } }}                                          | ${{ selectedTags: [], systemProfile: { sap_system: true } }}
-    ${[]}                              | ${['abc']}         | ${{ SAP: { isSelected: true } }}                                          | ${{ selectedTags: [], systemProfile: { sap_sids: ['abc'], sap_system: true } }}
-    ${[]}                              | ${['abc', 'bca']}  | ${{ SAP: { isSelected: true }, 'Microsoft SQL': { isSelected: true } }}   | ${{ selectedTags: [], systemProfile: { sap_sids: ['abc', 'bca'], sap_system: true, mssql: { version: 'not_nil' } } }}
-    ${['null/key.BnZPeP=tag.MNGmxQ']}  | ${['abc', 'bca']}  | ${{ SAP: { isSelected: true } }}                                              | ${{ selectedTags: ["tags=null%2Fkey.BnZPeP%3Dtag.MNGmxQ"], systemProfile: { sap_sids: ['abc', 'bca'], sap_system: true } }}
-     `('mapGlobalFilters: Should build correct global filters, $tags, $SIDs, $workloads ', ({ tags, SIDs, workloads, result }) => {
-         expect(mapGlobalFilters(tags, SIDs, workloads,)).toEqual(result);
+    ${[]}                              | ${[]}              | ${{'Ansible Automation Platform': {isSelected: true}}}                | ${{
+        selectedTags: [],
+        systemProfile: {ansible: {controller_version: 'not_nil'}}
+    }}
+    ${[]}                              | ${[]}              | ${{'Microsoft SQL': {isSelected: true}}}                              | ${{
+        selectedTags: [],
+        systemProfile: {mssql: {version: 'not_nil'}}
+    }}
+    ${[]}                              | ${[]}              | ${{SAP: {isSelected: true}}}                                          | ${{
+        selectedTags: [],
+        systemProfile: {sap_system: true}
+    }}
+    ${[]}                              | ${['abc']}         | ${{SAP: {isSelected: true}}}                                          | ${{
+        selectedTags: [],
+        systemProfile: {sap_sids: ['abc'], sap_system: true}
+    }}
+    ${[]}                              | ${['abc', 'bca']}  | ${{
+        SAP: {isSelected: true},
+        'Microsoft SQL': {isSelected: true}
+    }}   | ${{
+        selectedTags: [],
+        systemProfile: {sap_sids: ['abc', 'bca'], sap_system: true, mssql: {version: 'not_nil'}}
+    }}
+    ${['null/key.BnZPeP=tag.MNGmxQ']}  | ${['abc', 'bca']}  | ${{SAP: {isSelected: true}}}                                              | ${{
+        selectedTags: ["tags=null%2Fkey.BnZPeP%3Dtag.MNGmxQ"],
+        systemProfile: {sap_sids: ['abc', 'bca'], sap_system: true}
+    }}
+     `('mapGlobalFilters: Should build correct global filters, $tags, $SIDs, $workloads ', ({
+                                                                                                      tags,
+                                                                                                      SIDs,
+                                                                                                      workloads,
+                                                                                                      result
+                                                                                                  }) => {
+        expect(mapGlobalFilters(tags, SIDs, workloads,)).toEqual(result);
     });
 })
 /* eslint-enable */

--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -1,7 +1,4 @@
-import { BugIcon } from '@patternfly/react-icons';
-import { EnhancementIcon } from '@patternfly/react-icons';
-import { SecurityIcon } from '@patternfly/react-icons';
-import { FlagIcon } from '@patternfly/react-icons';
+import { BugIcon, EnhancementIcon, FlagIcon, SecurityIcon } from '@patternfly/react-icons';
 import React from 'react';
 import { subtractDate } from './Helpers';
 
@@ -90,7 +87,7 @@ export const publicDateOptions = [
 
 export const advisorySeverities = [
     {
-        value: 0,
+        value: null,
         label: 'None',
         color: 'var(--pf-t--global--icon--color--severity--minor--default)'
     },
@@ -141,22 +138,22 @@ export const advisoryTypes = [
     {
         value: 'security',
         label: 'Security',
-        icon: <SecurityIcon />
+        icon: <SecurityIcon/>
     },
     {
         value: 'bugfix',
         label: 'Bugfix',
-        icon: <BugIcon />
+        icon: <BugIcon/>
     },
     {
         value: 'enhancement',
         label: 'Enhancement',
-        icon: <EnhancementIcon />
+        icon: <EnhancementIcon/>
     },
     {
         value: 'other',
         label: 'Other',
-        icon: <FlagIcon />
+        icon: <FlagIcon/>
     }
 ];
 
@@ -223,6 +220,10 @@ export const filterCategories = {
     advisory_type_name: {
         label: 'Advisory type',
         values: advisoryTypes
+    },
+    severity: {
+        label: 'Severity',
+        values: advisorySeverities
     },
     public_date: {
         label: 'Public date',


### PR DESCRIPTION
# Description

This PR implements a severity column and associated filter to advisory views.

* Tables Updated: The `Advisories` and `SystemAdvisories` tables now include the new column and filter.
* Advisor App: No changes were required in the separate Advisor repository, as the `SystemAdvisories` table is automatically proxied there.
* New Component: A new `<AdvisorySeverity>` component was created to standardize the display of the severity icon and label across the UI.

We're now displaying an icon for the `severity=null` state to signify that "None" is a valid state as opposed to omitting the icon, which could be mistaken for a bug. Showing the icon maintains consistency since all other severity levels have one. Let me know your thoughts.

<img width="2239" height="1399" alt="Screenshot From 2025-11-03 14-02-55" src="https://github.com/user-attachments/assets/958c4ede-fc7f-44ff-bc5f-8b64c1261a3e" />

<img width="2239" height="1399" alt="Screenshot From 2025-11-03 22-01-59" src="https://github.com/user-attachments/assets/37e60d77-0909-4fe7-b7eb-af6c2a0c498e" />

**Heads up:** Just wanted to flag that not all files in Patch were following the ESLint rules, which might make the code review feel cumbersome. Let me know if you'd like me to undo the inconsistent formatting to streamline the process for you.

# How to test the PR

- Verify that the app builds without any errors.
- Ensure that all automated tests pass.

# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [x] Tests for the changes have been added
- [x] README.md is updated if necessary
- [x] Needs additional dependent work
