### PR TITLE
fix: handle empty relations and reduce test flakiness

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -29,10 +29,10 @@ export default defineConfig({
     launchOptions: {
       args: ['--use-fake-device-for-media-stream'],
     },
-    ...(process.env.TOKEN
+    ...(process.env.ADMIN_TOKEN
       ? {
           extraHTTPHeaders: {
-            Authorization: process.env.TOKEN,
+            Authorization: process.env.ADMIN_TOKEN,
           },
         }
       : {}),

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -50,25 +50,44 @@ export default defineConfig({
     video: 'on',
   },
   projects: [
-    { name: 'setup', testMatch: /.*\.setup\.ts/, use: { trace: 'off' } },
-    process.env.INTEGRATION
-      ? {
-          name: 'Integration',
-          use: {
-            ...devices['Desktop Chrome'],
-            storageState: '.auth/ADMIN_TOKEN.json',
+    { name: 'setup', testMatch: /auth\.setup\.ts/, use: { trace: 'off' } },
+    ...(process.env.INTEGRATION
+      ? [
+          {
+            name: 'Integration',
+            use: {
+              ...devices['Desktop Chrome'],
+              storageState: '.auth/ADMIN_TOKEN.json',
+            },
+            testDir: './playwright/Integration/',
+            dependencies: ['setup'],
           },
-          testDir: './playwright/Integration/',
-          dependencies: ['setup'],
-        }
-      : {
-          name: 'UI',
-          use: {
-            ...devices['Desktop Chrome'],
-            storageState: '.auth/ADMIN_TOKEN.json',
+        ]
+      : [
+          {
+            name: 'UI-default-user',
+            use: {
+              ...devices['Desktop Chrome'],
+              storageState: '.auth/ADMIN_TOKEN.json',
+            },
+            testDir: './playwright/UI/',
+            testIgnore: ['**/AdvisoriesTests.spec.ts'],
+            dependencies: ['setup'],
           },
-          testDir: './playwright/UI/',
-          dependencies: ['setup'],
-        },
+          {
+            name: 'UI-advisory-remediation-user',
+            use: {
+              ...devices['Desktop Chrome'],
+              storageState: '.auth/ADVISORY_REMEDIATION_TOKEN.json',
+              extraHTTPHeaders: process.env.ADVISORY_REMEDIATION_TOKEN
+                ? { Authorization: process.env.ADVISORY_REMEDIATION_TOKEN }
+                : {},
+            },
+            testDir: './playwright/UI/',
+            testMatch: ['**/AdvisoriesTests.spec.ts'],
+            // Run after all default-user UI tests to prevent auth state conflicts
+            dependencies: ['setup', 'UI-default-user'],
+          },
+        ]),
   ],
 });

--- a/playwright/UI/AdvisoriesTests.spec.ts
+++ b/playwright/UI/AdvisoriesTests.spec.ts
@@ -9,12 +9,8 @@ import {
 import { cleanupRemediationPlan } from 'test-utils/helpers/cleaners';
 
 test.describe('Advisories Tests', () => {
-  test.use({
-    storageState: '.auth/ADVISORY_REMEDIATION_TOKEN.json',
-    extraHTTPHeaders: process.env.ADVISORY_REMEDIATION_TOKEN
-      ? { Authorization: process.env.ADVISORY_REMEDIATION_TOKEN }
-      : {},
-  });
+  // Disable retries for this test, systems are not deleted immediately in patch so second attempt will likely fail
+  test.describe.configure({ retries: 0 });
 
   test('Create a new remediation plan', async ({ page, request, systems, cleanup }) => {
     const system = await systems.add(

--- a/playwright/test-utils/helpers/auth.ts
+++ b/playwright/test-utils/helpers/auth.ts
@@ -74,7 +74,6 @@ export const storeStorageStateAndToken = async (page: Page, tokenEnvVar: string)
     .context()
     .storageState({ path: path.join(__dirname, '../../../.auth', storageFile) });
   const token = cookies.find((cookie) => cookie.name === 'cs_jwt')?.value;
-  process.env.TOKEN = `Bearer ${token}`;
   process.env[tokenEnvVar] = `Bearer ${token}`;
 };
 

--- a/src/Utilities/hooks/useKesselWorkspaceIds.js
+++ b/src/Utilities/hooks/useKesselWorkspaceIds.js
@@ -55,7 +55,7 @@ export const useKesselWorkspaceIds = (enabled = true) => {
         setError(true);
       })
       .finally(() => setIsLoading(false));
-  }, [baseUrl]);
+  }, [baseUrl, enabled]);
 
   return {
     workspaceIds,

--- a/src/Utilities/hooks/usePermissionCheck.js
+++ b/src/Utilities/hooks/usePermissionCheck.js
@@ -45,9 +45,14 @@ const useKesselPermission = (requiredPermissions, enabled = true) => {
     return { hasAccess: false, isLoading: false };
   }
 
-  const hasAccess = Array.isArray(data)
-    ? data.some((check) => check.allowed)
-    : (data?.allowed ?? false);
+  if (data?.length === 0) {
+    return { hasAccess: false, isLoading: true };
+  }
+
+  const hasAccess =
+    Array.isArray(data) && data.length > 0
+      ? data.some((check) => check.allowed)
+      : (data?.allowed ?? false);
 
   return { hasAccess, isLoading: loading };
 };


### PR DESCRIPTION
# Description

- Adjusts permission check to wait for relations to load fully before granting/denying access
- Updates playwright UI test config and AdvisoriesTests to reduce flakiness 
  - First issue: When multiple users fetch workspaces at the same time, this seems to cause auth leakage across sessions so workspaces for the wrong user might be fetched to determine access. To prevent this, this PR isolates UI test projects by user and runs each project serially
  - Second issue: Since AdvisoriesTests creates a remediation plan for an advisory, any systems the advisory is associated with are included in the request to remediations. If a system in the request has already been deleted in inventory, it will still be in patch for around 10 minutes. Retrying will almost always result in this kind of failure, so this PR disables retries for this test
 
# How to test the PR

- The "not authorized" page shouldn't flash briefly on initial app load or refresh
- There shouldn't be any test failures related to rejected access

# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
