### PR TITLE
HMS-9989: update template links to remove `/details` suffix

### DIFF
--- a/src/SmartComponents/SystemDetail/InventoryDetail.js
+++ b/src/SmartComponents/SystemDetail/InventoryDetail.js
@@ -93,7 +93,7 @@ const InventoryDetail = () => {
                     {intl.formatMessage(messages.labelsColumnsTemplate)}:
                     <InsightsLink
                       app='content'
-                      to={`/templates/${templateUUID}/details`}
+                      to={`/templates/${templateUUID}`}
                       className='pf-v6-u-ml-xs'
                     >
                       {templateName}

--- a/src/SmartComponents/Systems/SystemsListAssets.js
+++ b/src/SmartComponents/Systems/SystemsListAssets.js
@@ -64,7 +64,7 @@ export const SYSTEMS_LIST_COLUMNS = [
       row.satellite_managed ? (
         <ManagedBySatelliteCell />
       ) : value ? (
-        <InsightsLink app='content' to={{ pathname: `/templates/${row.template_uuid}/details` }}>
+        <InsightsLink app='content' to={{ pathname: `/templates/${row.template_uuid}` }}>
           {value}
         </InsightsLink>
       ) : (
@@ -145,7 +145,7 @@ export const ADVISORY_SYSTEMS_COLUMNS = [
       row.satellite_managed ? (
         <ManagedBySatelliteCell />
       ) : value ? (
-        <InsightsLink app='content' to={{ pathname: `/templates/${row.template_uuid}/details` }}>
+        <InsightsLink app='content' to={{ pathname: `/templates/${row.template_uuid}` }}>
           {value}
         </InsightsLink>
       ) : (
@@ -214,7 +214,7 @@ export const PACKAGE_SYSTEMS_COLUMNS = [
       row.satellite_managed ? (
         <ManagedBySatelliteCell />
       ) : value ? (
-        <InsightsLink app='content' to={{ pathname: `/templates/${row.template_uuid}/details` }}>
+        <InsightsLink app='content' to={{ pathname: `/templates/${row.template_uuid}` }}>
           {value}
         </InsightsLink>
       ) : (


### PR DESCRIPTION
# Description

Corrects the redirection logic for template links to ensure users are sent to the specific Template Detail page rather than the general Templates List page.

The previous URL structure included a `/details` segment which was recently deprecated and removed from the Content app's routing. This PR updates the remaining link logic to match the new simplified URL pattern.

Associated Jira ticket: https://issues.redhat.com/browse/HMS-9989

# Before the change
<img width="1821" height="2071" alt="Screenshot From 2026-01-07 16-32-54" src="https://github.com/user-attachments/assets/67d63557-1e15-406b-a23a-d9be1fb4ef9a" />

# How to test the PR
1. Open a System Detail page that has an associated template
2. Click the template link
3. Verify the user is redirected to `/templates/{templateId}` and the Template Detail page renders correctly

# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [x] Tests for the changes have been added
- [x] README.md is updated if necessary
- [ ] Needs additional dependent work
