### PR TITLE
chore: increase title length to 70

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    'header-max-length': [2, 'always', 50], // Enforce 50 character max for commit title
+    'header-max-length': [2, 'always', 70], // Enforce 70 character max for commit title
     'body-max-line-length': [2, 'always', 72], // Wrap body lines at 72 characters
     'subject-case': [0, 'always'],
     'footer-max-length': [0, 'always'],


### PR DESCRIPTION
I noticed most of the commits here fail the test for title length, and it gets ignored and merged anyway. Let's increase it to a number that might be more convenient to enforce.
