### PR TITLE
chore: add analytics API keys to frontend deploy config

### DIFF
--- a/deploy/frontend.yml
+++ b/deploy/frontend.yml
@@ -22,7 +22,14 @@ objects:
           - /apps/patch
       image: ${IMAGE}:${IMAGE_TAG}
       module:
+        analytics:
+          APIKey: apRCg9V6oMXCcnTingqRYW6m1er4hkCW
+          APIKeyDev: aMINBssUhXV1okzk7ZBaqwdTgtA0ySpg
         manifestLocation: /apps/patch/fed-mods.json
+        config:
+          supportCaseData:
+            product: Red Hat Insights
+            version: Patch
         modules:
           - id: patch
             module: ./RootApp


### PR DESCRIPTION
## Summary
- Adds the `analytics` block with `APIKey` and `APIKeyDev` to the `module` section in `deploy/frontend.yml`
- Aligns with the pattern used by other frontends (inventory, advisor, tasks, ocp-advisor)
- Fixes RHINENG-25987
## Test plan
- [ ] Verify the YAML is valid and the deploy CRD parses correctly
- [ ] Confirm analytics events are sent in stage with the correct API key