### PR TITLE
chore(CI): Add Konflux to commitlint exceptions

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -21,7 +21,7 @@ jobs:
         if: github.event_name == 'push'
         run: npx commitlint --last --verbose
       - name: Validate PR commits with commitlint
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.user.login != 'red-hat-konflux[bot]'
         run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
       - run: npm run ci:verify
       - name: Upload code coverage


### PR DESCRIPTION
Commit lint is being hard on PRs that are opened by konflux bot. Sometime ago we have configured automerge for konflux PRs that are not breaking important pipelines (such as konflux-on-pull-request, npm tests). But currently commit-lint pipeline prevents automerges (see example https://github.com/RedHatInsights/patchman-ui/pull/1471) by being to strict to bot commits

# Description

Associated Jira ticket: # (issue)

Please include a summary of the change, what this fixes/creates/improves.


# How to test the PR

Please include steps to test your PR.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
