### PR TITLE
test(HMS-10052): extend patch pagination tests

### DIFF
--- a/playwright/test-utils/helpers/pagination.ts
+++ b/playwright/test-utils/helpers/pagination.ts
@@ -8,3 +8,38 @@ export async function getTotalCountFromPagination(page: Page): Promise<number> {
   }
   throw new Error(`Could not extract total count from pagination: ${paginationText}`);
 }
+
+export const commonNonInventoryPaginationLocators = (page: Page) => {
+  const currentPageNumber = page.getByRole('spinbutton', { name: 'Current page' });
+  const pageCountLocator = page.locator('.pf-v6-c-pagination__nav-page-select > span').last();
+  const toolbarTopPaginationToggle = page.locator('#options-menu-top-toggle');
+  const toolbarBottomPaginationToggle = page.locator(
+    '#pagination-options-menu-bottom-bottom-toggle',
+  );
+  const topPreviousButton = page
+    .locator('#options-menu-top-pagination')
+    .getByRole('button', { name: 'Go to previous page' });
+  const topNextButton = page
+    .locator('#options-menu-top-pagination')
+    .getByRole('button', { name: 'Go to next page' });
+  const bottomNextButton = page
+    .locator('#pagination-options-menu-bottom-bottom-pagination')
+    .getByRole('button', { name: 'Go to next page' });
+  const bottomPreviousButton = page
+    .locator('#pagination-options-menu-bottom-bottom-pagination')
+    .getByRole('button', { name: 'Go to previous page' });
+  const bottomLastPageButton = page.getByRole('button', { name: 'Go to last page' });
+  const bottomFirstPageButton = page.getByRole('button', { name: 'Go to first page' });
+  return {
+    currentPageNumber,
+    pageCountLocator,
+    toolbarTopPaginationToggle,
+    toolbarBottomPaginationToggle,
+    topPreviousButton,
+    topNextButton,
+    bottomNextButton,
+    bottomPreviousButton,
+    bottomLastPageButton,
+    bottomFirstPageButton,
+  };
+};


### PR DESCRIPTION
# Description

Associated Jira ticket: #HMS-10052

This PR extends the patch pagination tests to include advisories and packages.
Plus refactoring of the systems pagination test.

# How to test/review the PR

- Pagination tests should be green.
- The main idea behind this PR is to test all pagination elements and check the state after each change. Both top and bottom control elements are used for interactions and change.
- The `advisories` and `packages` are similar except for the `targetRows` locator.
- The `systems` page uses different table (`inventory`) which is why the locators and checks are different - it is more static, so there is no need to combine the test with the new ones.
- The `commonNonInventoryLocators` function is a helper to not define the same locators multiple times.