### PR TITLE
feat(RHINENG-23946): Add kessel feature flag for Kessel integration

### DIFF
--- a/src/Utilities/hooks/useFeatureFlag.js
+++ b/src/Utilities/hooks/useFeatureFlag.js
@@ -1,7 +1,12 @@
 import { useFlag, useFlagsStatus } from '@unleash/proxy-client-react';
 
-export default (flag) => {
+const useFeatureFlag = (flag) => {
   const { flagsReady } = useFlagsStatus();
   const isFlagEnabled = useFlag(flag);
   return flagsReady ? isFlagEnabled : false;
 };
+
+export default useFeatureFlag;
+
+export const useKesselFeatureFlag = () =>
+  useFeatureFlag('patch-frontend.kessel-enabled');


### PR DESCRIPTION
Add useKesselFeatureFlag hook to gate Kessel authorization integration behind the patch-frontend.kessel-enabled feature flag.

This is part of the Kessel integration effort for patchman-ui. The feature flag allows us to incrementally roll out Kessel-based access checks without impacting existing functionality.

Ref: https://issues.redhat.com/browse/RHINENG-23946

# Description

Associated Jira ticket: # (issue)

Please include a summary of the change, what this fixes/creates/improves.


# How to test the PR

Please include steps to test your PR.

# Before the change


# After the change


# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
