### PR TITLE
chore(advisory-systems): add filtering by workspace

### DIFF
--- a/src/SmartComponents/AdvisorySystems/AdvisorySystemsTable.js
+++ b/src/SmartComponents/AdvisorySystems/AdvisorySystemsTable.js
@@ -131,7 +131,7 @@ const AdvisorySystemsTable = ({
         autoRefresh
         initialLoading
         ignoreRefresh
-        hideFilters={{ all: true, tags: false, operatingSystem: false }}
+        hideFilters={{ all: true, tags: false, hostGroupFilter: false, operatingSystem: false }}
         columns={(inventoryColumns) =>
           mergeInventoryColumns(
             appliedColumns.filter((column) => column.isShown),

--- a/src/SmartComponents/AdvisorySystems/AdvisorySystemsTable.test.js
+++ b/src/SmartComponents/AdvisorySystems/AdvisorySystemsTable.test.js
@@ -80,13 +80,14 @@ describe('AdvisorySystemsTable.js', () => {
     );
   });
 
-  it('should use os and tag filter from Inventory', async () => {
+  it('should use os, tag and workspace filter from Inventory', async () => {
     await renderComponent(mockState);
     expect(InventoryTable).toHaveBeenCalledWith(
       expect.objectContaining({
         hideFilters: {
           all: true,
           tags: false,
+          hostGroupFilter: false,
           operatingSystem: false,
         },
       }),

--- a/src/Utilities/DataMappers.js
+++ b/src/Utilities/DataMappers.js
@@ -218,6 +218,7 @@ export const createPackageSystemsRows = (rows, selectedRows = {}) => {
 export const createAdvisorySystemsRows = (rows, selectedRows = {}) => {
   const data = rows.map(({ id, ...rest }) => {
     const {
+      groups,
       packages_installed: installedPckg,
       os,
       rhsm,
@@ -227,6 +228,7 @@ export const createAdvisorySystemsRows = (rows, selectedRows = {}) => {
     } = rest;
     return {
       id,
+      groups,
       ...rest,
       key: Math.random().toString() + id,
       packages_installed: installedPckg,


### PR DESCRIPTION
# Description

Associated Jira ticket: [RHINENG-5432](https://issues.redhat.com/browse/RHINENG-5432)

This PR enables filtering by workspace for the systems list on the Advisory details page.


# How to test the PR

1. Make sure you have one or more workspaces
2. Go to Content -> Advisories
3. Click on any advisory
4. If the filter dropbox select "Workspace" and select some workspace from the list

# Before the change
"Workspace" option was not enabled in the filter dropbox.
<img width="1417" height="868" alt="Screenshot 2025-11-07 at 15 22 06" src="https://github.com/user-attachments/assets/354af5f5-2ec8-47e8-aad4-b8ddf070c8ff" />

# After the change
"Workspace" option is enabled in the filter dropbox.
<img width="1417" height="868" alt="Screenshot 2025-11-07 at 15 21 57" src="https://github.com/user-attachments/assets/ca78af69-da7a-4f5c-854d-9fadb967f281" />

# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [x] Tests for the changes have been added
- [x] README.md is updated if necessary
- [x] Needs additional dependent work
