### PR TITLE
Standardize konflux-pipelines to main branch

### DIFF
--- a/.tekton/patchman-ui-sc-pull-request.yaml
+++ b/.tekton/patchman-ui-sc-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.43.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/main/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: insights-patch-sc

--- a/.tekton/patchman-ui-sc-push.yaml
+++ b/.tekton/patchman-ui-sc-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "security-compliance"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.43.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/main/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: insights-patch-sc


### PR DESCRIPTION
## Summary
- Removed version pinning from konflux-pipelines URL in SC YAML files
- Updated to `main` branch reference

## Changes
Updated all `*-sc-*.yaml` files in `.tekton/` directory

## Reason
Standardizing pipeline references across the platform to use the main branch instead of version-specific URLs.