### PR TITLE
fix(SystemDetail, Systems): Fix broken link to content templates (HMS-9991)

### DIFF
--- a/src/SmartComponents/SystemDetail/InventoryDetail.js
+++ b/src/SmartComponents/SystemDetail/InventoryDetail.js
@@ -93,7 +93,7 @@ const InventoryDetail = () => {
                     {intl.formatMessage(messages.labelsColumnsTemplate)}:
                     <InsightsLink
                       app='content'
-                      to={`/templates/${templateUUID}/details`}
+                      to={`/templates/${templateUUID}`}
                       className='pf-v6-u-ml-xs'
                     >
                       {templateName}

--- a/src/SmartComponents/Systems/SystemsListAssets.js
+++ b/src/SmartComponents/Systems/SystemsListAssets.js
@@ -64,7 +64,7 @@ export const SYSTEMS_LIST_COLUMNS = [
       row.satellite_managed ? (
         <ManagedBySatelliteCell />
       ) : value ? (
-        <InsightsLink app='content' to={{ pathname: `/templates/${row.template_uuid}/details` }}>
+        <InsightsLink app='content' to={{ pathname: `/templates/${row.template_uuid}` }}>
           {value}
         </InsightsLink>
       ) : (
@@ -145,7 +145,7 @@ export const ADVISORY_SYSTEMS_COLUMNS = [
       row.satellite_managed ? (
         <ManagedBySatelliteCell />
       ) : value ? (
-        <InsightsLink app='content' to={{ pathname: `/templates/${row.template_uuid}/details` }}>
+        <InsightsLink app='content' to={{ pathname: `/templates/${row.template_uuid}` }}>
           {value}
         </InsightsLink>
       ) : (
@@ -214,7 +214,7 @@ export const PACKAGE_SYSTEMS_COLUMNS = [
       row.satellite_managed ? (
         <ManagedBySatelliteCell />
       ) : value ? (
-        <InsightsLink app='content' to={{ pathname: `/templates/${row.template_uuid}/details` }}>
+        <InsightsLink app='content' to={{ pathname: `/templates/${row.template_uuid}` }}>
           {value}
         </InsightsLink>
       ) : (


### PR DESCRIPTION
# Description

Associated Jira ticket: HMS-9991

The` /details` target does not exist and leads users back to the overview of templates. By removing it, the user gets redirected to the default location, which currently is `/systems`.
By not explicitly making it systems, we retain flexibility to change the default page later without having to update these links.

<img width="1237" height="702" alt="image" src="https://github.com/user-attachments/assets/75d584a0-ef4a-4b99-9525-4c1c32372726" />


# How to test the PR

Navigate to the Systems page in Content and select a single system.
Click on the link to the associated content template. You will be redirected to the overview of templates as opposed to the details of the single, selected template.

# Before the change

Users get redirected to the list of templates.

# After the change

Users get to the template in question.

# Dependent work link


# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
