### PR TITLE
RHINENG-21469: bulk select only items on page as default

### DIFF
--- a/src/Utilities/hooks/Hooks.js
+++ b/src/Utilities/hooks/Hooks.js
@@ -167,11 +167,10 @@ export const useBulkSelectConfig = (selectedCount, onSelect, metadata, rows, onC
         onSelect: () => {
             let action = 'none';
             if (selectedCount === 0) {
-                setBulkLoading(true);
-                action = 'all';
+                action = 'page';
             }
 
-            onSelect(action, null, null, setBulkLoading);
+            onSelect(action);
         },
         toggleProps: {
             'data-ouia-component-type': 'bulk-select-toggle-button',


### PR DESCRIPTION
# Description

Associated Jira ticket: # ([RHINENG-21469](https://issues.redhat.com/browse/RHINENG-21469))

This PR changes the default behavior of the bulk select from "all" to "page" in the "useBulkSelectConfig" hook that used in different components.

# How to test the PR

1. Go to Content -> Advisories
2. Click on checkbox to select all items

# Before the change
All the items are selected on all pages
<img width="1661" height="669" alt="Screenshot 2025-11-03 at 15 59 28" src="https://github.com/user-attachments/assets/cebf9ad3-3904-41df-97fb-4ed796c7f4e4" />

# After the change
Only items visible on the page are selected.
<img width="1661" height="656" alt="Screenshot 2025-11-03 at 15 57 21" src="https://github.com/user-attachments/assets/32fd3204-a9f6-4f46-9926-06f473d14ae5" />