### PR TITLE
fix: lock to major version for react-redux

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,12 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "react-dom"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "react-redux"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "redux"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react-redux"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "htmlparser2"
         update-types: ["version-update:semver-major"]
       - dependency-name: "jest"

--- a/package.json
+++ b/package.json
@@ -128,5 +128,9 @@
   ],
   "insights": {
     "appname": "patch"
+  },
+  "overrides": {
+    "react-redux": "^7.2.9",
+    "redux": "^4.2.1"
   }
 }


### PR DESCRIPTION
# Description

lock to major version for react & react-redux
overides to set min version in package.json

