### PR TITLE
chore: change codeowners to a content team subset

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @RedHatInsights/team-interact
+* @RedHatInsights/patchman-ui-reviewers
 
 .tekton/*
 


### PR DESCRIPTION
# Description
Changes the `codeowners` default team to a newly created group of default reviewers.
