### PR TITLE
HMS-9331: migrate fec-notifications to v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@patternfly/react-icons": "^6.3.1",
         "@patternfly/react-table": "^6.3.1",
         "@redhat-cloud-services/frontend-components": "^7.0.4",
-        "@redhat-cloud-services/frontend-components-notifications": "^5.0.6",
+        "@redhat-cloud-services/frontend-components-notifications": "^6.1.13",
         "@redhat-cloud-services/frontend-components-remediations": "^4.0.17",
         "@redhat-cloud-services/frontend-components-translations": "^4.0.11",
         "@redhat-cloud-services/frontend-components-utilities": "^7.0.4",
@@ -4977,127 +4977,19 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-notifications": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-5.0.7.tgz",
-      "integrity": "sha512-CCkioaXuz/gCK4qbBOIEle14C2EM1Qj77uyEnD0m0zpF68VRAT1xDIUO6eWFpWGTbSpklLy/Iz+5iGcSDIBxuw==",
+      "version": "6.1.13",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-6.1.13.tgz",
+      "integrity": "sha512-So3fFNZMOX6ccpcLQBtwA8Ydu229vpQAmKiPvnucmPq41YiYqDgZLBEuJH8UIltMZq71lyylnNz6kYEDp4WiwQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@redhat-cloud-services/frontend-components": "^6.0.0",
-        "@redhat-cloud-services/frontend-components-utilities": "^6.0.0",
-        "redux-promise-middleware": "6.1.3"
+        "@redhat-cloud-services/frontend-components": "^7.0.0",
+        "@redhat-cloud-services/frontend-components-utilities": "^7.0.0"
       },
       "peerDependencies": {
         "@patternfly/react-core": "^6.0.0",
         "@patternfly/react-icons": "^6.0.0",
-        "prop-types": "^15.6.2",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "react-redux": "^7.2.9 || ^8.0.0 || ^9.0.0",
-        "redux": ">=4.2.0"
-      }
-    },
-    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/@redhat-cloud-services/frontend-components": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-6.1.1.tgz",
-      "integrity": "sha512-p6nqk6pLL8nnxxIzfyQd5K6yW4EBqNZlAlgWmgSttwuuPAzHTDHFtutTvtCMK/hzlyfTnyGgjRMe2TL+wXrEcQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@patternfly/react-component-groups": "^6.0.0",
-        "@redhat-cloud-services/frontend-components-utilities": "^6.0.0",
-        "@redhat-cloud-services/types": "^2.0.0",
-        "@scalprum/core": "^0.8.1",
-        "@scalprum/react-core": "^0.9.1",
-        "classnames": "^2.2.5",
-        "sanitize-html": "^2.13.1"
-      },
-      "peerDependencies": {
-        "@patternfly/react-core": "^6.0.0",
-        "@patternfly/react-icons": "^6.0.0",
-        "@patternfly/react-table": "^6.0.0",
-        "@patternfly/react-tokens": "^6.0.0",
-        "lodash": "^4.17.15",
-        "prop-types": "^15.6.2",
-        "react": "^18.2.0",
-        "react-content-loader": "^6.2.0",
-        "react-dom": "^18.2.0",
-        "react-redux": "^7.0.0 || ^8.0.0 || ^9.0.0",
-        "react-router-dom": "^5.0.0 || ^6.0.0"
-      }
-    },
-    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/@redhat-cloud-services/frontend-components-utilities": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-6.1.1.tgz",
-      "integrity": "sha512-ETaL9dUOyxrqjJx+QcxI5pBmDOShC6voJINlU4afhelJBfam01oMQxQYB1aPFKs2JmBDbYgT2fgT/6s/1FJS0Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@redhat-cloud-services/rbac-client": "^1.0.111 || 2.x",
-        "@redhat-cloud-services/types": "^2.0.0",
-        "@sentry/browser": "^7.119.1",
-        "awesome-debounce-promise": "^2.1.0",
-        "axios": "^0.28.1 || ^1.7.0",
-        "commander": "^2.20.3",
-        "mkdirp": "^1.0.4",
-        "p-map": "^7.0.2",
-        "react-content-loader": "^6.2.0"
-      },
-      "peerDependencies": {
-        "@patternfly/react-core": "^6.0.0",
-        "@patternfly/react-table": "^6.0.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "react-redux": "^7.0.0 || ^8.0.0 || ^9.0.0",
-        "react-router-dom": "^5.0.0 || ^6.0.0"
-      }
-    },
-    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/@redhat-cloud-services/javascript-clients-shared": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/javascript-clients-shared/-/javascript-clients-shared-1.2.7.tgz",
-      "integrity": "sha512-DfH1Sdjwc9YYVM2wLznnNfC3+DFpdH8Ak59LW93KQWaPAn8ZHDoEXi/TZ8MisEgWTQv7jpsDVtlVQwOWkzKhUA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "axios": "^1.7.2",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/@redhat-cloud-services/rbac-client": {
-      "version": "2.2.11",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-2.2.11.tgz",
-      "integrity": "sha512-3LLW5XtBMqcdlYJ4lAFo7MaGnHXUBP01O3kty4ocU69EPjiip6/Gtj83vAx5hkgAWX9h6ZEntTDeDuU/ZfGdKQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@redhat-cloud-services/javascript-clients-shared": "^1.2.4",
-        "axios": "^1.7.2",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/@redhat-cloud-services/types": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-2.0.3.tgz",
-      "integrity": "sha512-tsubBSPwPwlK868Zr3xv9FbnjV9qb+l/8SwHj9ZP5NIlP/YWae81sTnGdRk+af+uX5PZo5AVV2JGzdSRJhPekw==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/@scalprum/react-core": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.9.5.tgz",
-      "integrity": "sha512-Z468yqlnjCL66Dkj5qAPKGkzhDs/dcyouMR3833BVOecG/G1f8temOXX20ztAMxqk7Hf7Wa0zvR1KFk0hGgEyA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@openshift/dynamic-plugin-sdk": "^5.0.1",
-        "@scalprum/core": "^0.8.3",
-        "lodash": "^4.17.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0 || >=17.0.0 || ^18.0.0",
-        "react-dom": ">=16.8.0 || >=17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/redux-promise-middleware": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/redux-promise-middleware/-/redux-promise-middleware-6.1.3.tgz",
-      "integrity": "sha512-B/Hi5Ct5d9y5d/KG0f6MZUXKA0nrQh5583mHCx13HY3Avte8KfpoRH/TB5QT6k/FcjT6JCxjv7jedymidy2A1A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "redux": "^2.0.0 || ^3.0.0 || ^4.0.0"
+        "react-dom": "^18.2.0"
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-remediations": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@patternfly/react-icons": "^6.3.1",
     "@patternfly/react-table": "^6.3.1",
     "@redhat-cloud-services/frontend-components": "^7.0.4",
-    "@redhat-cloud-services/frontend-components-notifications": "^5.0.6",
+    "@redhat-cloud-services/frontend-components-notifications": "^6.1.13",
     "@redhat-cloud-services/frontend-components-remediations": "^4.0.17",
     "@redhat-cloud-services/frontend-components-translations": "^4.0.11",
     "@redhat-cloud-services/frontend-components-utilities": "^7.0.4",

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import NotificationPortal from '@redhat-cloud-services/frontend-components-notifications/NotificationPortal';
+import { NotificationsProvider } from '@redhat-cloud-services/frontend-components-notifications';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import '@redhat-cloud-services/frontend-components-notifications/index.css';
 import { RBACProvider } from '@redhat-cloud-services/frontend-components/RBACProvider';
@@ -42,9 +42,10 @@ const App = () => {
 
   return (
     <React.Fragment>
-      <NotificationPortal />
       <RBACProvider appName='patch'>
-        <Routes />
+        <NotificationsProvider>
+          <Routes />
+        </NotificationsProvider>
       </RBACProvider>
     </React.Fragment>
   );

--- a/src/SmartComponents/Advisories/Advisories.js
+++ b/src/SmartComponents/Advisories/Advisories.js
@@ -33,7 +33,6 @@ import {
   useSortColumn,
 } from '../../Utilities/hooks';
 import { intl } from '../../Utilities/IntlProvider';
-import { clearNotifications } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import AdvisoriesStatusReport from '../../PresentationalComponents/StatusReports/AdvisoriesStatusReport';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import { useNavigate, useSearchParams } from 'react-router-dom';
@@ -69,13 +68,6 @@ const Advisories = () => {
   );
 
   const [isRemediationLoading, setRemediationLoading] = React.useState(false);
-
-  React.useEffect(
-    () => () => {
-      dispatch(clearNotifications());
-    },
-    [],
-  );
 
   useEffect(() => {
     if (firstMount) {

--- a/src/SmartComponents/AdvisoryDetail/AdvisoryDetail.js
+++ b/src/SmartComponents/AdvisoryDetail/AdvisoryDetail.js
@@ -14,7 +14,6 @@ import {
 } from '../../store/Actions/Actions';
 import { intl } from '../../Utilities/IntlProvider';
 import AdvisorySystems from '../AdvisorySystems/AdvisorySystems';
-import { clearNotifications } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 
 const AdvisoryDetail = () => {
@@ -38,7 +37,6 @@ const AdvisoryDetail = () => {
     () => () => {
       dispatch(clearEntitiesStore());
       dispatch(clearAdvisoryDetailStore());
-      dispatch(clearNotifications());
     },
     [],
   );

--- a/src/SmartComponents/Modals/AssignSystemsModal.js
+++ b/src/SmartComponents/Modals/AssignSystemsModal.js
@@ -6,8 +6,7 @@ import { injectIntl } from 'react-intl';
 import SelectExistingSets from '../PatchSetWizard/InputFields/SelectExistingSets';
 import messages from '../../Messages';
 import { updatePatchSets } from '../../Utilities/api';
-import { useDispatch } from 'react-redux';
-import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
+import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications';
 import { patchSetAssignSystemsNotifications } from '../PatchSet/PatchSetAssets';
 import { filterSelectedActiveSystemIDs } from '../../Utilities/Helpers';
 import { filterSatelliteManagedSystems } from './Helpers';
@@ -15,8 +14,6 @@ import { useFetchBatched } from '../../Utilities/hooks';
 import isEmpty from 'lodash/isEmpty';
 
 const AssignSystemsModal = ({ patchSetState = {}, setPatchSetState, intl, totalItems }) => {
-  const dispatch = useDispatch();
-
   const { systemsIDs, isAssignSystemsModalOpen } = patchSetState;
   const [selectedPatchSet, setSelectedPatchSet] = useState([]);
   const [selectedPatchSetDetails, setSelectedPatchSetDetails] = useState({});
@@ -24,6 +21,7 @@ const AssignSystemsModal = ({ patchSetState = {}, setPatchSetState, intl, totalI
   const [systemsNotManagedBySatellite, setSystemsNotManagedBySatellite] = useState([]);
   const [systemsLoading, setSystemsLoading] = useState(true);
   const { fetchBatched } = useFetchBatched();
+  const addNotification = useAddNotification();
 
   const closeModal = () => {
     setPatchSetState({
@@ -42,18 +40,16 @@ const AssignSystemsModal = ({ patchSetState = {}, setPatchSetState, intl, totalI
 
     updatePatchSets({ inventory_ids: systemsIDs }, selectedPatchSetDetails.id)
       .then(() => {
-        dispatch(
-          addNotification(patchSetAssignSystemsNotifications(Object.keys(systems).length).success),
-        );
-        setPatchSetState({
-          ...patchSetState,
-          shouldRefresh: true,
-          isAssignSystemsModalOpen: false,
-          systemsIDs: [],
-        });
+        (addNotification(patchSetAssignSystemsNotifications(Object.keys(systems).length).success),
+          setPatchSetState({
+            ...patchSetState,
+            shouldRefresh: true,
+            isAssignSystemsModalOpen: false,
+            systemsIDs: [],
+          }));
       })
       .catch(() => {
-        dispatch(addNotification(patchSetAssignSystemsNotifications().failure));
+        addNotification(patchSetAssignSystemsNotifications().failure);
       });
 
     closeModal();

--- a/src/SmartComponents/Modals/UnassignSystemsModal.test.js
+++ b/src/SmartComponents/Modals/UnassignSystemsModal.test.js
@@ -1,4 +1,4 @@
-import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
+import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications';
 import UnassignSystemsModal from './UnassignSystemsModal';
 import { unassignSystemFromPatchSet } from '../../Utilities/api';
 import { initMocks } from '../../Utilities/unitTestingUtilities';
@@ -19,9 +19,11 @@ jest.mock('react-redux', () => ({
   useDispatch: jest.fn(() => () => {}),
 }));
 
-jest.mock('@redhat-cloud-services/frontend-components-notifications/redux', () => ({
-  addNotification: jest.fn(() => {}),
+jest.mock('@redhat-cloud-services/frontend-components-notifications', () => ({
+  useAddNotification: jest.fn(() => {}),
 }));
+
+const mockAddNotification = jest.fn();
 
 let unassignSystemsModalState = {
   isUnassignSystemsModalOpen: true,
@@ -33,6 +35,8 @@ const setUnassignSystemsModalOpen = (modalState) => {
 
 beforeEach(() => {
   unassignSystemsModalState.isUnassignSystemsModalOpen = true;
+  useAddNotification.mockReturnValue(mockAddNotification);
+
   render(
     <IntlProvider>
       <UnassignSystemsModal
@@ -57,7 +61,9 @@ describe('UnassignSystemsModal', () => {
     await user.click(screen.getByText('Remove'));
 
     await waitFor(() => {
-      expect(addNotification).toHaveBeenCalledWith(patchSetUnassignSystemsNotifications(1).success);
+      expect(mockAddNotification).toHaveBeenCalledWith(
+        patchSetUnassignSystemsNotifications(1).success,
+      );
       expect(unassignSystemsModalState).toEqual({
         isUnassignSystemsModalOpen: false,
         shouldRefresh: true,

--- a/src/SmartComponents/Modals/useUnassignSystemsHook.js
+++ b/src/SmartComponents/Modals/useUnassignSystemsHook.js
@@ -1,5 +1,4 @@
-import { useDispatch } from 'react-redux';
-import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
+import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications';
 
 import { unassignSystemFromPatchSet } from '../../Utilities/api';
 import { patchSetUnassignSystemsNotifications } from '../PatchSet/PatchSetAssets';
@@ -11,19 +10,18 @@ import { patchSetUnassignSystemsNotifications } from '../PatchSet/PatchSetAssets
  * @returns {handleSystemsRemoval}
  */
 export const useUnassignSystemsHook = (handleModalToggle, systemsWithPatchSet) => {
-  const dispatch = useDispatch();
+  const addNotification = useAddNotification();
+
   const handleSystemsRemoval = async () => {
     const result = await unassignSystemFromPatchSet({ inventory_ids: systemsWithPatchSet });
     handleModalToggle(true);
 
     if (result.status === 200) {
-      dispatch(
-        addNotification(
-          patchSetUnassignSystemsNotifications(systemsWithPatchSet?.length || 0).success,
-        ),
+      addNotification(
+        patchSetUnassignSystemsNotifications(systemsWithPatchSet?.length || 0).success,
       );
     } else {
-      dispatch(addNotification(patchSetUnassignSystemsNotifications().failure));
+      addNotification(patchSetUnassignSystemsNotifications().failure);
     }
   };
 

--- a/src/SmartComponents/PackageDetail/PackageDetail.js
+++ b/src/SmartComponents/PackageDetail/PackageDetail.js
@@ -10,7 +10,6 @@ import { Unavailable } from '@redhat-cloud-services/frontend-components/Unavaila
 import PackageSystems from '../../SmartComponents/PackageSystems/PackageSystems';
 import { clearPackageDetailStore, fetchPackageDetails } from '../../store/Actions/Actions';
 import { intl } from '../../Utilities/IntlProvider';
-import { clearNotifications } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import ErrorHandler from '../../PresentationalComponents/Snippets/ErrorHandler';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 
@@ -32,7 +31,6 @@ const PackageDetail = () => {
 
   React.useEffect(
     () => () => {
-      dispatch(clearNotifications());
       dispatch(clearPackageDetailStore());
     },
     [],

--- a/src/SmartComponents/PatchSet/PatchSet.js
+++ b/src/SmartComponents/PatchSet/PatchSet.js
@@ -26,10 +26,7 @@ import {
   ID_API_ENDPOINTS,
 } from '../../Utilities/hooks';
 import { intl } from '../../Utilities/IntlProvider';
-import {
-  clearNotifications,
-  addNotification,
-} from '@redhat-cloud-services/frontend-components-notifications/redux';
+import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications';
 import {
   patchSetColumns,
   CreatePatchSetButton as createPatchSetButton,
@@ -57,6 +54,7 @@ const PatchSet = () => {
   const [firstMount, setFirstMount] = React.useState(true);
   const [isDeleteConfirmModalOpen, setDeleteConfirmModalOpen] = React.useState(false);
   const [patchSetToDelete, setPatchSetToDelete] = React.useState(null);
+  const addNotification = useAddNotification();
 
   const patchSets = useSelector(({ PatchSetsStore }) => PatchSetsStore.rows);
 
@@ -81,7 +79,6 @@ const PatchSet = () => {
   useEffect(
     () => () => {
       dispatch(clearPatchSetsAction());
-      dispatch(clearNotifications());
     },
     [],
   );
@@ -128,13 +125,11 @@ const PatchSet = () => {
   const handlePatchSetDelete = () => {
     deletePatchSet(patchSetToDelete.id)
       .then(() => {
-        dispatch(
-          addNotification(patchSetDeleteNotifications(patchSetToDelete.displayName).success),
-        );
+        addNotification(patchSetDeleteNotifications(patchSetToDelete.displayName).success);
         refreshTable();
       })
       .catch(() => {
-        dispatch(addNotification(patchSetDeleteNotifications(patchSetToDelete.displayName).error));
+        addNotification(patchSetDeleteNotifications(patchSetToDelete.displayName).error);
       });
   };
 

--- a/src/SmartComponents/PatchSetDetail/PatchSetDetail.js
+++ b/src/SmartComponents/PatchSetDetail/PatchSetDetail.js
@@ -37,7 +37,7 @@ import {
 } from '@patternfly/react-core';
 import DeleteSetModal from '../Modals/DeleteSetModal';
 import { deletePatchSet, fetchPatchSetSystems } from '../../Utilities/api';
-import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
+import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications';
 import { patchSetDeleteNotifications } from '../../Utilities/constants';
 import ErrorHandler from '../../PresentationalComponents/Snippets/ErrorHandler';
 import {
@@ -79,6 +79,7 @@ const PatchSetDetail = () => {
   const inventory = useRef(null);
 
   const { templateName: patchSetId } = useParams();
+  const addNotification = useAddNotification();
 
   const [firstMount, setFirstMount] = React.useState(true);
   const [isHeaderDropdownOpen, setHeaderDropdownOpen] = useState(false);
@@ -190,11 +191,11 @@ const PatchSetDetail = () => {
   const deleteSet = () => {
     deletePatchSet(patchSetId)
       .then(() => {
-        dispatch(addNotification(patchSetDeleteNotifications(patchSetName).success));
+        addNotification(patchSetDeleteNotifications(patchSetName).success);
         navigate('../templates');
       })
       .catch(() => {
-        dispatch(addNotification(patchSetDeleteNotifications(patchSetName).error));
+        addNotification(patchSetDeleteNotifications(patchSetName).error);
       });
   };
 

--- a/src/SmartComponents/PatchSetWizard/steps/RequestProgress.js
+++ b/src/SmartComponents/PatchSetWizard/steps/RequestProgress.js
@@ -13,16 +13,15 @@ import {
 import { CheckCircleIcon, ExclamationCircleIcon, InProgressIcon } from '@patternfly/react-icons';
 import { intl } from '../../../Utilities/IntlProvider';
 import messages from '../../../Messages';
-import { useDispatch } from 'react-redux';
 import { apiFailedNotification } from '../WizardAssets';
-import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
+import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications';
 
 const RequestProgress = ({ onClose, state }) => {
   const { requestPending, failed, error } = state;
-  const dispatch = useDispatch();
+  const addNotification = useAddNotification();
 
   if (failed) {
-    dispatch(addNotification(apiFailedNotification(error.detail)));
+    addNotification(apiFailedNotification(error.detail));
   }
 
   return (

--- a/src/SmartComponents/Remediation/AsyncRemediationButton.js
+++ b/src/SmartComponents/Remediation/AsyncRemediationButton.js
@@ -1,7 +1,6 @@
-import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
+import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications';
 import propTypes from 'prop-types';
 import React from 'react';
-import { useDispatch } from 'react-redux';
 import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
 import { Spinner } from '@patternfly/react-core';
 import { intl } from '../../Utilities/IntlProvider';
@@ -14,9 +13,9 @@ const AsyncRemediationButton = ({
   patchNoAdvisoryText,
   hasSelected,
 }) => {
-  const dispatch = useDispatch();
+  const addNotification = useAddNotification();
   const handleRemediationSuccess = (res) => {
-    dispatch(addNotification(res.getNotification()));
+    addNotification(res.getNotification());
   };
 
   return (

--- a/src/SmartComponents/SystemDetail/InventoryDetail.js
+++ b/src/SmartComponents/SystemDetail/InventoryDetail.js
@@ -13,7 +13,6 @@ import {
 } from '@redhat-cloud-services/frontend-components/Inventory';
 import { Alert, Grid, GridItem, Content } from '@patternfly/react-core';
 import { fetchSystemDetailsAction } from '../../store/Actions/Actions';
-import { clearNotifications } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import PatchSetWrapper from '../../PresentationalComponents/PatchSetWrapper/PatchSetWrapper';
 import { usePatchSetState } from '../../Utilities/hooks';
 import { useParams } from 'react-router-dom';
@@ -38,10 +37,6 @@ const InventoryDetail = () => {
 
   useEffect(() => {
     dispatch(fetchSystemDetailsAction(inventoryId));
-
-    return () => {
-      dispatch(clearNotifications());
-    };
   }, []);
 
   useEffect(() => {

--- a/src/Utilities/hooks/Hooks.js
+++ b/src/Utilities/hooks/Hooks.js
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, Fragment, useState } from 'react';
 import { SortByDirection } from '@patternfly/react-table';
-import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux/actions/notifications';
+import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications';
 import { downloadFile } from '@redhat-cloud-services/frontend-components-utilities/helpers';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import isDeepEqualReact from 'fast-deep-equal/react';
@@ -286,17 +286,19 @@ export const useGetEntities = (
   return getEntities;
 };
 
-export const useOnExport = (prefix, queryParams, formatHandlers, dispatch) => {
+export const useOnExport = (prefix, queryParams, formatHandlers) => {
+  const addNotification = useAddNotification();
+
   const onExport = React.useCallback((_, format) => {
     const date = new Date().toISOString().replace(/[T:]/g, '-').split('.')[0] + '-utc';
     const filename = `${prefix}-${date}`;
-    dispatch(addNotification(exportNotifications(format).pending));
+    addNotification(exportNotifications(format).pending);
     formatHandlers[format](queryParams, prefix)
       .then((data) => {
-        dispatch(addNotification(exportNotifications(format).success));
+        addNotification(exportNotifications(format).success);
         downloadFile(data, filename, format);
       })
-      .catch(() => dispatch(addNotification(exportNotifications().error)));
+      .catch(() => addNotification(exportNotifications().error));
   });
   return onExport;
 };

--- a/src/Utilities/hooks/useRemediationDataProvider.js
+++ b/src/Utilities/hooks/useRemediationDataProvider.js
@@ -1,5 +1,4 @@
-import { useDispatch } from 'react-redux';
-import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
+import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import { removeUndefinedObjectKeys } from '../Helpers';
 
@@ -23,18 +22,16 @@ const deligateWorkerTask = (worker, task) => {
   });
 };
 
-export const prepareRemediationPairs = async (task, dispatch) => {
+export const prepareRemediationPairs = async (task, addNotification) => {
   const [worker, terminateWorker] = initializeWorker();
   const deligatedTask = deligateWorkerTask(worker, task);
 
   const response = await deligatedTask.catch((err) =>
-    dispatch(
-      addNotification({
-        title: `There was an error while processing.`,
-        description: err,
-        variant: 'danger',
-      }),
-    ),
+    addNotification({
+      title: `There was an error while processing.`,
+      description: err,
+      variant: 'danger',
+    }),
   );
 
   terminateWorker();
@@ -55,8 +52,8 @@ export const useRemediationDataProvider = (
   remediationType,
   areAllSelected,
 ) => {
-  const dispatch = useDispatch();
   const chrome = useChrome();
+  const addNotification = useAddNotification();
   const remediationDataProvider = async () => {
     setRemediationLoading(true);
 
@@ -70,7 +67,7 @@ export const useRemediationDataProvider = (
         areAllSelected,
         authToken,
       },
-      dispatch,
+      addNotification,
     );
 
     setRemediationLoading(false);

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,5 +1,3 @@
-import notificationsMiddleware from '@redhat-cloud-services/frontend-components-notifications/notificationsMiddleware';
-import { notificationsReducer } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import promiseMiddleware from 'redux-promise-middleware';
 import { AdvisoryDetailStore } from './Reducers/AdvisoryDetailStore';
 import { AdvisoryListStore } from './Reducers/AdvisoryListStore';
@@ -43,10 +41,9 @@ export const defaultReducers = {
   PatchSetDetailStore,
   PatchSetDetailSystemsStore,
   SpecificPatchSetReducer,
-  notifications: notificationsReducer,
 };
 
 export const store = createStore(
   combineReducers(defaultReducers),
-  composeEnhancers(applyMiddleware(promiseMiddleware, notificationsMiddleware())),
+  composeEnhancers(applyMiddleware(promiseMiddleware)),
 );


### PR DESCRIPTION
# Description

Migrates fec-notifications to v6

Associated Jira ticket: # (issue)

[HMS-9331](https://issues.redhat.com/browse/HMS-9331)

# How to test the PR

1. Try any action that creates a toast notification (like exporting advisories, packages, systems or creating a plan remediation playbook)
2. Toast notifications should work as before, duplicate close button should be removed

# Before the change

<img width="720" height="183" alt="Screenshot From 2025-11-05 12-14-11" src="https://github.com/user-attachments/assets/f0d1fa38-7932-469d-90d2-655fe4c338fa" />

# After the change

<img width="719" height="174" alt="Screenshot From 2025-11-05 12-16-58" src="https://github.com/user-attachments/assets/af7a1cb5-505e-4ea8-9f25-b3ddf60603b2" />

# Dependent work link

# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
