### PR TITLE
chore: update readme and rules for agents

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,1 @@
+docs/rules/testing.md

--- a/.claude/rules/typescript.md
+++ b/.claude/rules/typescript.md
@@ -1,0 +1,1 @@
+docs/rules/typescript.md

--- a/.cursor/rules/testing.md
+++ b/.cursor/rules/testing.md
@@ -1,0 +1,1 @@
+docs/rules/testing.md

--- a/.cursor/rules/typescript.md
+++ b/.cursor/rules/typescript.md
@@ -1,0 +1,1 @@
+docs/rules/typescript.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS.md
+
+Project: Frontend for Red Hat's Patch service (React + JavaScript + TypeScript + PatternFly React)
+
+Backend: https://github.com/RedHatInsights/patchman-engine
+
+## Dev environment setup
+- Use `nvm use` to match node version in `.nvmrc`
+- Run [script to patch your
+   `/etc/hosts`](https://github.com/RedHatInsights/insights-proxy/blob/master/scripts/patch-etc-hosts.sh)
+- Always be connected to Red Hat VPN
+
+## Commit guidelines
+- Follow Conventional Commits format: `type(scope): description`
+- Common types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
+- Explain the "why" in the commit message, not the "what".
+- Keep commit message body no longer than 72 characters and header no longer than 50 characters

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://img.shields.io/github/actions/workflow/status/RedhatInsights/patchman-ui/test.yml?branch=master)](https://github.com/RedHatInsights/patchman-ui/actions/workflows/test.yml)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/RedhatInsights/patchman-ui/sentry.yml?branch=master)](https://github.com/RedHatInsights/patchman-ui/actions/workflows/sentry.yml)
 [![GitHub release](https://img.shields.io/github/v/release/RedHatInsights/patchman-ui.svg)](https://github.com/RedHatInsights/patchman-ui/releases/latest)
 [![codecov](https://codecov.io/gh/RedHatInsights/patchman-ui/branch/master/graph/badge.svg)](https://codecov.io/gh/RedHatInsights/patchman-ui)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
@@ -8,6 +8,22 @@
 Patch is one of the applications for console.redhat.com. It allows users to display and manage available patches for
 their registered systems. This repository contains source code for the frontend part of the application which uses the
 REST API available from [Patchman Engine](https://github.com/RedHatInsights/patchman-engine).
+
+<!--toc:start-->
+
+- [First time setup](#first-time-setup)
+- [Running locally](#running-locally)
+- [Testing](#testing)
+  - [Unit tests: Jest](#unit-tests-jest)
+  - [E2E (UI & Integration) tests: Playwright](#e2e-ui--integration-tests-playwright)
+    - [First time setup](#first-time-setup-1)
+    - [Running UI tests](#running-ui-tests)
+    - [Running Integration tests](#running-integration-tests)
+- [Deploying](#deploying)
+- [Design System](#design-system)
+- [Insights Components](#insights-components)
+- [AI Coding Assistants](#ai-coding-assistants)
+<!--toc:end-->
 
 ## First time setup
 
@@ -115,3 +131,12 @@ This app imports components
 from [Insights Front-end Components library](https://github.com/RedHatInsights/frontend-components). ESI tags are used
 to import [Insights Chrome](https://github.com/RedHatInsights/insights-chrome) which takes care of the header, sidebar,
 and footer.
+
+## AI Coding Assistants
+
+This project includes guidance for AI coding assistants (Claude Code, Cursor, etc.):
+
+- **`AGENTS.md`** - Main entry point with project context, setup requirements, and workflows
+- **`docs/rules/`** - Topic-specific detailed rules (testing, etc.)
+
+**For maintainers**: See [docs/rules/README.md](docs/rules/README.md) for how to add or modify AI assistant rules.

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -1,0 +1,34 @@
+# AI Assistant Rules
+
+Topic-specific rules for AI coding assistants. Files here are automatically picked up by Claude Code and Cursor via symlinks in `.claude/rules/` and `.cursor/rules/`.
+
+## Current Rules
+
+- **[testing.md](testing.md)**: Playwright testing conventions and best practices
+- **[typescript.md](typescript.md)**: JavaScript to TypeScript migration guidance
+
+## Adding New Rules
+
+1. Create `docs/rules/topic-name.md` with your rules
+2. Create symlinks:
+   ```bash
+   ln -s ../../docs/rules/topic-name.md .claude/rules/topic-name.md
+   ln -s ../../docs/rules/topic-name.md .cursor/rules/topic-name.md
+   ```
+3. Update the "Current Rules" list above
+
+**Example:**
+
+```bash
+# Create the rule file
+cat > docs/rules/react.md << 'EOF'
+# React Component Rules
+
+- Use functional components with hooks
+- Keep components small and focused
+EOF
+
+# Create symlinks
+ln -s ../../docs/rules/react.md .claude/rules/react.md
+ln -s ../../docs/rules/react.md .cursor/rules/react.md
+```

--- a/docs/rules/testing.md
+++ b/docs/rules/testing.md
@@ -1,9 +1,4 @@
----
-globs: **/*.spec.ts
-alwaysApply: false
----
-
-# Playwright Test Rules
+# Playwright Testing Rules
 
 Apply these rules to TypeScript test files (`**/*spec.ts`) in the `playwright` folder.
 

--- a/docs/rules/typescript.md
+++ b/docs/rules/typescript.md
@@ -1,0 +1,36 @@
+# TypeScript Rules
+
+Apply these rules when migrating files from JavaScript to TypeScript
+
+## General Guidelines
+
+- Do not introduce unrelated logic changes while adding types
+- Favor type safety over convenience (`any` is a last resort)
+- Use existing project patterns and types when available
+- Prefer inference when it is clear and sufficient
+
+## Typing Strategy
+
+- Use existing types/interfaces from the codebase
+- Define minimal types/interfaces when needed
+- Use `unknown` over `any` when type is unclear
+- Use `any` only as a temporary fallback
+- Organize types in dedicated files (`types.ts`) or alongside implementations
+- Create a central `types.ts` file or a `src/types` directory for shared types
+
+## React & Redux
+
+- Type props explicitly using `type` or `interface`
+- Use typed hooks (`useAppDispatch`, `useAppSelector`) instead of raw Redux hooks
+- Type event handlers (`React.ChangeEvent`, etc.)
+
+## State & Data
+
+- Avoid initializing empty arrays/objects without types (`useState<Type[]>([])`)
+- Prevent `never[]` by explicitly typing initial state
+- Use union types for nullable/optional values (`string | null`)
+
+## API
+
+- Type all API requests and responses
+- If API request/response types are unclear, ask for the API spec instead of guessing


### PR DESCRIPTION
# Description

- Adds initial setup for agents with the same config from [content-sources-frontend](https://github.com/content-services/content-sources-frontend/pull/963). Moves the existing Playwright rule so it's auto-loaded by  both Claude and Cursor
- Adds a rule and some initial guidelines to help agents help us with migrating to TypeScript
- Updates README

# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
