### PR TITLE
RHINENG-25703: dark mode support, reloading fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@patternfly/react-core": "^6.4.3",
     "@patternfly/react-icons": "^6.3.1",
     "@patternfly/react-table": "^6.4.3",
+    "@patternfly/react-styles": "^6.4.0",
     "@project-kessel/react-kessel-access-check": "^0.5.0",
     "@redhat-cloud-services/frontend-components": "^7.4.2",
     "@redhat-cloud-services/frontend-components-notifications": "^6.6.2",

--- a/src/PresentationalComponents/TableView/TableView.js
+++ b/src/PresentationalComponents/TableView/TableView.js
@@ -87,7 +87,7 @@ const TableView = ({
           <PrimaryToolbar
             pagination={
               isLoading ? (
-                <Skeleton fontSize='xl' width='200px' style={{ margin: 10 }} />
+                <Skeleton fontSize='xl' width='200px' />
               ) : (
                 {
                   itemCount: metadata.total_items,

--- a/src/SmartComponents/Advisories/Advisories.js
+++ b/src/SmartComponents/Advisories/Advisories.js
@@ -1,5 +1,5 @@
 import { Main } from '@redhat-cloud-services/frontend-components/Main';
-import React, { Fragment, useEffect } from 'react';
+import React, { Fragment, useEffect, useLayoutEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import messages from '../../Messages';
 import publishDateFilter from '../../PresentationalComponents/Filters/PublishDateFilter';
@@ -69,7 +69,7 @@ const Advisories = () => {
 
   const [isRemediationLoading, setRemediationLoading] = React.useState(false);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (firstMount) {
       apply(decodeQueryparams('?' + searchParams.toString()));
       setFirstMount(false);

--- a/src/SmartComponents/Packages/Packages.js
+++ b/src/SmartComponents/Packages/Packages.js
@@ -1,5 +1,5 @@
 import { Main } from '@redhat-cloud-services/frontend-components/Main';
-import React, { useEffect } from 'react';
+import React, { useEffect, useLayoutEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import messages from '../../Messages';
 import packagesListStatusFilter from '../../PresentationalComponents/Filters/PackagesListStatusFilter';
@@ -17,7 +17,6 @@ import {
   usePerPageSelect,
   useSetPage,
   useSortColumn,
-  useDeepCompareEffect,
 } from '../../Utilities/hooks';
 import { intl } from '../../Utilities/IntlProvider';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
@@ -39,7 +38,7 @@ const Packages = () => {
   const metadata = useSelector(({ PackagesListStore }) => PackagesListStore.metadata);
   const queryParams = useSelector(({ PackagesListStore }) => PackagesListStore.queryParams);
 
-  useDeepCompareEffect(() => {
+  useLayoutEffect(() => {
     if (firstMount) {
       apply(decodeQueryparams('?' + searchParams.toString()));
       setFirstMount(false);
@@ -47,7 +46,7 @@ const Packages = () => {
       setSearchParams(encodeURLParams(queryParams));
       dispatch(fetchPackagesAction(queryParams));
     }
-  }, [queryParams, firstMount]);
+  }, [JSON.stringify(queryParams), firstMount]);
 
   function apply(params) {
     dispatch(changePackagesListParams(params));

--- a/src/SmartComponents/SystemDetail/SystemDetail.js
+++ b/src/SmartComponents/SystemDetail/SystemDetail.js
@@ -3,11 +3,11 @@ import { useLocation } from 'react-router-dom';
 import { Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 import SystemAdvisories from '../SystemAdvisories/SystemAdvisories';
 import SystemPackages from '../SystemPackages/SystemPackages';
-import './SystemDetail.scss';
 import { intl } from '../../Utilities/IntlProvider';
 import messages from '../../Messages';
 import { NotConnected } from '@redhat-cloud-services/frontend-components/NotConnected';
 import propTypes from 'prop-types';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
 
 const SystemDetail = ({ isInventoryApp, inventoryId, shouldRefresh }) => {
   const { state } = useLocation();
@@ -26,7 +26,7 @@ const SystemDetail = ({ isInventoryApp, inventoryId, shouldRefresh }) => {
 
   return (
     (!areTabsHidden && (
-      <Tabs activeKey={activeTabKey} onSelect={onTabSelect} className='patchTabSelect' isHidden>
+      <Tabs activeKey={activeTabKey} onSelect={onTabSelect} isHidden isSubtab={isInventoryApp}>
         <Tab
           eventKey={0}
           title={<TabTitleText>{intl.formatMessage(messages.titlesAdvisories)}</TabTitleText>}
@@ -34,11 +34,13 @@ const SystemDetail = ({ isInventoryApp, inventoryId, shouldRefresh }) => {
           data-ouia-component-id='system-advisories-tab'
           id='system-advisories-tab'
         >
-          <SystemAdvisories
-            handleNoSystemData={handleNoSystemData}
-            inventoryId={inventoryId}
-            shouldRefresh={shouldRefresh}
-          />
+          <div className={spacing.mtMd}>
+            <SystemAdvisories
+              handleNoSystemData={handleNoSystemData}
+              inventoryId={inventoryId}
+              shouldRefresh={shouldRefresh}
+            />
+          </div>
         </Tab>
         <Tab
           eventKey={1}
@@ -47,11 +49,13 @@ const SystemDetail = ({ isInventoryApp, inventoryId, shouldRefresh }) => {
           data-ouia-component-id='system-packages-tab'
           id='system-packages-tab'
         >
-          <SystemPackages
-            handleNoSystemData={handleNoSystemData}
-            inventoryId={inventoryId}
-            shouldRefresh={shouldRefresh}
-          />
+          <div className={spacing.mtMd}>
+            <SystemPackages
+              handleNoSystemData={handleNoSystemData}
+              inventoryId={inventoryId}
+              shouldRefresh={shouldRefresh}
+            />
+          </div>
         </Tab>
       </Tabs>
     )) || <NotConnected />

--- a/src/SmartComponents/SystemDetail/SystemDetail.scss
+++ b/src/SmartComponents/SystemDetail/SystemDetail.scss
@@ -1,6 +1,0 @@
-.patchTabSelect {
-  background-color: white;
-  .pf-v6-c-tabs__item-text {
-    padding: 8px 0px 8px 0px;
-  }
-}

--- a/src/SmartComponents/SystemDetail/__snapshots__/SystemDetail.test.js.snap
+++ b/src/SmartComponents/SystemDetail/__snapshots__/SystemDetail.test.js.snap
@@ -3,7 +3,7 @@
 exports[`SystemDetail.js Should match the snapshot when Package tab is active by default 1`] = `
 <DocumentFragment>
   <div
-    class="pf-v6-c-tabs pf-m-animate-current pf-m-initializing-accent patchTabSelect"
+    class="pf-v6-c-tabs pf-m-animate-current pf-m-initializing-accent"
     data-ouia-component-id="OUIA-Generated-Tabs-2"
     data-ouia-component-type="PF6/Tabs"
     data-ouia-safe="true"
@@ -70,329 +70,60 @@ exports[`SystemDetail.js Should match the snapshot when Package tab is active by
     tabindex="0"
   >
     <div
-      class="pf-v6-c-toolbar  ins-c-primary-toolbar"
-      data-ouia-component-id="PrimaryToolbar"
-      data-ouia-component-type="PF6/Toolbar"
-      data-ouia-safe="true"
-      id="ins-primary-data-toolbar"
+      class="pf-v6-u-mt-md"
     >
       <div
-        class="pf-v6-c-toolbar__content"
+        class="pf-v6-c-toolbar  ins-c-primary-toolbar"
+        data-ouia-component-id="PrimaryToolbar"
+        data-ouia-component-type="PF6/Toolbar"
+        data-ouia-safe="true"
+        id="ins-primary-data-toolbar"
       >
         <div
-          class="pf-v6-c-toolbar__content-section pf-m-align-items-center"
+          class="pf-v6-c-toolbar__content"
         >
           <div
-            class="pf-v6-c-toolbar__group pf-m-filter-group ins-c-primary-toolbar__group-filter pf-m-spacer-md pf-m-space-items-lg"
+            class="pf-v6-c-toolbar__content-section pf-m-align-items-center"
           >
             <div
-              class="pf-v6-c-toolbar__item"
-            >
-              <button
-                aria-expanded="false"
-                aria-label="Select"
-                class="pf-v6-c-menu-toggle"
-                data-ouia-component-id="BulkSelect"
-                data-ouia-component-type="PF6/MenuToggle"
-                data-ouia-safe="true"
-                type="button"
-              >
-                <span
-                  class="pf-v6-c-menu-toggle__text"
-                >
-                  <label
-                    class="pf-v6-c-check"
-                  >
-                    <input
-                      aria-invalid="false"
-                      aria-label="Select all"
-                      class="pf-v6-c-check__input"
-                      data-ouia-component-id="BulkSelectCheckbox"
-                      data-ouia-component-type="PF6/MenuToggleCheckbox"
-                      data-ouia-safe="true"
-                      name="toggle-checkbox"
-                      type="checkbox"
-                    />
-                    <span
-                      aria-hidden="true"
-                      class="pf-v6-c-check__label"
-                      id="toggle-checkbox"
-                    >
-                      1 selected
-                    </span>
-                  </label>
-                </span>
-                <span
-                  class="pf-v6-c-menu-toggle__controls"
-                >
-                  <span
-                    class="pf-v6-c-menu-toggle__toggle-icon"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="pf-v6-svg"
-                      fill="currentColor"
-                      height="1em"
-                      role="img"
-                      viewBox="0 0 320 512"
-                      width="1em"
-                    >
-                      <path
-                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                      />
-                    </svg>
-                  </span>
-                </span>
-              </button>
-            </div>
-            <div
-              class="pf-v6-c-toolbar__item ins-c-primary-toolbar__filter"
+              class="pf-v6-c-toolbar__group pf-m-filter-group ins-c-primary-toolbar__group-filter pf-m-spacer-md pf-m-space-items-lg"
             >
               <div
-                class="pf-v6-l-split ins-c-conditional-filter ins-c-conditional-filter__split-items-space"
-              >
-                <div
-                  class="pf-v6-l-split__item"
-                >
-                  <button
-                    aria-expanded="false"
-                    aria-label="Conditional filter toggle"
-                    class="pf-v6-c-menu-toggle ins-c-conditional-filter__group"
-                    data-ouia-component-id="ConditionalFilterToggle"
-                    data-ouia-component-type="PF6/MenuToggle"
-                    data-ouia-safe="true"
-                    type="button"
-                  >
-                    <span
-                      class="pf-v6-c-menu-toggle__text"
-                    >
-                      <span
-                        class="pf-v6-c-icon pf-m-md"
-                      >
-                        <span
-                          class="pf-v6-c-icon__content"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="pf-v6-svg"
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            viewBox="0 0 512 512"
-                            width="1em"
-                          >
-                            <path
-                              d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                      <span
-                        class="ins-c-conditional-filter__value-selector"
-                      >
-                        Advisory
-                      </span>
-                    </span>
-                    <span
-                      class="pf-v6-c-menu-toggle__controls"
-                    >
-                      <span
-                        class="pf-v6-c-menu-toggle__toggle-icon"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v6-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 320 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                  </button>
-                </div>
-                <div
-                  class="pf-v6-l-split__item pf-m-fill"
-                  data-ouia-component-id="ConditionalFilter"
-                >
-                  <span
-                    class="pf-v6-c-form-control pf-m-icon ins-c-conditional-filter"
-                  >
-                    <input
-                      aria-invalid="false"
-                      aria-label="search-field"
-                      data-ouia-component-id="ConditionalFilter"
-                      data-ouia-component-type="PF6/TextInput"
-                      data-ouia-safe="true"
-                      placeholder="Filter by name or synopsis"
-                      type="text"
-                      value=""
-                      widget-type="InsightsInput"
-                    />
-                    <span
-                      class="pf-v6-c-form-control__utilities"
-                    >
-                      <span
-                        class="pf-v6-c-form-control__icon"
-                      >
-                        <span
-                          class="pf-v6-c-icon pf-m-md ins-c-search-icon"
-                        >
-                          <span
-                            class="pf-v6-c-icon__content"
-                          >
-                            <svg
-                              aria-hidden="true"
-                              class="pf-v6-svg"
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              viewBox="0 0 512 512"
-                              width="1em"
-                            >
-                              <path
-                                d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
-                              />
-                            </svg>
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="pf-v6-c-toolbar__item ins-c-primary-toolbar__first-action pf-m-spacer-sm"
-          >
-            <div
-              buttonprops="[object Object]"
-              fallback="[object Object]"
-              module="./RemediationButton"
-              scope="remediations"
-            >
-              AsyncComponent
-            </div>
-          </div>
-          <div
-            class="pf-v6-c-toolbar__item pf-m-spacer-sm"
-          >
-            <div
-              style="display: contents;"
-            >
-              <button
-                aria-expanded="false"
-                aria-label="Export"
-                class="pf-v6-c-menu-toggle pf-m-plain"
-                data-ouia-component-id="OUIA-Generated-MenuToggle-plain-5"
-                data-ouia-component-type="PF6/MenuToggle"
-                data-ouia-safe="true"
-                type="button"
-              >
-                <span
-                  class="pf-v6-c-menu-toggle__icon"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="pf-v6-svg"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 1024 1024"
-                    width="1em"
-                  >
-                    <path
-                      d="M975.8,636.9 L870.9,741.8 L457.9,328.6 C452.1,322.8 445.4,319.9 437.9,319.9 C430.4,319.9 423.7,322.8 417.9,328.6 L328.8,417.7 C323,423.5 320.1,430.2 320.1,437.7 C320.1,445.2 323,451.9 328.8,457.7 L742,870.7 L636.9,975.8 C610.5,1002.2 619.4,1024 656.8,1024 L956,1024 C1014.5,1024 1024,1013.7 1024,955.9 L1024,656.7 C1023.9,619.4 1002.2,610.5 975.8,636.9 Z M128,128 L896,128 L896,361.7 C896.007942,370.182681 899.389907,378.313788 905.4,384.3 L996.7,475.6 C1006.8,485.7 1024,478.5 1024,464.3 L1024,22.7 C1024,16.1 1021.9,10.7 1017.6,6.4 C1013.3,2.1 1007.9,0 1001.3,0 L22.7,0 C16.1,0 10.7,2.1 6.4,6.4 C2.1,10.7 0,16.1 0,22.7 L0,1001.3 C0,1007.9 2.1,1013.3 6.4,1017.6 C10.7,1021.9 16.1,1024 22.7,1024 L463.4,1024 C469.862884,1023.98894 475.684489,1020.0908 478.156232,1014.11925 C480.627976,1008.14769 479.264428,1001.27548 474.7,996.7 L383.4,905.4 C377.413788,899.389907 369.282681,896.007942 360.8,896 L128,896 L128,128 Z"
-                    />
-                  </svg>
-                </span>
-              </button>
-            </div>
-          </div>
-          <div
-            class="pf-v6-c-toolbar__item  ins-c-primary-toolbar__actions pf-m-spacer-sm"
-          >
-            <button
-              aria-expanded="false"
-              aria-label="kebab dropdown toggle"
-              class="pf-v6-c-menu-toggle pf-m-plain"
-              data-ouia-component-id="BulkActionsToggle"
-              data-ouia-component-type="PF6/MenuToggle"
-              data-ouia-safe="true"
-              type="button"
-            >
-              <span
-                class="pf-v6-c-menu-toggle__icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="pf-v6-svg"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 192 512"
-                  width="1em"
-                >
-                  <path
-                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                  />
-                </svg>
-              </span>
-            </button>
-          </div>
-          <div
-            class="pf-v6-c-toolbar__item ins-c-primary-toolbar__pagination"
-          >
-            <div
-              class="pf-v6-c-pagination"
-              data-ouia-component-id="top-system-advisories-pagination"
-              data-ouia-component-type="PF6/Pagination"
-              data-ouia-safe="true"
-              id="options-menu-top-pagination"
-              style="--pf-v6-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
-            >
-              <div
-                class="pf-v6-c-pagination__total-items"
-              >
-                <b>
-                  1 - 10
-                </b>
-                 of 
-                <b>
-                  10
-                </b>
-                 
-              </div>
-              <div
-                class="pf-v6-c-pagination__page-menu"
+                class="pf-v6-c-toolbar__item"
               >
                 <button
                   aria-expanded="false"
-                  aria-haspopup="listbox"
-                  class="pf-v6-c-menu-toggle pf-m-plain pf-m-text"
-                  data-ouia-component-id="OUIA-Generated-MenuToggle-plainText-3"
+                  aria-label="Select"
+                  class="pf-v6-c-menu-toggle"
+                  data-ouia-component-id="BulkSelect"
                   data-ouia-component-type="PF6/MenuToggle"
                   data-ouia-safe="true"
-                  id="options-menu-top-toggle"
                   type="button"
                 >
                   <span
                     class="pf-v6-c-menu-toggle__text"
                   >
-                    <b>
-                      1 - 10
-                    </b>
-                     of 
-                    <b>
-                      10
-                    </b>
-                     
+                    <label
+                      class="pf-v6-c-check"
+                    >
+                      <input
+                        aria-invalid="false"
+                        aria-label="Select all"
+                        class="pf-v6-c-check__input"
+                        data-ouia-component-id="BulkSelectCheckbox"
+                        data-ouia-component-type="PF6/MenuToggleCheckbox"
+                        data-ouia-safe="true"
+                        name="toggle-checkbox"
+                        type="checkbox"
+                      />
+                      <span
+                        aria-hidden="true"
+                        class="pf-v6-c-check__label"
+                        id="toggle-checkbox"
+                      >
+                        1 selected
+                      </span>
+                    </label>
                   </span>
                   <span
                     class="pf-v6-c-menu-toggle__controls"
@@ -417,660 +148,32 @@ exports[`SystemDetail.js Should match the snapshot when Package tab is active by
                   </span>
                 </button>
               </div>
-              <nav
-                aria-label="Pagination"
-                class="pf-v6-c-pagination__nav"
+              <div
+                class="pf-v6-c-toolbar__item ins-c-primary-toolbar__filter"
               >
                 <div
-                  class="pf-v6-c-pagination__nav-control"
-                >
-                  <button
-                    aria-label="Go to previous page"
-                    class="pf-v6-c-button pf-m-plain"
-                    data-action="previous"
-                    data-ouia-component-id="OUIA-Generated-Button-plain-8"
-                    data-ouia-component-type="PF6/Button"
-                    data-ouia-safe="true"
-                    disabled=""
-                    type="button"
-                  >
-                    <span
-                      class="pf-v6-c-button__icon"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="pf-v6-svg"
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        viewBox="0 0 256 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                        />
-                      </svg>
-                    </span>
-                  </button>
-                </div>
-                <div
-                  class="pf-v6-c-pagination__nav-control"
-                >
-                  <button
-                    aria-label="Go to next page"
-                    class="pf-v6-c-button pf-m-plain"
-                    data-action="next"
-                    data-ouia-component-id="OUIA-Generated-Button-plain-9"
-                    data-ouia-component-type="PF6/Button"
-                    data-ouia-safe="true"
-                    disabled=""
-                    type="button"
-                  >
-                    <span
-                      class="pf-v6-c-button__icon"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="pf-v6-svg"
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        viewBox="0 0 256 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                        />
-                      </svg>
-                    </span>
-                  </button>
-                </div>
-              </nav>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="pf-v6-c-toolbar__content pf-m-hidden"
-        hidden=""
-      >
-        <div
-          class="pf-v6-c-toolbar__group"
-        />
-      </div>
-    </div>
-    <table
-      aria-label="Patch table view"
-      class="pf-v6-c-table pf-m-grid-md pf-m-compact pf-m-sticky-header"
-      data-ouia-component-id="system-advisories-table"
-      data-ouia-component-type="PF6/Table"
-      data-ouia-safe="true"
-      role="grid"
-    >
-      <thead
-        class="pf-v6-c-table__thead"
-      >
-        <tr
-          class="pf-v6-c-table__tr"
-          data-ouia-component-id="OUIA-Generated-TableRow-10"
-          data-ouia-component-type="PF6/TableRow"
-          data-ouia-safe="true"
-        >
-          <th
-            class="pf-v6-c-table__th"
-            data-key="0"
-            data-label=""
-            scope=""
-            tabindex="-1"
-          />
-          <th
-            class="pf-v6-c-table__th"
-            data-key="1"
-            data-label=""
-            scope=""
-            tabindex="-1"
-          />
-          <th
-            class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-15"
-            data-key="2"
-            data-label="Name"
-            scope="col"
-            tabindex="-1"
-          >
-            <button
-              class="pf-v6-c-table__button"
-              type="button"
-            >
-              <div
-                class="pf-v6-c-table__button-content"
-              >
-                <span
-                  class="pf-v6-c-table__text"
-                >
-                  Name
-                </span>
-                <span
-                  class="pf-v6-c-table__sort-indicator"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="pf-v6-svg"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 256 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                    />
-                  </svg>
-                </span>
-              </div>
-            </button>
-          </th>
-          <th
-            class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-35"
-            data-key="3"
-            data-label="Synopsis"
-            scope="col"
-            tabindex="-1"
-          >
-            <button
-              class="pf-v6-c-table__button"
-              type="button"
-            >
-              <div
-                class="pf-v6-c-table__button-content"
-              >
-                <span
-                  class="pf-v6-c-table__text"
-                >
-                  Synopsis
-                </span>
-                <span
-                  class="pf-v6-c-table__sort-indicator"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="pf-v6-svg"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 256 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                    />
-                  </svg>
-                </span>
-              </div>
-            </button>
-          </th>
-          <th
-            class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-10"
-            data-key="4"
-            data-label="Status"
-            scope="col"
-            tabindex="-1"
-          >
-            <button
-              class="pf-v6-c-table__button"
-              type="button"
-            >
-              <div
-                class="pf-v6-c-table__button-content"
-              >
-                <span
-                  class="pf-v6-c-table__text"
-                >
-                  Status
-                </span>
-                <span
-                  class="pf-v6-c-table__sort-indicator"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="pf-v6-svg"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 256 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                    />
-                  </svg>
-                </span>
-              </div>
-            </button>
-          </th>
-          <th
-            class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-10"
-            data-key="5"
-            data-label="Type"
-            scope="col"
-            tabindex="-1"
-          >
-            <button
-              class="pf-v6-c-table__button"
-              type="button"
-            >
-              <div
-                class="pf-v6-c-table__button-content"
-              >
-                <span
-                  class="pf-v6-c-table__text"
-                >
-                  Type
-                </span>
-                <span
-                  class="pf-v6-c-table__sort-indicator"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="pf-v6-svg"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 256 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                    />
-                  </svg>
-                </span>
-              </div>
-            </button>
-          </th>
-          <th
-            class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-10"
-            data-key="6"
-            data-label="Severity"
-            scope="col"
-            tabindex="-1"
-          >
-            <button
-              class="pf-v6-c-table__button"
-              type="button"
-            >
-              <div
-                class="pf-v6-c-table__button-content"
-              >
-                <span
-                  class="pf-v6-c-table__text"
-                >
-                  Severity
-                </span>
-                <span
-                  class="pf-v6-c-table__sort-indicator"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="pf-v6-svg"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 256 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                    />
-                  </svg>
-                </span>
-              </div>
-            </button>
-          </th>
-          <th
-            class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-10"
-            data-key="7"
-            data-label="Reboot"
-            scope="col"
-            tabindex="-1"
-          >
-            <button
-              class="pf-v6-c-table__button"
-              type="button"
-            >
-              <div
-                class="pf-v6-c-table__button-content"
-              >
-                <span
-                  class="pf-v6-c-table__text"
-                >
-                  Reboot
-                </span>
-                <span
-                  class="pf-v6-c-table__sort-indicator"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="pf-v6-svg"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 256 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                    />
-                  </svg>
-                </span>
-              </div>
-            </button>
-          </th>
-          <th
-            class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-10"
-            data-key="8"
-            data-label="Publish date"
-            scope="col"
-            tabindex="-1"
-          >
-            <button
-              class="pf-v6-c-table__button"
-              type="button"
-            >
-              <div
-                class="pf-v6-c-table__button-content"
-              >
-                <span
-                  class="pf-v6-c-table__text"
-                >
-                  Publish date
-                </span>
-                <span
-                  class="pf-v6-c-table__sort-indicator"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="pf-v6-svg"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 256 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                    />
-                  </svg>
-                </span>
-              </div>
-            </button>
-          </th>
-        </tr>
-      </thead>
-      <tbody
-        class="pf-v6-c-table__tbody"
-        role="rowgroup"
-      >
-        <tr
-          class="pf-v6-c-table__tr"
-          data-ouia-component-id="OUIA-Generated-TableRow-11"
-          data-ouia-component-type="PF6/TableRow"
-          data-ouia-safe="true"
-        >
-          <td
-            class="pf-v6-c-table__td pf-v6-c-table__toggle"
-            data-key="0"
-            tabindex="-1"
-          >
-            <button
-              aria-expanded="false"
-              aria-label="Details"
-              aria-labelledby="simple-node0 expandable-toggle0"
-              class="pf-v6-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-10"
-              data-ouia-component-type="PF6/Button"
-              data-ouia-safe="true"
-              id="expandable-toggle0"
-              type="button"
-            >
-              <span
-                class="pf-v6-c-button__icon"
-              >
-                <div
-                  class="pf-v6-c-table__toggle-icon"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="pf-v6-svg"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 320 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                    />
-                  </svg>
-                </div>
-              </span>
-            </button>
-          </td>
-          <td
-            class="pf-v6-c-table__td pf-v6-c-table__check"
-            data-key="1"
-            tabindex="-1"
-          >
-            <label>
-              <input
-                aria-label="Select row 0"
-                checked=""
-                name="checkrow0"
-                type="checkbox"
-              />
-            </label>
-          </td>
-          <td
-            class="pf-v6-c-table__td"
-            data-key="2"
-            data-label="Name"
-            tabindex="-1"
-          >
-            <a
-              href="/insights/patch/advisories/RHSA-2020:2774"
-            >
-              RHSA-2020:2774
-            </a>
-          </td>
-          <td
-            class="pf-v6-c-table__td"
-            data-key="3"
-            data-label="Synopsis"
-            tabindex="-1"
-          >
-            <div
-              class="LinesEllipsis  "
-            >
-              Important
-              <wbr />
-            </div>
-          </td>
-          <td
-            class="pf-v6-c-table__td"
-            data-key="4"
-            data-label="Status"
-            tabindex="-1"
-          >
-            Installable
-          </td>
-          <td
-            class="pf-v6-c-table__td"
-            data-key="5"
-            data-label="Type"
-            tabindex="-1"
-          >
-            <div
-              class="pf-v6-l-split pf-m-gutter"
-            >
-              <div
-                class="pf-v6-l-split__item"
-              >
-                <span
-                  class="pf-v6-c-icon"
-                >
-                  <span
-                    class="pf-v6-c-icon__content"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="pf-v6-svg"
-                      fill="currentColor"
-                      height="1em"
-                      role="img"
-                      viewBox="0 0 896 1024"
-                      width="1em"
-                    >
-                      <path
-                        d="M861.5,0 L34.5,0 C15.4,0 0,14.3 0,32 L0,452.1 C0,768 387.7,1024 448.5,1024 C509.3,1024 896,768 896,452.2 L896,32 C896,14.3 880.6,0 861.5,0 Z M490.7,768 L405.3,768 C393.5,767.8 384.2,757.5 384,744.7 L384,663.3 C384.2,650.5 393.6,640.3 405.3,640 L490.7,640 C502.5,640.2 511.8,650.5 512,663.3 L512,744.7 L512.1,744.7 C511.8,757.5 502.4,767.8 490.7,768 Z M543.9,162.7 L517.2,514.4 C515.8,530.9 502,544 485.3,544 L410.6,544 C394,544 380.1,531.2 378.7,514.7 L352.1,163 C350.5,144.3 365.3,128.3 384,128.3 L512,128 C530.7,128 545.4,144 543.9,162.7 Z"
-                      />
-                    </svg>
-                  </span>
-                </span>
-              </div>
-              <div
-                class="pf-v6-l-split__item pf-m-fill"
-              >
-                Security
-              </div>
-            </div>
-          </td>
-          <td
-            class="pf-v6-c-table__td"
-            data-key="6"
-            data-label="Severity"
-            tabindex="-1"
-          >
-            <div
-              class="pf-v6-l-flex pf-m-nowrap pf-m-gap-sm"
-            >
-              <span
-                class="pf-v6-c-icon pf-m-sm"
-              >
-                <span
-                  class="pf-v6-c-icon__content"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="pf-v6-svg"
-                    color="var(--pf-t--global--icon--color--severity--important--default)"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 1024 1024"
-                    width="1em"
-                  >
-                    <path
-                      d="M0,587.2c0,23.2,10.8,40.4,30.7,51.6,20.8,11.7,42.1,12.5,63.1-.5l378.4-235.4c26.5-16.7,51.7-16.4,78.7.5,123.4,77.2,247.5,153.4,371,230.5,22.9,14.3,44.9,18.7,69.3,5.3,24.5-13.5,32.5-35,32.3-61.4-.4-49.4,0-41.9,0-91.3s-.3-99.9,0-149.8c.2-27.6-11.5-47.8-35.1-61.8C841.4,187.2,694.4,99.5,547.5,11.7c-24.5-14.6-48.1-14.4-72.4.2C327.3,100.3,179.4,188.5,31.7,276.8c-21.1,12.6-31.7,31.5-31.7,56.1v254.3ZM1023.8,857.8c0,1.9,0-.6.2-10.3,0-2.1,0-4.1-.2-6.1v-35.1c0-29.9,0,8.8,0,33.8-1.8-23.9-13.4-41.7-34.9-54.4-147-87.7-294-175.4-441-263.3-24.5-14.6-48.1-14.4-72.4.2-147.7,88.4-295.6,176.6-443.4,265-21.1,12.6-31.7,31.4-31.7,56.1v120.3c0,23.2,10.8,40.4,30.7,51.6,20.8,11.7,42.1,12.5,63.1-.5l378.4-235.4c26.5-16.7,51.7-16.4,78.7.5,123.4,77.2,247.5,153.4,371,230.5,22.9,14.3,44.9,18.7,69.3,5.3,24.5-13.5,32.5-35,32.3-61.4-.2-32.3-.2-64.6-.2-96.9h.2Z"
-                    />
-                  </svg>
-                </span>
-              </span>
-              Important
-            </div>
-          </td>
-          <td
-            class="pf-v6-c-table__td"
-            data-key="7"
-            data-label="Reboot"
-            tabindex="-1"
-          >
-            Required
-          </td>
-          <td
-            class="pf-v6-c-table__td"
-            data-key="8"
-            data-label="Publish date"
-            tabindex="-1"
-          >
-            30 June 2020
-          </td>
-        </tr>
-        <tr
-          class="pf-v6-c-table__tr pf-v6-c-table__expandable-row"
-          data-ouia-component-id="OUIA-Generated-TableRow-12"
-          data-ouia-component-type="PF6/TableRow"
-          data-ouia-safe="true"
-          hidden=""
-        >
-          <td
-            class="pf-v6-c-table__td"
-            data-key="0"
-            tabindex="-1"
-          />
-          <td
-            class="pf-v6-c-table__td"
-            data-key="1"
-            tabindex="-1"
-          />
-          <td
-            class="pf-v6-c-table__td"
-            colspan="7"
-            data-key="2"
-            id="expanded-content1-2"
-            tabindex="-1"
-          >
-            <div
-              class="pf-v6-c-table__expandable-row-content"
-            >
-              <div
-                class="pf-v6-c-content patch-advisory-description"
-                data-ouia-component-id="OUIA-Generated-Content-3"
-                data-ouia-component-type="PF6/Content"
-                data-ouia-safe="true"
-                data-pf-content="true"
-              >
-                <span
-                  class="patchman-label"
-                >
-                  Description
-                </span>
-                <p
-                  class="pf-v6-c-content--p"
-                  data-ouia-component-id="OUIA-Generated-Content-4"
-                  data-ouia-component-type="PF6/Content"
-                  data-ouia-safe="true"
-                  data-pf-content="true"
-                  style="white-space: pre-line;"
-                >
-                  Kernel-based Virtual.
-                </p>
-                <div
-                  class="pf-v6-l-flex pf-m-column"
+                  class="pf-v6-l-split ins-c-conditional-filter ins-c-conditional-filter__split-items-space"
                 >
                   <div
-                    class="pf-m-spacer-none"
+                    class="pf-v6-l-split__item"
                   >
-                    <h6
-                      class="pf-v6-c-title pf-m-h6"
-                      data-ouia-component-id="OUIA-Generated-Title-2"
-                      data-ouia-component-type="PF6/Title"
+                    <button
+                      aria-expanded="false"
+                      aria-label="Conditional filter toggle"
+                      class="pf-v6-c-menu-toggle ins-c-conditional-filter__group"
+                      data-ouia-component-id="ConditionalFilterToggle"
+                      data-ouia-component-type="PF6/MenuToggle"
                       data-ouia-safe="true"
+                      type="button"
                     >
-                      Reboot
-                    </h6>
-                  </div>
-                  <div
-                    class="pf-m-spacer-sm"
-                  >
-                    <div
-                      class="pf-v6-l-split pf-m-gutter"
-                    >
-                      <div
-                        class="pf-v6-l-split__item"
+                      <span
+                        class="pf-v6-c-menu-toggle__text"
                       >
                         <span
                           class="pf-v6-c-icon pf-m-md"
                         >
                           <span
-                            class="pf-v6-c-icon__content pf-m-danger"
+                            class="pf-v6-c-icon__content"
                           >
                             <svg
                               aria-hidden="true"
@@ -1082,383 +185,22 @@ exports[`SystemDetail.js Should match the snapshot when Package tab is active by
                               width="1em"
                             >
                               <path
-                                d="M400 54.1c63 45 104 118.6 104 201.9 0 136.8-110.8 247.7-247.5 248C120 504.3 8.2 393 8 256.4 7.9 173.1 48.9 99.3 111.8 54.2c11.7-8.3 28-4.8 35 7.7L162.6 90c5.9 10.5 3.1 23.8-6.6 31-41.5 30.8-68 79.6-68 134.9-.1 92.3 74.5 168.1 168 168.1 91.6 0 168.6-74.2 168-169.1-.3-51.8-24.7-101.8-68.1-134-9.7-7.2-12.4-20.5-6.5-30.9l15.8-28.1c7-12.4 23.2-16.1 34.8-7.8zM296 264V24c0-13.3-10.7-24-24-24h-32c-13.3 0-24 10.7-24 24v240c0 13.3 10.7 24 24 24h32c13.3 0 24-10.7 24-24z"
+                                d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
                               />
                             </svg>
                           </span>
                         </span>
-                      </div>
-                      <div
-                        class="pf-v6-l-split__item pf-m-fill"
-                      >
-                        Reboot is required
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <a
-                  href="https://access.redhat.com/errata/RHSA-2020:2774"
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  View packages and errata at access.redhat.com
-                  <svg
-                    aria-hidden="true"
-                    class="pf-v6-svg pf-v6-u-ml-xs"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 512 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
-                    />
-                  </svg>
-                </a>
-              </div>
-            </div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <div
-      class="pf-v6-c-toolbar ins-c-table__toolbar ins-m-footer"
-      data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-3"
-      data-ouia-component-type="RHI/TableToolbar"
-      data-ouia-safe="true"
-      id="pf-random-id-2"
-    >
-      <div
-        class="pf-v6-c-pagination pf-m-bottom"
-        data-ouia-component-id="bottom-system-advisories-pagination"
-        data-ouia-component-type="PF6/Pagination"
-        data-ouia-safe="true"
-        id="pagination-options-menu-bottom-bottom-pagination"
-        style="--pf-v6-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
-      >
-        <div
-          class="pf-v6-c-pagination__page-menu"
-        >
-          <button
-            aria-expanded="false"
-            aria-haspopup="listbox"
-            class="pf-v6-c-menu-toggle pf-m-plain pf-m-text"
-            data-ouia-component-id="OUIA-Generated-MenuToggle-plainText-4"
-            data-ouia-component-type="PF6/MenuToggle"
-            data-ouia-safe="true"
-            id="pagination-options-menu-bottom-bottom-toggle"
-            type="button"
-          >
-            <span
-              class="pf-v6-c-menu-toggle__text"
-            >
-              <b>
-                1 - 10
-              </b>
-               of 
-              <b>
-                10
-              </b>
-               
-            </span>
-            <span
-              class="pf-v6-c-menu-toggle__controls"
-            >
-              <span
-                class="pf-v6-c-menu-toggle__toggle-icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="pf-v6-svg"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 320 512"
-                  width="1em"
-                >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  />
-                </svg>
-              </span>
-            </span>
-          </button>
-        </div>
-        <nav
-          aria-label="Pagination"
-          class="pf-v6-c-pagination__nav"
-        >
-          <div
-            class="pf-v6-c-pagination__nav-control pf-m-first"
-          >
-            <button
-              aria-label="Go to first page"
-              class="pf-v6-c-button pf-m-plain"
-              data-action="first"
-              data-ouia-component-id="OUIA-Generated-Button-plain-11"
-              data-ouia-component-type="PF6/Button"
-              data-ouia-safe="true"
-              disabled=""
-              type="button"
-            >
-              <span
-                class="pf-v6-c-button__icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="pf-v6-svg"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 448 512"
-                  width="1em"
-                >
-                  <path
-                    d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                  />
-                </svg>
-              </span>
-            </button>
-          </div>
-          <div
-            class="pf-v6-c-pagination__nav-control"
-          >
-            <button
-              aria-label="Go to previous page"
-              class="pf-v6-c-button pf-m-plain"
-              data-action="previous"
-              data-ouia-component-id="OUIA-Generated-Button-plain-12"
-              data-ouia-component-type="PF6/Button"
-              data-ouia-safe="true"
-              disabled=""
-              type="button"
-            >
-              <span
-                class="pf-v6-c-button__icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="pf-v6-svg"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 256 512"
-                  width="1em"
-                >
-                  <path
-                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                  />
-                </svg>
-              </span>
-            </button>
-          </div>
-          <div
-            class="pf-v6-c-pagination__nav-page-select"
-          >
-            <span
-              class="pf-v6-c-form-control pf-m-disabled"
-            >
-              <input
-                aria-invalid="false"
-                aria-label="Current page"
-                data-ouia-component-id="OUIA-Generated-TextInputBase-5"
-                data-ouia-component-type="PF6/TextInput"
-                data-ouia-safe="true"
-                disabled=""
-                max="1"
-                min="1"
-                type="number"
-                value="1"
-              />
-            </span>
-            <span
-              aria-hidden="true"
-            >
-              of 1
-            </span>
-          </div>
-          <div
-            class="pf-v6-c-pagination__nav-control"
-          >
-            <button
-              aria-label="Go to next page"
-              class="pf-v6-c-button pf-m-plain"
-              data-action="next"
-              data-ouia-component-id="OUIA-Generated-Button-plain-13"
-              data-ouia-component-type="PF6/Button"
-              data-ouia-safe="true"
-              disabled=""
-              type="button"
-            >
-              <span
-                class="pf-v6-c-button__icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="pf-v6-svg"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 256 512"
-                  width="1em"
-                >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                  />
-                </svg>
-              </span>
-            </button>
-          </div>
-          <div
-            class="pf-v6-c-pagination__nav-control pf-m-last"
-          >
-            <button
-              aria-label="Go to last page"
-              class="pf-v6-c-button pf-m-plain"
-              data-action="last"
-              data-ouia-component-id="OUIA-Generated-Button-plain-14"
-              data-ouia-component-type="PF6/Button"
-              data-ouia-safe="true"
-              disabled=""
-              type="button"
-            >
-              <span
-                class="pf-v6-c-button__icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="pf-v6-svg"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 448 512"
-                  width="1em"
-                >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                  />
-                </svg>
-              </span>
-            </button>
-          </div>
-        </nav>
-      </div>
-      <div
-        class="pf-v6-c-toolbar__content pf-m-hidden"
-        hidden=""
-      >
-        <div
-          class="pf-v6-c-toolbar__group"
-        />
-      </div>
-    </div>
-  </section>
-  <section
-    aria-labelledby="pf-tab-1-system-packages-tab"
-    class="pf-v6-c-tab-content"
-    data-ouia-component-type="PF6/TabContent"
-    data-ouia-safe="true"
-    id="pf-tab-section-1-system-packages-tab"
-    role="tabpanel"
-    tabindex="0"
-  >
-    <div
-      class="pf-v6-c-toolbar  ins-c-primary-toolbar"
-      data-ouia-component-id="PrimaryToolbar"
-      data-ouia-component-type="PF6/Toolbar"
-      data-ouia-safe="true"
-      id="ins-primary-data-toolbar"
-    >
-      <div
-        class="pf-v6-c-toolbar__content"
-      >
-        <div
-          class="pf-v6-c-toolbar__content-section pf-m-align-items-center"
-        >
-          <div
-            class="pf-v6-c-toolbar__group pf-m-filter-group ins-c-primary-toolbar__group-filter pf-m-spacer-md pf-m-space-items-lg"
-          >
-            <div
-              class="pf-v6-c-toolbar__item"
-            >
-              <button
-                aria-expanded="false"
-                aria-label="Select"
-                class="pf-v6-c-menu-toggle pf-m-disabled"
-                data-ouia-component-id="BulkSelect"
-                data-ouia-component-type="PF6/MenuToggle"
-                data-ouia-safe="true"
-                disabled=""
-                type="button"
-              >
-                <span
-                  class="pf-v6-c-menu-toggle__text"
-                >
-                  <label
-                    class="pf-v6-c-check pf-m-standalone"
-                  >
-                    <input
-                      aria-invalid="false"
-                      aria-label="Select all"
-                      class="pf-v6-c-check__input"
-                      data-ouia-component-id="BulkSelectCheckbox"
-                      data-ouia-component-type="PF6/MenuToggleCheckbox"
-                      data-ouia-safe="true"
-                      name="toggle-checkbox"
-                      type="checkbox"
-                    />
-                  </label>
-                </span>
-                <span
-                  class="pf-v6-c-menu-toggle__controls"
-                >
-                  <span
-                    class="pf-v6-c-menu-toggle__toggle-icon"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="pf-v6-svg"
-                      fill="currentColor"
-                      height="1em"
-                      role="img"
-                      viewBox="0 0 320 512"
-                      width="1em"
-                    >
-                      <path
-                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                      />
-                    </svg>
-                  </span>
-                </span>
-              </button>
-            </div>
-            <div
-              class="pf-v6-c-toolbar__item ins-c-primary-toolbar__filter"
-            >
-              <div
-                class="pf-v6-l-split ins-c-conditional-filter ins-c-conditional-filter__split-items-space"
-              >
-                <div
-                  class="pf-v6-l-split__item"
-                >
-                  <button
-                    aria-expanded="false"
-                    aria-label="Conditional filter toggle"
-                    class="pf-v6-c-menu-toggle ins-c-conditional-filter__group"
-                    data-ouia-component-id="ConditionalFilterToggle"
-                    data-ouia-component-type="PF6/MenuToggle"
-                    data-ouia-safe="true"
-                    type="button"
-                  >
-                    <span
-                      class="pf-v6-c-menu-toggle__text"
-                    >
+                        <span
+                          class="ins-c-conditional-filter__value-selector"
+                        >
+                          Advisory
+                        </span>
+                      </span>
                       <span
-                        class="pf-v6-c-icon pf-m-md"
+                        class="pf-v6-c-menu-toggle__controls"
                       >
                         <span
-                          class="pf-v6-c-icon__content"
+                          class="pf-v6-c-menu-toggle__toggle-icon"
                         >
                           <svg
                             aria-hidden="true"
@@ -1466,20 +208,194 @@ exports[`SystemDetail.js Should match the snapshot when Package tab is active by
                             fill="currentColor"
                             height="1em"
                             role="img"
-                            viewBox="0 0 512 512"
+                            viewBox="0 0 320 512"
                             width="1em"
                           >
                             <path
-                              d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
+                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
                             />
                           </svg>
                         </span>
                       </span>
+                    </button>
+                  </div>
+                  <div
+                    class="pf-v6-l-split__item pf-m-fill"
+                    data-ouia-component-id="ConditionalFilter"
+                  >
+                    <span
+                      class="pf-v6-c-form-control pf-m-icon ins-c-conditional-filter"
+                    >
+                      <input
+                        aria-invalid="false"
+                        aria-label="search-field"
+                        data-ouia-component-id="ConditionalFilter"
+                        data-ouia-component-type="PF6/TextInput"
+                        data-ouia-safe="true"
+                        placeholder="Filter by name or synopsis"
+                        type="text"
+                        value=""
+                        widget-type="InsightsInput"
+                      />
                       <span
-                        class="ins-c-conditional-filter__value-selector"
+                        class="pf-v6-c-form-control__utilities"
                       >
-                        Package
+                        <span
+                          class="pf-v6-c-form-control__icon"
+                        >
+                          <span
+                            class="pf-v6-c-icon pf-m-md ins-c-search-icon"
+                          >
+                            <span
+                              class="pf-v6-c-icon__content"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v6-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 512 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                        </span>
                       </span>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="pf-v6-c-toolbar__item ins-c-primary-toolbar__first-action pf-m-spacer-sm"
+            >
+              <div
+                buttonprops="[object Object]"
+                fallback="[object Object]"
+                module="./RemediationButton"
+                scope="remediations"
+              >
+                AsyncComponent
+              </div>
+            </div>
+            <div
+              class="pf-v6-c-toolbar__item pf-m-spacer-sm"
+            >
+              <div
+                style="display: contents;"
+              >
+                <button
+                  aria-expanded="false"
+                  aria-label="Export"
+                  class="pf-v6-c-menu-toggle pf-m-plain"
+                  data-ouia-component-id="OUIA-Generated-MenuToggle-plain-5"
+                  data-ouia-component-type="PF6/MenuToggle"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <span
+                    class="pf-v6-c-menu-toggle__icon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 1024 1024"
+                      width="1em"
+                    >
+                      <path
+                        d="M975.8,636.9 L870.9,741.8 L457.9,328.6 C452.1,322.8 445.4,319.9 437.9,319.9 C430.4,319.9 423.7,322.8 417.9,328.6 L328.8,417.7 C323,423.5 320.1,430.2 320.1,437.7 C320.1,445.2 323,451.9 328.8,457.7 L742,870.7 L636.9,975.8 C610.5,1002.2 619.4,1024 656.8,1024 L956,1024 C1014.5,1024 1024,1013.7 1024,955.9 L1024,656.7 C1023.9,619.4 1002.2,610.5 975.8,636.9 Z M128,128 L896,128 L896,361.7 C896.007942,370.182681 899.389907,378.313788 905.4,384.3 L996.7,475.6 C1006.8,485.7 1024,478.5 1024,464.3 L1024,22.7 C1024,16.1 1021.9,10.7 1017.6,6.4 C1013.3,2.1 1007.9,0 1001.3,0 L22.7,0 C16.1,0 10.7,2.1 6.4,6.4 C2.1,10.7 0,16.1 0,22.7 L0,1001.3 C0,1007.9 2.1,1013.3 6.4,1017.6 C10.7,1021.9 16.1,1024 22.7,1024 L463.4,1024 C469.862884,1023.98894 475.684489,1020.0908 478.156232,1014.11925 C480.627976,1008.14769 479.264428,1001.27548 474.7,996.7 L383.4,905.4 C377.413788,899.389907 369.282681,896.007942 360.8,896 L128,896 L128,128 Z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              class="pf-v6-c-toolbar__item  ins-c-primary-toolbar__actions pf-m-spacer-sm"
+            >
+              <button
+                aria-expanded="false"
+                aria-label="kebab dropdown toggle"
+                class="pf-v6-c-menu-toggle pf-m-plain"
+                data-ouia-component-id="BulkActionsToggle"
+                data-ouia-component-type="PF6/MenuToggle"
+                data-ouia-safe="true"
+                type="button"
+              >
+                <span
+                  class="pf-v6-c-menu-toggle__icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 192 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+            <div
+              class="pf-v6-c-toolbar__item ins-c-primary-toolbar__pagination"
+            >
+              <div
+                class="pf-v6-c-pagination"
+                data-ouia-component-id="top-system-advisories-pagination"
+                data-ouia-component-type="PF6/Pagination"
+                data-ouia-safe="true"
+                id="options-menu-top-pagination"
+                style="--pf-v6-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+              >
+                <div
+                  class="pf-v6-c-pagination__total-items"
+                >
+                  <b>
+                    1 - 10
+                  </b>
+                   of 
+                  <b>
+                    10
+                  </b>
+                   
+                </div>
+                <div
+                  class="pf-v6-c-pagination__page-menu"
+                >
+                  <button
+                    aria-expanded="false"
+                    aria-haspopup="listbox"
+                    class="pf-v6-c-menu-toggle pf-m-plain pf-m-text"
+                    data-ouia-component-id="OUIA-Generated-MenuToggle-plainText-3"
+                    data-ouia-component-type="PF6/MenuToggle"
+                    data-ouia-safe="true"
+                    id="options-menu-top-toggle"
+                    type="button"
+                  >
+                    <span
+                      class="pf-v6-c-menu-toggle__text"
+                    >
+                      <b>
+                        1 - 10
+                      </b>
+                       of 
+                      <b>
+                        10
+                      </b>
+                       
                     </span>
                     <span
                       class="pf-v6-c-menu-toggle__controls"
@@ -1504,32 +420,1049 @@ exports[`SystemDetail.js Should match the snapshot when Package tab is active by
                     </span>
                   </button>
                 </div>
-                <div
-                  class="pf-v6-l-split__item pf-m-fill"
-                  data-ouia-component-id="ConditionalFilter"
+                <nav
+                  aria-label="Pagination"
+                  class="pf-v6-c-pagination__nav"
                 >
-                  <span
-                    class="pf-v6-c-form-control pf-m-icon ins-c-conditional-filter"
+                  <div
+                    class="pf-v6-c-pagination__nav-control"
                   >
-                    <input
-                      aria-invalid="false"
-                      aria-label="search-field"
-                      data-ouia-component-id="ConditionalFilter"
-                      data-ouia-component-type="PF6/TextInput"
+                    <button
+                      aria-label="Go to previous page"
+                      class="pf-v6-c-button pf-m-plain"
+                      data-action="previous"
+                      data-ouia-component-id="OUIA-Generated-Button-plain-8"
+                      data-ouia-component-type="PF6/Button"
                       data-ouia-safe="true"
-                      placeholder="Filter by name or summary"
-                      type="text"
-                      value=""
-                      widget-type="InsightsInput"
-                    />
-                    <span
-                      class="pf-v6-c-form-control__utilities"
+                      disabled=""
+                      type="button"
                     >
                       <span
-                        class="pf-v6-c-form-control__icon"
+                        class="pf-v6-c-button__icon"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="pf-v6-svg"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 256 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                          />
+                        </svg>
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    class="pf-v6-c-pagination__nav-control"
+                  >
+                    <button
+                      aria-label="Go to next page"
+                      class="pf-v6-c-button pf-m-plain"
+                      data-action="next"
+                      data-ouia-component-id="OUIA-Generated-Button-plain-9"
+                      data-ouia-component-type="PF6/Button"
+                      data-ouia-safe="true"
+                      disabled=""
+                      type="button"
+                    >
+                      <span
+                        class="pf-v6-c-button__icon"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="pf-v6-svg"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 256 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                          />
+                        </svg>
+                      </span>
+                    </button>
+                  </div>
+                </nav>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="pf-v6-c-toolbar__content pf-m-hidden"
+          hidden=""
+        >
+          <div
+            class="pf-v6-c-toolbar__group"
+          />
+        </div>
+      </div>
+      <table
+        aria-label="Patch table view"
+        class="pf-v6-c-table pf-m-grid-md pf-m-compact pf-m-sticky-header"
+        data-ouia-component-id="system-advisories-table"
+        data-ouia-component-type="PF6/Table"
+        data-ouia-safe="true"
+        role="grid"
+      >
+        <thead
+          class="pf-v6-c-table__thead"
+        >
+          <tr
+            class="pf-v6-c-table__tr"
+            data-ouia-component-id="OUIA-Generated-TableRow-10"
+            data-ouia-component-type="PF6/TableRow"
+            data-ouia-safe="true"
+          >
+            <th
+              class="pf-v6-c-table__th"
+              data-key="0"
+              data-label=""
+              scope=""
+              tabindex="-1"
+            />
+            <th
+              class="pf-v6-c-table__th"
+              data-key="1"
+              data-label=""
+              scope=""
+              tabindex="-1"
+            />
+            <th
+              class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-15"
+              data-key="2"
+              data-label="Name"
+              scope="col"
+              tabindex="-1"
+            >
+              <button
+                class="pf-v6-c-table__button"
+                type="button"
+              >
+                <div
+                  class="pf-v6-c-table__button-content"
+                >
+                  <span
+                    class="pf-v6-c-table__text"
+                  >
+                    Name
+                  </span>
+                  <span
+                    class="pf-v6-c-table__sort-indicator"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 256 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </button>
+            </th>
+            <th
+              class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-35"
+              data-key="3"
+              data-label="Synopsis"
+              scope="col"
+              tabindex="-1"
+            >
+              <button
+                class="pf-v6-c-table__button"
+                type="button"
+              >
+                <div
+                  class="pf-v6-c-table__button-content"
+                >
+                  <span
+                    class="pf-v6-c-table__text"
+                  >
+                    Synopsis
+                  </span>
+                  <span
+                    class="pf-v6-c-table__sort-indicator"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 256 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </button>
+            </th>
+            <th
+              class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-10"
+              data-key="4"
+              data-label="Status"
+              scope="col"
+              tabindex="-1"
+            >
+              <button
+                class="pf-v6-c-table__button"
+                type="button"
+              >
+                <div
+                  class="pf-v6-c-table__button-content"
+                >
+                  <span
+                    class="pf-v6-c-table__text"
+                  >
+                    Status
+                  </span>
+                  <span
+                    class="pf-v6-c-table__sort-indicator"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 256 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </button>
+            </th>
+            <th
+              class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-10"
+              data-key="5"
+              data-label="Type"
+              scope="col"
+              tabindex="-1"
+            >
+              <button
+                class="pf-v6-c-table__button"
+                type="button"
+              >
+                <div
+                  class="pf-v6-c-table__button-content"
+                >
+                  <span
+                    class="pf-v6-c-table__text"
+                  >
+                    Type
+                  </span>
+                  <span
+                    class="pf-v6-c-table__sort-indicator"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 256 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </button>
+            </th>
+            <th
+              class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-10"
+              data-key="6"
+              data-label="Severity"
+              scope="col"
+              tabindex="-1"
+            >
+              <button
+                class="pf-v6-c-table__button"
+                type="button"
+              >
+                <div
+                  class="pf-v6-c-table__button-content"
+                >
+                  <span
+                    class="pf-v6-c-table__text"
+                  >
+                    Severity
+                  </span>
+                  <span
+                    class="pf-v6-c-table__sort-indicator"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 256 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </button>
+            </th>
+            <th
+              class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-10"
+              data-key="7"
+              data-label="Reboot"
+              scope="col"
+              tabindex="-1"
+            >
+              <button
+                class="pf-v6-c-table__button"
+                type="button"
+              >
+                <div
+                  class="pf-v6-c-table__button-content"
+                >
+                  <span
+                    class="pf-v6-c-table__text"
+                  >
+                    Reboot
+                  </span>
+                  <span
+                    class="pf-v6-c-table__sort-indicator"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 256 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </button>
+            </th>
+            <th
+              class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-10"
+              data-key="8"
+              data-label="Publish date"
+              scope="col"
+              tabindex="-1"
+            >
+              <button
+                class="pf-v6-c-table__button"
+                type="button"
+              >
+                <div
+                  class="pf-v6-c-table__button-content"
+                >
+                  <span
+                    class="pf-v6-c-table__text"
+                  >
+                    Publish date
+                  </span>
+                  <span
+                    class="pf-v6-c-table__sort-indicator"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 256 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </button>
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="pf-v6-c-table__tbody"
+          role="rowgroup"
+        >
+          <tr
+            class="pf-v6-c-table__tr"
+            data-ouia-component-id="OUIA-Generated-TableRow-11"
+            data-ouia-component-type="PF6/TableRow"
+            data-ouia-safe="true"
+          >
+            <td
+              class="pf-v6-c-table__td pf-v6-c-table__toggle"
+              data-key="0"
+              tabindex="-1"
+            >
+              <button
+                aria-expanded="false"
+                aria-label="Details"
+                aria-labelledby="simple-node0 expandable-toggle0"
+                class="pf-v6-c-button pf-m-plain"
+                data-ouia-component-id="OUIA-Generated-Button-plain-10"
+                data-ouia-component-type="PF6/Button"
+                data-ouia-safe="true"
+                id="expandable-toggle0"
+                type="button"
+              >
+                <span
+                  class="pf-v6-c-button__icon"
+                >
+                  <div
+                    class="pf-v6-c-table__toggle-icon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 320 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                      />
+                    </svg>
+                  </div>
+                </span>
+              </button>
+            </td>
+            <td
+              class="pf-v6-c-table__td pf-v6-c-table__check"
+              data-key="1"
+              tabindex="-1"
+            >
+              <label>
+                <input
+                  aria-label="Select row 0"
+                  checked=""
+                  name="checkrow0"
+                  type="checkbox"
+                />
+              </label>
+            </td>
+            <td
+              class="pf-v6-c-table__td"
+              data-key="2"
+              data-label="Name"
+              tabindex="-1"
+            >
+              <a
+                href="/insights/patch/advisories/RHSA-2020:2774"
+              >
+                RHSA-2020:2774
+              </a>
+            </td>
+            <td
+              class="pf-v6-c-table__td"
+              data-key="3"
+              data-label="Synopsis"
+              tabindex="-1"
+            >
+              <div
+                class="LinesEllipsis  "
+              >
+                Important
+                <wbr />
+              </div>
+            </td>
+            <td
+              class="pf-v6-c-table__td"
+              data-key="4"
+              data-label="Status"
+              tabindex="-1"
+            >
+              Installable
+            </td>
+            <td
+              class="pf-v6-c-table__td"
+              data-key="5"
+              data-label="Type"
+              tabindex="-1"
+            >
+              <div
+                class="pf-v6-l-split pf-m-gutter"
+              >
+                <div
+                  class="pf-v6-l-split__item"
+                >
+                  <span
+                    class="pf-v6-c-icon"
+                  >
+                    <span
+                      class="pf-v6-c-icon__content"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="pf-v6-svg"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 896 1024"
+                        width="1em"
+                      >
+                        <path
+                          d="M861.5,0 L34.5,0 C15.4,0 0,14.3 0,32 L0,452.1 C0,768 387.7,1024 448.5,1024 C509.3,1024 896,768 896,452.2 L896,32 C896,14.3 880.6,0 861.5,0 Z M490.7,768 L405.3,768 C393.5,767.8 384.2,757.5 384,744.7 L384,663.3 C384.2,650.5 393.6,640.3 405.3,640 L490.7,640 C502.5,640.2 511.8,650.5 512,663.3 L512,744.7 L512.1,744.7 C511.8,757.5 502.4,767.8 490.7,768 Z M543.9,162.7 L517.2,514.4 C515.8,530.9 502,544 485.3,544 L410.6,544 C394,544 380.1,531.2 378.7,514.7 L352.1,163 C350.5,144.3 365.3,128.3 384,128.3 L512,128 C530.7,128 545.4,144 543.9,162.7 Z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </div>
+                <div
+                  class="pf-v6-l-split__item pf-m-fill"
+                >
+                  Security
+                </div>
+              </div>
+            </td>
+            <td
+              class="pf-v6-c-table__td"
+              data-key="6"
+              data-label="Severity"
+              tabindex="-1"
+            >
+              <div
+                class="pf-v6-l-flex pf-m-nowrap pf-m-gap-sm"
+              >
+                <span
+                  class="pf-v6-c-icon pf-m-sm"
+                >
+                  <span
+                    class="pf-v6-c-icon__content"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      color="var(--pf-t--global--icon--color--severity--important--default)"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 1024 1024"
+                      width="1em"
+                    >
+                      <path
+                        d="M0,587.2c0,23.2,10.8,40.4,30.7,51.6,20.8,11.7,42.1,12.5,63.1-.5l378.4-235.4c26.5-16.7,51.7-16.4,78.7.5,123.4,77.2,247.5,153.4,371,230.5,22.9,14.3,44.9,18.7,69.3,5.3,24.5-13.5,32.5-35,32.3-61.4-.4-49.4,0-41.9,0-91.3s-.3-99.9,0-149.8c.2-27.6-11.5-47.8-35.1-61.8C841.4,187.2,694.4,99.5,547.5,11.7c-24.5-14.6-48.1-14.4-72.4.2C327.3,100.3,179.4,188.5,31.7,276.8c-21.1,12.6-31.7,31.5-31.7,56.1v254.3ZM1023.8,857.8c0,1.9,0-.6.2-10.3,0-2.1,0-4.1-.2-6.1v-35.1c0-29.9,0,8.8,0,33.8-1.8-23.9-13.4-41.7-34.9-54.4-147-87.7-294-175.4-441-263.3-24.5-14.6-48.1-14.4-72.4.2-147.7,88.4-295.6,176.6-443.4,265-21.1,12.6-31.7,31.4-31.7,56.1v120.3c0,23.2,10.8,40.4,30.7,51.6,20.8,11.7,42.1,12.5,63.1-.5l378.4-235.4c26.5-16.7,51.7-16.4,78.7.5,123.4,77.2,247.5,153.4,371,230.5,22.9,14.3,44.9,18.7,69.3,5.3,24.5-13.5,32.5-35,32.3-61.4-.2-32.3-.2-64.6-.2-96.9h.2Z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+                Important
+              </div>
+            </td>
+            <td
+              class="pf-v6-c-table__td"
+              data-key="7"
+              data-label="Reboot"
+              tabindex="-1"
+            >
+              Required
+            </td>
+            <td
+              class="pf-v6-c-table__td"
+              data-key="8"
+              data-label="Publish date"
+              tabindex="-1"
+            >
+              30 June 2020
+            </td>
+          </tr>
+          <tr
+            class="pf-v6-c-table__tr pf-v6-c-table__expandable-row"
+            data-ouia-component-id="OUIA-Generated-TableRow-12"
+            data-ouia-component-type="PF6/TableRow"
+            data-ouia-safe="true"
+            hidden=""
+          >
+            <td
+              class="pf-v6-c-table__td"
+              data-key="0"
+              tabindex="-1"
+            />
+            <td
+              class="pf-v6-c-table__td"
+              data-key="1"
+              tabindex="-1"
+            />
+            <td
+              class="pf-v6-c-table__td"
+              colspan="7"
+              data-key="2"
+              id="expanded-content1-2"
+              tabindex="-1"
+            >
+              <div
+                class="pf-v6-c-table__expandable-row-content"
+              >
+                <div
+                  class="pf-v6-c-content patch-advisory-description"
+                  data-ouia-component-id="OUIA-Generated-Content-3"
+                  data-ouia-component-type="PF6/Content"
+                  data-ouia-safe="true"
+                  data-pf-content="true"
+                >
+                  <span
+                    class="patchman-label"
+                  >
+                    Description
+                  </span>
+                  <p
+                    class="pf-v6-c-content--p"
+                    data-ouia-component-id="OUIA-Generated-Content-4"
+                    data-ouia-component-type="PF6/Content"
+                    data-ouia-safe="true"
+                    data-pf-content="true"
+                    style="white-space: pre-line;"
+                  >
+                    Kernel-based Virtual.
+                  </p>
+                  <div
+                    class="pf-v6-l-flex pf-m-column"
+                  >
+                    <div
+                      class="pf-m-spacer-none"
+                    >
+                      <h6
+                        class="pf-v6-c-title pf-m-h6"
+                        data-ouia-component-id="OUIA-Generated-Title-2"
+                        data-ouia-component-type="PF6/Title"
+                        data-ouia-safe="true"
+                      >
+                        Reboot
+                      </h6>
+                    </div>
+                    <div
+                      class="pf-m-spacer-sm"
+                    >
+                      <div
+                        class="pf-v6-l-split pf-m-gutter"
+                      >
+                        <div
+                          class="pf-v6-l-split__item"
+                        >
+                          <span
+                            class="pf-v6-c-icon pf-m-md"
+                          >
+                            <span
+                              class="pf-v6-c-icon__content pf-m-danger"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v6-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 512 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M400 54.1c63 45 104 118.6 104 201.9 0 136.8-110.8 247.7-247.5 248C120 504.3 8.2 393 8 256.4 7.9 173.1 48.9 99.3 111.8 54.2c11.7-8.3 28-4.8 35 7.7L162.6 90c5.9 10.5 3.1 23.8-6.6 31-41.5 30.8-68 79.6-68 134.9-.1 92.3 74.5 168.1 168 168.1 91.6 0 168.6-74.2 168-169.1-.3-51.8-24.7-101.8-68.1-134-9.7-7.2-12.4-20.5-6.5-30.9l15.8-28.1c7-12.4 23.2-16.1 34.8-7.8zM296 264V24c0-13.3-10.7-24-24-24h-32c-13.3 0-24 10.7-24 24v240c0 13.3 10.7 24 24 24h32c13.3 0 24-10.7 24-24z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="pf-v6-l-split__item pf-m-fill"
+                        >
+                          Reboot is required
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <a
+                    href="https://access.redhat.com/errata/RHSA-2020:2774"
+                    rel="noreferrer"
+                    target="_blank"
+                  >
+                    View packages and errata at access.redhat.com
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg pf-v6-u-ml-xs"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 512 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                      />
+                    </svg>
+                  </a>
+                </div>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div
+        class="pf-v6-c-toolbar ins-c-table__toolbar ins-m-footer"
+        data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-3"
+        data-ouia-component-type="RHI/TableToolbar"
+        data-ouia-safe="true"
+        id="pf-random-id-2"
+      >
+        <div
+          class="pf-v6-c-pagination pf-m-bottom"
+          data-ouia-component-id="bottom-system-advisories-pagination"
+          data-ouia-component-type="PF6/Pagination"
+          data-ouia-safe="true"
+          id="pagination-options-menu-bottom-bottom-pagination"
+          style="--pf-v6-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+        >
+          <div
+            class="pf-v6-c-pagination__page-menu"
+          >
+            <button
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              class="pf-v6-c-menu-toggle pf-m-plain pf-m-text"
+              data-ouia-component-id="OUIA-Generated-MenuToggle-plainText-4"
+              data-ouia-component-type="PF6/MenuToggle"
+              data-ouia-safe="true"
+              id="pagination-options-menu-bottom-bottom-toggle"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-menu-toggle__text"
+              >
+                <b>
+                  1 - 10
+                </b>
+                 of 
+                <b>
+                  10
+                </b>
+                 
+              </span>
+              <span
+                class="pf-v6-c-menu-toggle__controls"
+              >
+                <span
+                  class="pf-v6-c-menu-toggle__toggle-icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </button>
+          </div>
+          <nav
+            aria-label="Pagination"
+            class="pf-v6-c-pagination__nav"
+          >
+            <div
+              class="pf-v6-c-pagination__nav-control pf-m-first"
+            >
+              <button
+                aria-label="Go to first page"
+                class="pf-v6-c-button pf-m-plain"
+                data-action="first"
+                data-ouia-component-id="OUIA-Generated-Button-plain-11"
+                data-ouia-component-type="PF6/Button"
+                data-ouia-safe="true"
+                disabled=""
+                type="button"
+              >
+                <span
+                  class="pf-v6-c-button__icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+            <div
+              class="pf-v6-c-pagination__nav-control"
+            >
+              <button
+                aria-label="Go to previous page"
+                class="pf-v6-c-button pf-m-plain"
+                data-action="previous"
+                data-ouia-component-id="OUIA-Generated-Button-plain-12"
+                data-ouia-component-type="PF6/Button"
+                data-ouia-safe="true"
+                disabled=""
+                type="button"
+              >
+                <span
+                  class="pf-v6-c-button__icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+            <div
+              class="pf-v6-c-pagination__nav-page-select"
+            >
+              <span
+                class="pf-v6-c-form-control pf-m-disabled"
+              >
+                <input
+                  aria-invalid="false"
+                  aria-label="Current page"
+                  data-ouia-component-id="OUIA-Generated-TextInputBase-5"
+                  data-ouia-component-type="PF6/TextInput"
+                  data-ouia-safe="true"
+                  disabled=""
+                  max="1"
+                  min="1"
+                  type="number"
+                  value="1"
+                />
+              </span>
+              <span
+                aria-hidden="true"
+              >
+                of 1
+              </span>
+            </div>
+            <div
+              class="pf-v6-c-pagination__nav-control"
+            >
+              <button
+                aria-label="Go to next page"
+                class="pf-v6-c-button pf-m-plain"
+                data-action="next"
+                data-ouia-component-id="OUIA-Generated-Button-plain-13"
+                data-ouia-component-type="PF6/Button"
+                data-ouia-safe="true"
+                disabled=""
+                type="button"
+              >
+                <span
+                  class="pf-v6-c-button__icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+            <div
+              class="pf-v6-c-pagination__nav-control pf-m-last"
+            >
+              <button
+                aria-label="Go to last page"
+                class="pf-v6-c-button pf-m-plain"
+                data-action="last"
+                data-ouia-component-id="OUIA-Generated-Button-plain-14"
+                data-ouia-component-type="PF6/Button"
+                data-ouia-safe="true"
+                disabled=""
+                type="button"
+              >
+                <span
+                  class="pf-v6-c-button__icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </nav>
+        </div>
+        <div
+          class="pf-v6-c-toolbar__content pf-m-hidden"
+          hidden=""
+        >
+          <div
+            class="pf-v6-c-toolbar__group"
+          />
+        </div>
+      </div>
+    </div>
+  </section>
+  <section
+    aria-labelledby="pf-tab-1-system-packages-tab"
+    class="pf-v6-c-tab-content"
+    data-ouia-component-type="PF6/TabContent"
+    data-ouia-safe="true"
+    id="pf-tab-section-1-system-packages-tab"
+    role="tabpanel"
+    tabindex="0"
+  >
+    <div
+      class="pf-v6-u-mt-md"
+    >
+      <div
+        class="pf-v6-c-toolbar  ins-c-primary-toolbar"
+        data-ouia-component-id="PrimaryToolbar"
+        data-ouia-component-type="PF6/Toolbar"
+        data-ouia-safe="true"
+        id="ins-primary-data-toolbar"
+      >
+        <div
+          class="pf-v6-c-toolbar__content"
+        >
+          <div
+            class="pf-v6-c-toolbar__content-section pf-m-align-items-center"
+          >
+            <div
+              class="pf-v6-c-toolbar__group pf-m-filter-group ins-c-primary-toolbar__group-filter pf-m-spacer-md pf-m-space-items-lg"
+            >
+              <div
+                class="pf-v6-c-toolbar__item"
+              >
+                <button
+                  aria-expanded="false"
+                  aria-label="Select"
+                  class="pf-v6-c-menu-toggle pf-m-disabled"
+                  data-ouia-component-id="BulkSelect"
+                  data-ouia-component-type="PF6/MenuToggle"
+                  data-ouia-safe="true"
+                  disabled=""
+                  type="button"
+                >
+                  <span
+                    class="pf-v6-c-menu-toggle__text"
+                  >
+                    <label
+                      class="pf-v6-c-check pf-m-standalone"
+                    >
+                      <input
+                        aria-invalid="false"
+                        aria-label="Select all"
+                        class="pf-v6-c-check__input"
+                        data-ouia-component-id="BulkSelectCheckbox"
+                        data-ouia-component-type="PF6/MenuToggleCheckbox"
+                        data-ouia-safe="true"
+                        name="toggle-checkbox"
+                        type="checkbox"
+                      />
+                    </label>
+                  </span>
+                  <span
+                    class="pf-v6-c-menu-toggle__controls"
+                  >
+                    <span
+                      class="pf-v6-c-menu-toggle__toggle-icon"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="pf-v6-svg"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 320 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+              </div>
+              <div
+                class="pf-v6-c-toolbar__item ins-c-primary-toolbar__filter"
+              >
+                <div
+                  class="pf-v6-l-split ins-c-conditional-filter ins-c-conditional-filter__split-items-space"
+                >
+                  <div
+                    class="pf-v6-l-split__item"
+                  >
+                    <button
+                      aria-expanded="false"
+                      aria-label="Conditional filter toggle"
+                      class="pf-v6-c-menu-toggle ins-c-conditional-filter__group"
+                      data-ouia-component-id="ConditionalFilterToggle"
+                      data-ouia-component-type="PF6/MenuToggle"
+                      data-ouia-safe="true"
+                      type="button"
+                    >
+                      <span
+                        class="pf-v6-c-menu-toggle__text"
                       >
                         <span
-                          class="pf-v6-c-icon pf-m-md ins-c-search-icon"
+                          class="pf-v6-c-icon pf-m-md"
                         >
                           <span
                             class="pf-v6-c-icon__content"
@@ -1544,41 +1477,147 @@ exports[`SystemDetail.js Should match the snapshot when Package tab is active by
                               width="1em"
                             >
                               <path
-                                d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                                d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
                               />
                             </svg>
                           </span>
                         </span>
+                        <span
+                          class="ins-c-conditional-filter__value-selector"
+                        >
+                          Package
+                        </span>
+                      </span>
+                      <span
+                        class="pf-v6-c-menu-toggle__controls"
+                      >
+                        <span
+                          class="pf-v6-c-menu-toggle__toggle-icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="pf-v6-svg"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    class="pf-v6-l-split__item pf-m-fill"
+                    data-ouia-component-id="ConditionalFilter"
+                  >
+                    <span
+                      class="pf-v6-c-form-control pf-m-icon ins-c-conditional-filter"
+                    >
+                      <input
+                        aria-invalid="false"
+                        aria-label="search-field"
+                        data-ouia-component-id="ConditionalFilter"
+                        data-ouia-component-type="PF6/TextInput"
+                        data-ouia-safe="true"
+                        placeholder="Filter by name or summary"
+                        type="text"
+                        value=""
+                        widget-type="InsightsInput"
+                      />
+                      <span
+                        class="pf-v6-c-form-control__utilities"
+                      >
+                        <span
+                          class="pf-v6-c-form-control__icon"
+                        >
+                          <span
+                            class="pf-v6-c-icon pf-m-md ins-c-search-icon"
+                          >
+                            <span
+                              class="pf-v6-c-icon__content"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v6-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 512 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                        </span>
                       </span>
                     </span>
-                  </span>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-          <div
-            class="pf-v6-c-toolbar__item ins-c-primary-toolbar__first-action pf-m-spacer-sm"
-          >
             <div
-              buttonprops="[object Object]"
-              fallback="[object Object]"
-              module="./RemediationButton"
-              scope="remediations"
+              class="pf-v6-c-toolbar__item ins-c-primary-toolbar__first-action pf-m-spacer-sm"
             >
-              AsyncComponent
+              <div
+                buttonprops="[object Object]"
+                fallback="[object Object]"
+                module="./RemediationButton"
+                scope="remediations"
+              >
+                AsyncComponent
+              </div>
             </div>
-          </div>
-          <div
-            class="pf-v6-c-toolbar__item pf-m-spacer-sm"
-          >
             <div
-              style="display: contents;"
+              class="pf-v6-c-toolbar__item pf-m-spacer-sm"
+            >
+              <div
+                style="display: contents;"
+              >
+                <button
+                  aria-expanded="false"
+                  aria-label="Export"
+                  class="pf-v6-c-menu-toggle pf-m-plain"
+                  data-ouia-component-id="OUIA-Generated-MenuToggle-plain-7"
+                  data-ouia-component-type="PF6/MenuToggle"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <span
+                    class="pf-v6-c-menu-toggle__icon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 1024 1024"
+                      width="1em"
+                    >
+                      <path
+                        d="M975.8,636.9 L870.9,741.8 L457.9,328.6 C452.1,322.8 445.4,319.9 437.9,319.9 C430.4,319.9 423.7,322.8 417.9,328.6 L328.8,417.7 C323,423.5 320.1,430.2 320.1,437.7 C320.1,445.2 323,451.9 328.8,457.7 L742,870.7 L636.9,975.8 C610.5,1002.2 619.4,1024 656.8,1024 L956,1024 C1014.5,1024 1024,1013.7 1024,955.9 L1024,656.7 C1023.9,619.4 1002.2,610.5 975.8,636.9 Z M128,128 L896,128 L896,361.7 C896.007942,370.182681 899.389907,378.313788 905.4,384.3 L996.7,475.6 C1006.8,485.7 1024,478.5 1024,464.3 L1024,22.7 C1024,16.1 1021.9,10.7 1017.6,6.4 C1013.3,2.1 1007.9,0 1001.3,0 L22.7,0 C16.1,0 10.7,2.1 6.4,6.4 C2.1,10.7 0,16.1 0,22.7 L0,1001.3 C0,1007.9 2.1,1013.3 6.4,1017.6 C10.7,1021.9 16.1,1024 22.7,1024 L463.4,1024 C469.862884,1023.98894 475.684489,1020.0908 478.156232,1014.11925 C480.627976,1008.14769 479.264428,1001.27548 474.7,996.7 L383.4,905.4 C377.413788,899.389907 369.282681,896.007942 360.8,896 L128,896 L128,128 Z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              class="pf-v6-c-toolbar__item  ins-c-primary-toolbar__actions pf-m-spacer-sm"
             >
               <button
                 aria-expanded="false"
-                aria-label="Export"
+                aria-label="kebab dropdown toggle"
                 class="pf-v6-c-menu-toggle pf-m-plain"
-                data-ouia-component-id="OUIA-Generated-MenuToggle-plain-7"
+                data-ouia-component-id="BulkActionsToggle"
                 data-ouia-component-type="PF6/MenuToggle"
                 data-ouia-safe="true"
                 type="button"
@@ -1592,170 +1631,139 @@ exports[`SystemDetail.js Should match the snapshot when Package tab is active by
                     fill="currentColor"
                     height="1em"
                     role="img"
-                    viewBox="0 0 1024 1024"
+                    viewBox="0 0 192 512"
                     width="1em"
                   >
                     <path
-                      d="M975.8,636.9 L870.9,741.8 L457.9,328.6 C452.1,322.8 445.4,319.9 437.9,319.9 C430.4,319.9 423.7,322.8 417.9,328.6 L328.8,417.7 C323,423.5 320.1,430.2 320.1,437.7 C320.1,445.2 323,451.9 328.8,457.7 L742,870.7 L636.9,975.8 C610.5,1002.2 619.4,1024 656.8,1024 L956,1024 C1014.5,1024 1024,1013.7 1024,955.9 L1024,656.7 C1023.9,619.4 1002.2,610.5 975.8,636.9 Z M128,128 L896,128 L896,361.7 C896.007942,370.182681 899.389907,378.313788 905.4,384.3 L996.7,475.6 C1006.8,485.7 1024,478.5 1024,464.3 L1024,22.7 C1024,16.1 1021.9,10.7 1017.6,6.4 C1013.3,2.1 1007.9,0 1001.3,0 L22.7,0 C16.1,0 10.7,2.1 6.4,6.4 C2.1,10.7 0,16.1 0,22.7 L0,1001.3 C0,1007.9 2.1,1013.3 6.4,1017.6 C10.7,1021.9 16.1,1024 22.7,1024 L463.4,1024 C469.862884,1023.98894 475.684489,1020.0908 478.156232,1014.11925 C480.627976,1008.14769 479.264428,1001.27548 474.7,996.7 L383.4,905.4 C377.413788,899.389907 369.282681,896.007942 360.8,896 L128,896 L128,128 Z"
+                      d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
                     />
                   </svg>
                 </span>
               </button>
             </div>
-          </div>
-          <div
-            class="pf-v6-c-toolbar__item  ins-c-primary-toolbar__actions pf-m-spacer-sm"
-          >
-            <button
-              aria-expanded="false"
-              aria-label="kebab dropdown toggle"
-              class="pf-v6-c-menu-toggle pf-m-plain"
-              data-ouia-component-id="BulkActionsToggle"
-              data-ouia-component-type="PF6/MenuToggle"
-              data-ouia-safe="true"
-              type="button"
-            >
-              <span
-                class="pf-v6-c-menu-toggle__icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="pf-v6-svg"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 192 512"
-                  width="1em"
-                >
-                  <path
-                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                  />
-                </svg>
-              </span>
-            </button>
-          </div>
-          <div
-            class="pf-v6-c-toolbar__item ins-c-primary-toolbar__pagination"
-          >
             <div
-              class="pf-v6-c-skeleton pf-m-text-xl"
-              style="--pf-v6-c-skeleton--Width: 200px; margin: 10px;"
+              class="pf-v6-c-toolbar__item ins-c-primary-toolbar__pagination"
             >
-              <span
-                class="pf-v6-screen-reader"
-              />
+              <div
+                class="pf-v6-c-skeleton pf-m-text-xl"
+                style="--pf-v6-c-skeleton--Width: 200px;"
+              >
+                <span
+                  class="pf-v6-screen-reader"
+                />
+              </div>
             </div>
           </div>
         </div>
-      </div>
-      <div
-        class="pf-v6-c-toolbar__content pf-m-hidden"
-        hidden=""
-      >
         <div
-          class="pf-v6-c-toolbar__group"
-        />
-      </div>
-    </div>
-    <table
-      aria-label="Loading"
-      class="pf-v6-c-table pf-m-grid-md pf-m-compact"
-      data-ouia-component-id="SkeletonTable"
-      data-ouia-component-type="PF6/Table"
-      data-ouia-safe="true"
-      numberofcolumns="6"
-      role="grid"
-      rows="20"
-    >
-      <thead
-        class="pf-v6-c-table__thead"
-        data-ouia-component-id="SkeletonTable-thead"
-      >
-        <tr
-          class="pf-v6-c-table__tr"
-          data-ouia-component-id="SkeletonTable-tr-head"
-          data-ouia-component-type="PF6/TableRow"
-          data-ouia-safe="true"
+          class="pf-v6-c-toolbar__content pf-m-hidden"
+          hidden=""
         >
-          <th
-            class="pf-v6-c-table__th"
-            data-ouia-component-id="SkeletonTable-th-0"
-            scope="col"
-            tabindex="-1"
-          >
-            <div
-              class="pf-v6-c-skeleton"
-            >
-              <span
-                class="pf-v6-screen-reader"
-              />
-            </div>
-          </th>
-        </tr>
-      </thead>
-      <tbody
-        class="pf-v6-c-table__tbody"
-        data-ouia-component-id="SkeletonTable-tbody"
-        role="rowgroup"
-      >
-        <tr
-          class="pf-v6-c-table__tr"
-          data-ouia-component-id="SkeletonTable-tr-0"
-          data-ouia-component-type="PF6/TableRow"
-          data-ouia-safe="true"
-        />
-        <tr
-          class="pf-v6-c-table__tr"
-          data-ouia-component-id="SkeletonTable-tr-1"
-          data-ouia-component-type="PF6/TableRow"
-          data-ouia-safe="true"
-        />
-        <tr
-          class="pf-v6-c-table__tr"
-          data-ouia-component-id="SkeletonTable-tr-2"
-          data-ouia-component-type="PF6/TableRow"
-          data-ouia-safe="true"
-        />
-        <tr
-          class="pf-v6-c-table__tr"
-          data-ouia-component-id="SkeletonTable-tr-3"
-          data-ouia-component-type="PF6/TableRow"
-          data-ouia-safe="true"
-        />
-        <tr
-          class="pf-v6-c-table__tr"
-          data-ouia-component-id="SkeletonTable-tr-4"
-          data-ouia-component-type="PF6/TableRow"
-          data-ouia-safe="true"
-        />
-      </tbody>
-    </table>
-    <div
-      class="pf-v6-c-toolbar ins-c-table__toolbar ins-m-footer"
-      data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-4"
-      data-ouia-component-type="RHI/TableToolbar"
-      data-ouia-safe="true"
-      id="pf-random-id-3"
-    >
-      <div
-        class="pf-v6-c-pagination pf-m-bottom"
-      >
-        <div
-          class="pf-v6-c-skeleton pf-m-text-xl"
-          style="--pf-v6-c-skeleton--Width: 350px; margin: 10px;"
-        >
-          <span
-            class="pf-v6-screen-reader"
+          <div
+            class="pf-v6-c-toolbar__group"
           />
         </div>
       </div>
+      <table
+        aria-label="Loading"
+        class="pf-v6-c-table pf-m-grid-md pf-m-compact"
+        data-ouia-component-id="SkeletonTable"
+        data-ouia-component-type="PF6/Table"
+        data-ouia-safe="true"
+        numberofcolumns="6"
+        role="grid"
+        rows="20"
+      >
+        <thead
+          class="pf-v6-c-table__thead"
+          data-ouia-component-id="SkeletonTable-thead"
+        >
+          <tr
+            class="pf-v6-c-table__tr"
+            data-ouia-component-id="SkeletonTable-tr-head"
+            data-ouia-component-type="PF6/TableRow"
+            data-ouia-safe="true"
+          >
+            <th
+              class="pf-v6-c-table__th"
+              data-ouia-component-id="SkeletonTable-th-0"
+              scope="col"
+              tabindex="-1"
+            >
+              <div
+                class="pf-v6-c-skeleton"
+              >
+                <span
+                  class="pf-v6-screen-reader"
+                />
+              </div>
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="pf-v6-c-table__tbody"
+          data-ouia-component-id="SkeletonTable-tbody"
+          role="rowgroup"
+        >
+          <tr
+            class="pf-v6-c-table__tr"
+            data-ouia-component-id="SkeletonTable-tr-0"
+            data-ouia-component-type="PF6/TableRow"
+            data-ouia-safe="true"
+          />
+          <tr
+            class="pf-v6-c-table__tr"
+            data-ouia-component-id="SkeletonTable-tr-1"
+            data-ouia-component-type="PF6/TableRow"
+            data-ouia-safe="true"
+          />
+          <tr
+            class="pf-v6-c-table__tr"
+            data-ouia-component-id="SkeletonTable-tr-2"
+            data-ouia-component-type="PF6/TableRow"
+            data-ouia-safe="true"
+          />
+          <tr
+            class="pf-v6-c-table__tr"
+            data-ouia-component-id="SkeletonTable-tr-3"
+            data-ouia-component-type="PF6/TableRow"
+            data-ouia-safe="true"
+          />
+          <tr
+            class="pf-v6-c-table__tr"
+            data-ouia-component-id="SkeletonTable-tr-4"
+            data-ouia-component-type="PF6/TableRow"
+            data-ouia-safe="true"
+          />
+        </tbody>
+      </table>
       <div
-        class="pf-v6-c-toolbar__content pf-m-hidden"
-        hidden=""
+        class="pf-v6-c-toolbar ins-c-table__toolbar ins-m-footer"
+        data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-4"
+        data-ouia-component-type="RHI/TableToolbar"
+        data-ouia-safe="true"
+        id="pf-random-id-3"
       >
         <div
-          class="pf-v6-c-toolbar__group"
-        />
+          class="pf-v6-c-pagination pf-m-bottom"
+        >
+          <div
+            class="pf-v6-c-skeleton pf-m-text-xl"
+            style="--pf-v6-c-skeleton--Width: 350px; margin: 10px;"
+          >
+            <span
+              class="pf-v6-screen-reader"
+            />
+          </div>
+        </div>
+        <div
+          class="pf-v6-c-toolbar__content pf-m-hidden"
+          hidden=""
+        >
+          <div
+            class="pf-v6-c-toolbar__group"
+          />
+        </div>
       </div>
     </div>
   </section>
@@ -1765,7 +1773,7 @@ exports[`SystemDetail.js Should match the snapshot when Package tab is active by
 exports[`SystemDetail.js Should match the snapshots 1`] = `
 <DocumentFragment>
   <div
-    class="pf-v6-c-tabs pf-m-animate-current pf-m-initializing-accent patchTabSelect"
+    class="pf-v6-c-tabs pf-m-animate-current pf-m-initializing-accent"
     data-ouia-component-id="OUIA-Generated-Tabs-1"
     data-ouia-component-type="PF6/Tabs"
     data-ouia-safe="true"
@@ -1831,329 +1839,60 @@ exports[`SystemDetail.js Should match the snapshots 1`] = `
     tabindex="0"
   >
     <div
-      class="pf-v6-c-toolbar  ins-c-primary-toolbar"
-      data-ouia-component-id="PrimaryToolbar"
-      data-ouia-component-type="PF6/Toolbar"
-      data-ouia-safe="true"
-      id="ins-primary-data-toolbar"
+      class="pf-v6-u-mt-md"
     >
       <div
-        class="pf-v6-c-toolbar__content"
+        class="pf-v6-c-toolbar  ins-c-primary-toolbar"
+        data-ouia-component-id="PrimaryToolbar"
+        data-ouia-component-type="PF6/Toolbar"
+        data-ouia-safe="true"
+        id="ins-primary-data-toolbar"
       >
         <div
-          class="pf-v6-c-toolbar__content-section pf-m-align-items-center"
+          class="pf-v6-c-toolbar__content"
         >
           <div
-            class="pf-v6-c-toolbar__group pf-m-filter-group ins-c-primary-toolbar__group-filter pf-m-spacer-md pf-m-space-items-lg"
+            class="pf-v6-c-toolbar__content-section pf-m-align-items-center"
           >
             <div
-              class="pf-v6-c-toolbar__item"
-            >
-              <button
-                aria-expanded="false"
-                aria-label="Select"
-                class="pf-v6-c-menu-toggle"
-                data-ouia-component-id="BulkSelect"
-                data-ouia-component-type="PF6/MenuToggle"
-                data-ouia-safe="true"
-                type="button"
-              >
-                <span
-                  class="pf-v6-c-menu-toggle__text"
-                >
-                  <label
-                    class="pf-v6-c-check"
-                  >
-                    <input
-                      aria-invalid="false"
-                      aria-label="Select all"
-                      class="pf-v6-c-check__input"
-                      data-ouia-component-id="BulkSelectCheckbox"
-                      data-ouia-component-type="PF6/MenuToggleCheckbox"
-                      data-ouia-safe="true"
-                      name="toggle-checkbox"
-                      type="checkbox"
-                    />
-                    <span
-                      aria-hidden="true"
-                      class="pf-v6-c-check__label"
-                      id="toggle-checkbox"
-                    >
-                      1 selected
-                    </span>
-                  </label>
-                </span>
-                <span
-                  class="pf-v6-c-menu-toggle__controls"
-                >
-                  <span
-                    class="pf-v6-c-menu-toggle__toggle-icon"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="pf-v6-svg"
-                      fill="currentColor"
-                      height="1em"
-                      role="img"
-                      viewBox="0 0 320 512"
-                      width="1em"
-                    >
-                      <path
-                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                      />
-                    </svg>
-                  </span>
-                </span>
-              </button>
-            </div>
-            <div
-              class="pf-v6-c-toolbar__item ins-c-primary-toolbar__filter"
+              class="pf-v6-c-toolbar__group pf-m-filter-group ins-c-primary-toolbar__group-filter pf-m-spacer-md pf-m-space-items-lg"
             >
               <div
-                class="pf-v6-l-split ins-c-conditional-filter ins-c-conditional-filter__split-items-space"
-              >
-                <div
-                  class="pf-v6-l-split__item"
-                >
-                  <button
-                    aria-expanded="false"
-                    aria-label="Conditional filter toggle"
-                    class="pf-v6-c-menu-toggle ins-c-conditional-filter__group"
-                    data-ouia-component-id="ConditionalFilterToggle"
-                    data-ouia-component-type="PF6/MenuToggle"
-                    data-ouia-safe="true"
-                    type="button"
-                  >
-                    <span
-                      class="pf-v6-c-menu-toggle__text"
-                    >
-                      <span
-                        class="pf-v6-c-icon pf-m-md"
-                      >
-                        <span
-                          class="pf-v6-c-icon__content"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="pf-v6-svg"
-                            fill="currentColor"
-                            height="1em"
-                            role="img"
-                            viewBox="0 0 512 512"
-                            width="1em"
-                          >
-                            <path
-                              d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                      <span
-                        class="ins-c-conditional-filter__value-selector"
-                      >
-                        Advisory
-                      </span>
-                    </span>
-                    <span
-                      class="pf-v6-c-menu-toggle__controls"
-                    >
-                      <span
-                        class="pf-v6-c-menu-toggle__toggle-icon"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="pf-v6-svg"
-                          fill="currentColor"
-                          height="1em"
-                          role="img"
-                          viewBox="0 0 320 512"
-                          width="1em"
-                        >
-                          <path
-                            d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                  </button>
-                </div>
-                <div
-                  class="pf-v6-l-split__item pf-m-fill"
-                  data-ouia-component-id="ConditionalFilter"
-                >
-                  <span
-                    class="pf-v6-c-form-control pf-m-icon ins-c-conditional-filter"
-                  >
-                    <input
-                      aria-invalid="false"
-                      aria-label="search-field"
-                      data-ouia-component-id="ConditionalFilter"
-                      data-ouia-component-type="PF6/TextInput"
-                      data-ouia-safe="true"
-                      placeholder="Filter by name or synopsis"
-                      type="text"
-                      value=""
-                      widget-type="InsightsInput"
-                    />
-                    <span
-                      class="pf-v6-c-form-control__utilities"
-                    >
-                      <span
-                        class="pf-v6-c-form-control__icon"
-                      >
-                        <span
-                          class="pf-v6-c-icon pf-m-md ins-c-search-icon"
-                        >
-                          <span
-                            class="pf-v6-c-icon__content"
-                          >
-                            <svg
-                              aria-hidden="true"
-                              class="pf-v6-svg"
-                              fill="currentColor"
-                              height="1em"
-                              role="img"
-                              viewBox="0 0 512 512"
-                              width="1em"
-                            >
-                              <path
-                                d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
-                              />
-                            </svg>
-                          </span>
-                        </span>
-                      </span>
-                    </span>
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="pf-v6-c-toolbar__item ins-c-primary-toolbar__first-action pf-m-spacer-sm"
-          >
-            <div
-              buttonprops="[object Object]"
-              fallback="[object Object]"
-              module="./RemediationButton"
-              scope="remediations"
-            >
-              AsyncComponent
-            </div>
-          </div>
-          <div
-            class="pf-v6-c-toolbar__item pf-m-spacer-sm"
-          >
-            <div
-              style="display: contents;"
-            >
-              <button
-                aria-expanded="false"
-                aria-label="Export"
-                class="pf-v6-c-menu-toggle pf-m-plain"
-                data-ouia-component-id="OUIA-Generated-MenuToggle-plain-1"
-                data-ouia-component-type="PF6/MenuToggle"
-                data-ouia-safe="true"
-                type="button"
-              >
-                <span
-                  class="pf-v6-c-menu-toggle__icon"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="pf-v6-svg"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 1024 1024"
-                    width="1em"
-                  >
-                    <path
-                      d="M975.8,636.9 L870.9,741.8 L457.9,328.6 C452.1,322.8 445.4,319.9 437.9,319.9 C430.4,319.9 423.7,322.8 417.9,328.6 L328.8,417.7 C323,423.5 320.1,430.2 320.1,437.7 C320.1,445.2 323,451.9 328.8,457.7 L742,870.7 L636.9,975.8 C610.5,1002.2 619.4,1024 656.8,1024 L956,1024 C1014.5,1024 1024,1013.7 1024,955.9 L1024,656.7 C1023.9,619.4 1002.2,610.5 975.8,636.9 Z M128,128 L896,128 L896,361.7 C896.007942,370.182681 899.389907,378.313788 905.4,384.3 L996.7,475.6 C1006.8,485.7 1024,478.5 1024,464.3 L1024,22.7 C1024,16.1 1021.9,10.7 1017.6,6.4 C1013.3,2.1 1007.9,0 1001.3,0 L22.7,0 C16.1,0 10.7,2.1 6.4,6.4 C2.1,10.7 0,16.1 0,22.7 L0,1001.3 C0,1007.9 2.1,1013.3 6.4,1017.6 C10.7,1021.9 16.1,1024 22.7,1024 L463.4,1024 C469.862884,1023.98894 475.684489,1020.0908 478.156232,1014.11925 C480.627976,1008.14769 479.264428,1001.27548 474.7,996.7 L383.4,905.4 C377.413788,899.389907 369.282681,896.007942 360.8,896 L128,896 L128,128 Z"
-                    />
-                  </svg>
-                </span>
-              </button>
-            </div>
-          </div>
-          <div
-            class="pf-v6-c-toolbar__item  ins-c-primary-toolbar__actions pf-m-spacer-sm"
-          >
-            <button
-              aria-expanded="false"
-              aria-label="kebab dropdown toggle"
-              class="pf-v6-c-menu-toggle pf-m-plain"
-              data-ouia-component-id="BulkActionsToggle"
-              data-ouia-component-type="PF6/MenuToggle"
-              data-ouia-safe="true"
-              type="button"
-            >
-              <span
-                class="pf-v6-c-menu-toggle__icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="pf-v6-svg"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 192 512"
-                  width="1em"
-                >
-                  <path
-                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                  />
-                </svg>
-              </span>
-            </button>
-          </div>
-          <div
-            class="pf-v6-c-toolbar__item ins-c-primary-toolbar__pagination"
-          >
-            <div
-              class="pf-v6-c-pagination"
-              data-ouia-component-id="top-system-advisories-pagination"
-              data-ouia-component-type="PF6/Pagination"
-              data-ouia-safe="true"
-              id="options-menu-top-pagination"
-              style="--pf-v6-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
-            >
-              <div
-                class="pf-v6-c-pagination__total-items"
-              >
-                <b>
-                  1 - 10
-                </b>
-                 of 
-                <b>
-                  10
-                </b>
-                 
-              </div>
-              <div
-                class="pf-v6-c-pagination__page-menu"
+                class="pf-v6-c-toolbar__item"
               >
                 <button
                   aria-expanded="false"
-                  aria-haspopup="listbox"
-                  class="pf-v6-c-menu-toggle pf-m-plain pf-m-text"
-                  data-ouia-component-id="OUIA-Generated-MenuToggle-plainText-1"
+                  aria-label="Select"
+                  class="pf-v6-c-menu-toggle"
+                  data-ouia-component-id="BulkSelect"
                   data-ouia-component-type="PF6/MenuToggle"
                   data-ouia-safe="true"
-                  id="options-menu-top-toggle"
                   type="button"
                 >
                   <span
                     class="pf-v6-c-menu-toggle__text"
                   >
-                    <b>
-                      1 - 10
-                    </b>
-                     of 
-                    <b>
-                      10
-                    </b>
-                     
+                    <label
+                      class="pf-v6-c-check"
+                    >
+                      <input
+                        aria-invalid="false"
+                        aria-label="Select all"
+                        class="pf-v6-c-check__input"
+                        data-ouia-component-id="BulkSelectCheckbox"
+                        data-ouia-component-type="PF6/MenuToggleCheckbox"
+                        data-ouia-safe="true"
+                        name="toggle-checkbox"
+                        type="checkbox"
+                      />
+                      <span
+                        aria-hidden="true"
+                        class="pf-v6-c-check__label"
+                        id="toggle-checkbox"
+                      >
+                        1 selected
+                      </span>
+                    </label>
                   </span>
                   <span
                     class="pf-v6-c-menu-toggle__controls"
@@ -2178,660 +1917,32 @@ exports[`SystemDetail.js Should match the snapshots 1`] = `
                   </span>
                 </button>
               </div>
-              <nav
-                aria-label="Pagination"
-                class="pf-v6-c-pagination__nav"
+              <div
+                class="pf-v6-c-toolbar__item ins-c-primary-toolbar__filter"
               >
                 <div
-                  class="pf-v6-c-pagination__nav-control"
-                >
-                  <button
-                    aria-label="Go to previous page"
-                    class="pf-v6-c-button pf-m-plain"
-                    data-action="previous"
-                    data-ouia-component-id="OUIA-Generated-Button-plain-1"
-                    data-ouia-component-type="PF6/Button"
-                    data-ouia-safe="true"
-                    disabled=""
-                    type="button"
-                  >
-                    <span
-                      class="pf-v6-c-button__icon"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="pf-v6-svg"
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        viewBox="0 0 256 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                        />
-                      </svg>
-                    </span>
-                  </button>
-                </div>
-                <div
-                  class="pf-v6-c-pagination__nav-control"
-                >
-                  <button
-                    aria-label="Go to next page"
-                    class="pf-v6-c-button pf-m-plain"
-                    data-action="next"
-                    data-ouia-component-id="OUIA-Generated-Button-plain-2"
-                    data-ouia-component-type="PF6/Button"
-                    data-ouia-safe="true"
-                    disabled=""
-                    type="button"
-                  >
-                    <span
-                      class="pf-v6-c-button__icon"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="pf-v6-svg"
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        viewBox="0 0 256 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                        />
-                      </svg>
-                    </span>
-                  </button>
-                </div>
-              </nav>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="pf-v6-c-toolbar__content pf-m-hidden"
-        hidden=""
-      >
-        <div
-          class="pf-v6-c-toolbar__group"
-        />
-      </div>
-    </div>
-    <table
-      aria-label="Patch table view"
-      class="pf-v6-c-table pf-m-grid-md pf-m-compact pf-m-sticky-header"
-      data-ouia-component-id="system-advisories-table"
-      data-ouia-component-type="PF6/Table"
-      data-ouia-safe="true"
-      role="grid"
-    >
-      <thead
-        class="pf-v6-c-table__thead"
-      >
-        <tr
-          class="pf-v6-c-table__tr"
-          data-ouia-component-id="OUIA-Generated-TableRow-1"
-          data-ouia-component-type="PF6/TableRow"
-          data-ouia-safe="true"
-        >
-          <th
-            class="pf-v6-c-table__th"
-            data-key="0"
-            data-label=""
-            scope=""
-            tabindex="-1"
-          />
-          <th
-            class="pf-v6-c-table__th"
-            data-key="1"
-            data-label=""
-            scope=""
-            tabindex="-1"
-          />
-          <th
-            class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-15"
-            data-key="2"
-            data-label="Name"
-            scope="col"
-            tabindex="-1"
-          >
-            <button
-              class="pf-v6-c-table__button"
-              type="button"
-            >
-              <div
-                class="pf-v6-c-table__button-content"
-              >
-                <span
-                  class="pf-v6-c-table__text"
-                >
-                  Name
-                </span>
-                <span
-                  class="pf-v6-c-table__sort-indicator"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="pf-v6-svg"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 256 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                    />
-                  </svg>
-                </span>
-              </div>
-            </button>
-          </th>
-          <th
-            class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-35"
-            data-key="3"
-            data-label="Synopsis"
-            scope="col"
-            tabindex="-1"
-          >
-            <button
-              class="pf-v6-c-table__button"
-              type="button"
-            >
-              <div
-                class="pf-v6-c-table__button-content"
-              >
-                <span
-                  class="pf-v6-c-table__text"
-                >
-                  Synopsis
-                </span>
-                <span
-                  class="pf-v6-c-table__sort-indicator"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="pf-v6-svg"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 256 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                    />
-                  </svg>
-                </span>
-              </div>
-            </button>
-          </th>
-          <th
-            class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-10"
-            data-key="4"
-            data-label="Status"
-            scope="col"
-            tabindex="-1"
-          >
-            <button
-              class="pf-v6-c-table__button"
-              type="button"
-            >
-              <div
-                class="pf-v6-c-table__button-content"
-              >
-                <span
-                  class="pf-v6-c-table__text"
-                >
-                  Status
-                </span>
-                <span
-                  class="pf-v6-c-table__sort-indicator"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="pf-v6-svg"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 256 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                    />
-                  </svg>
-                </span>
-              </div>
-            </button>
-          </th>
-          <th
-            class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-10"
-            data-key="5"
-            data-label="Type"
-            scope="col"
-            tabindex="-1"
-          >
-            <button
-              class="pf-v6-c-table__button"
-              type="button"
-            >
-              <div
-                class="pf-v6-c-table__button-content"
-              >
-                <span
-                  class="pf-v6-c-table__text"
-                >
-                  Type
-                </span>
-                <span
-                  class="pf-v6-c-table__sort-indicator"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="pf-v6-svg"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 256 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                    />
-                  </svg>
-                </span>
-              </div>
-            </button>
-          </th>
-          <th
-            class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-10"
-            data-key="6"
-            data-label="Severity"
-            scope="col"
-            tabindex="-1"
-          >
-            <button
-              class="pf-v6-c-table__button"
-              type="button"
-            >
-              <div
-                class="pf-v6-c-table__button-content"
-              >
-                <span
-                  class="pf-v6-c-table__text"
-                >
-                  Severity
-                </span>
-                <span
-                  class="pf-v6-c-table__sort-indicator"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="pf-v6-svg"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 256 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                    />
-                  </svg>
-                </span>
-              </div>
-            </button>
-          </th>
-          <th
-            class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-10"
-            data-key="7"
-            data-label="Reboot"
-            scope="col"
-            tabindex="-1"
-          >
-            <button
-              class="pf-v6-c-table__button"
-              type="button"
-            >
-              <div
-                class="pf-v6-c-table__button-content"
-              >
-                <span
-                  class="pf-v6-c-table__text"
-                >
-                  Reboot
-                </span>
-                <span
-                  class="pf-v6-c-table__sort-indicator"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="pf-v6-svg"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 256 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                    />
-                  </svg>
-                </span>
-              </div>
-            </button>
-          </th>
-          <th
-            class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-10"
-            data-key="8"
-            data-label="Publish date"
-            scope="col"
-            tabindex="-1"
-          >
-            <button
-              class="pf-v6-c-table__button"
-              type="button"
-            >
-              <div
-                class="pf-v6-c-table__button-content"
-              >
-                <span
-                  class="pf-v6-c-table__text"
-                >
-                  Publish date
-                </span>
-                <span
-                  class="pf-v6-c-table__sort-indicator"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="pf-v6-svg"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 256 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                    />
-                  </svg>
-                </span>
-              </div>
-            </button>
-          </th>
-        </tr>
-      </thead>
-      <tbody
-        class="pf-v6-c-table__tbody"
-        role="rowgroup"
-      >
-        <tr
-          class="pf-v6-c-table__tr"
-          data-ouia-component-id="OUIA-Generated-TableRow-2"
-          data-ouia-component-type="PF6/TableRow"
-          data-ouia-safe="true"
-        >
-          <td
-            class="pf-v6-c-table__td pf-v6-c-table__toggle"
-            data-key="0"
-            tabindex="-1"
-          >
-            <button
-              aria-expanded="false"
-              aria-label="Details"
-              aria-labelledby="simple-node0 expandable-toggle0"
-              class="pf-v6-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-3"
-              data-ouia-component-type="PF6/Button"
-              data-ouia-safe="true"
-              id="expandable-toggle0"
-              type="button"
-            >
-              <span
-                class="pf-v6-c-button__icon"
-              >
-                <div
-                  class="pf-v6-c-table__toggle-icon"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="pf-v6-svg"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 320 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
-                    />
-                  </svg>
-                </div>
-              </span>
-            </button>
-          </td>
-          <td
-            class="pf-v6-c-table__td pf-v6-c-table__check"
-            data-key="1"
-            tabindex="-1"
-          >
-            <label>
-              <input
-                aria-label="Select row 0"
-                checked=""
-                name="checkrow0"
-                type="checkbox"
-              />
-            </label>
-          </td>
-          <td
-            class="pf-v6-c-table__td"
-            data-key="2"
-            data-label="Name"
-            tabindex="-1"
-          >
-            <a
-              href="/insights/patch/advisories/RHSA-2020:2774"
-            >
-              RHSA-2020:2774
-            </a>
-          </td>
-          <td
-            class="pf-v6-c-table__td"
-            data-key="3"
-            data-label="Synopsis"
-            tabindex="-1"
-          >
-            <div
-              class="LinesEllipsis  "
-            >
-              Important
-              <wbr />
-            </div>
-          </td>
-          <td
-            class="pf-v6-c-table__td"
-            data-key="4"
-            data-label="Status"
-            tabindex="-1"
-          >
-            Installable
-          </td>
-          <td
-            class="pf-v6-c-table__td"
-            data-key="5"
-            data-label="Type"
-            tabindex="-1"
-          >
-            <div
-              class="pf-v6-l-split pf-m-gutter"
-            >
-              <div
-                class="pf-v6-l-split__item"
-              >
-                <span
-                  class="pf-v6-c-icon"
-                >
-                  <span
-                    class="pf-v6-c-icon__content"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="pf-v6-svg"
-                      fill="currentColor"
-                      height="1em"
-                      role="img"
-                      viewBox="0 0 896 1024"
-                      width="1em"
-                    >
-                      <path
-                        d="M861.5,0 L34.5,0 C15.4,0 0,14.3 0,32 L0,452.1 C0,768 387.7,1024 448.5,1024 C509.3,1024 896,768 896,452.2 L896,32 C896,14.3 880.6,0 861.5,0 Z M490.7,768 L405.3,768 C393.5,767.8 384.2,757.5 384,744.7 L384,663.3 C384.2,650.5 393.6,640.3 405.3,640 L490.7,640 C502.5,640.2 511.8,650.5 512,663.3 L512,744.7 L512.1,744.7 C511.8,757.5 502.4,767.8 490.7,768 Z M543.9,162.7 L517.2,514.4 C515.8,530.9 502,544 485.3,544 L410.6,544 C394,544 380.1,531.2 378.7,514.7 L352.1,163 C350.5,144.3 365.3,128.3 384,128.3 L512,128 C530.7,128 545.4,144 543.9,162.7 Z"
-                      />
-                    </svg>
-                  </span>
-                </span>
-              </div>
-              <div
-                class="pf-v6-l-split__item pf-m-fill"
-              >
-                Security
-              </div>
-            </div>
-          </td>
-          <td
-            class="pf-v6-c-table__td"
-            data-key="6"
-            data-label="Severity"
-            tabindex="-1"
-          >
-            <div
-              class="pf-v6-l-flex pf-m-nowrap pf-m-gap-sm"
-            >
-              <span
-                class="pf-v6-c-icon pf-m-sm"
-              >
-                <span
-                  class="pf-v6-c-icon__content"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="pf-v6-svg"
-                    color="var(--pf-t--global--icon--color--severity--important--default)"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 1024 1024"
-                    width="1em"
-                  >
-                    <path
-                      d="M0,587.2c0,23.2,10.8,40.4,30.7,51.6,20.8,11.7,42.1,12.5,63.1-.5l378.4-235.4c26.5-16.7,51.7-16.4,78.7.5,123.4,77.2,247.5,153.4,371,230.5,22.9,14.3,44.9,18.7,69.3,5.3,24.5-13.5,32.5-35,32.3-61.4-.4-49.4,0-41.9,0-91.3s-.3-99.9,0-149.8c.2-27.6-11.5-47.8-35.1-61.8C841.4,187.2,694.4,99.5,547.5,11.7c-24.5-14.6-48.1-14.4-72.4.2C327.3,100.3,179.4,188.5,31.7,276.8c-21.1,12.6-31.7,31.5-31.7,56.1v254.3ZM1023.8,857.8c0,1.9,0-.6.2-10.3,0-2.1,0-4.1-.2-6.1v-35.1c0-29.9,0,8.8,0,33.8-1.8-23.9-13.4-41.7-34.9-54.4-147-87.7-294-175.4-441-263.3-24.5-14.6-48.1-14.4-72.4.2-147.7,88.4-295.6,176.6-443.4,265-21.1,12.6-31.7,31.4-31.7,56.1v120.3c0,23.2,10.8,40.4,30.7,51.6,20.8,11.7,42.1,12.5,63.1-.5l378.4-235.4c26.5-16.7,51.7-16.4,78.7.5,123.4,77.2,247.5,153.4,371,230.5,22.9,14.3,44.9,18.7,69.3,5.3,24.5-13.5,32.5-35,32.3-61.4-.2-32.3-.2-64.6-.2-96.9h.2Z"
-                    />
-                  </svg>
-                </span>
-              </span>
-              Important
-            </div>
-          </td>
-          <td
-            class="pf-v6-c-table__td"
-            data-key="7"
-            data-label="Reboot"
-            tabindex="-1"
-          >
-            Required
-          </td>
-          <td
-            class="pf-v6-c-table__td"
-            data-key="8"
-            data-label="Publish date"
-            tabindex="-1"
-          >
-            30 June 2020
-          </td>
-        </tr>
-        <tr
-          class="pf-v6-c-table__tr pf-v6-c-table__expandable-row"
-          data-ouia-component-id="OUIA-Generated-TableRow-3"
-          data-ouia-component-type="PF6/TableRow"
-          data-ouia-safe="true"
-          hidden=""
-        >
-          <td
-            class="pf-v6-c-table__td"
-            data-key="0"
-            tabindex="-1"
-          />
-          <td
-            class="pf-v6-c-table__td"
-            data-key="1"
-            tabindex="-1"
-          />
-          <td
-            class="pf-v6-c-table__td"
-            colspan="7"
-            data-key="2"
-            id="expanded-content1-2"
-            tabindex="-1"
-          >
-            <div
-              class="pf-v6-c-table__expandable-row-content"
-            >
-              <div
-                class="pf-v6-c-content patch-advisory-description"
-                data-ouia-component-id="OUIA-Generated-Content-1"
-                data-ouia-component-type="PF6/Content"
-                data-ouia-safe="true"
-                data-pf-content="true"
-              >
-                <span
-                  class="patchman-label"
-                >
-                  Description
-                </span>
-                <p
-                  class="pf-v6-c-content--p"
-                  data-ouia-component-id="OUIA-Generated-Content-2"
-                  data-ouia-component-type="PF6/Content"
-                  data-ouia-safe="true"
-                  data-pf-content="true"
-                  style="white-space: pre-line;"
-                >
-                  Kernel-based Virtual.
-                </p>
-                <div
-                  class="pf-v6-l-flex pf-m-column"
+                  class="pf-v6-l-split ins-c-conditional-filter ins-c-conditional-filter__split-items-space"
                 >
                   <div
-                    class="pf-m-spacer-none"
+                    class="pf-v6-l-split__item"
                   >
-                    <h6
-                      class="pf-v6-c-title pf-m-h6"
-                      data-ouia-component-id="OUIA-Generated-Title-1"
-                      data-ouia-component-type="PF6/Title"
+                    <button
+                      aria-expanded="false"
+                      aria-label="Conditional filter toggle"
+                      class="pf-v6-c-menu-toggle ins-c-conditional-filter__group"
+                      data-ouia-component-id="ConditionalFilterToggle"
+                      data-ouia-component-type="PF6/MenuToggle"
                       data-ouia-safe="true"
+                      type="button"
                     >
-                      Reboot
-                    </h6>
-                  </div>
-                  <div
-                    class="pf-m-spacer-sm"
-                  >
-                    <div
-                      class="pf-v6-l-split pf-m-gutter"
-                    >
-                      <div
-                        class="pf-v6-l-split__item"
+                      <span
+                        class="pf-v6-c-menu-toggle__text"
                       >
                         <span
                           class="pf-v6-c-icon pf-m-md"
                         >
                           <span
-                            class="pf-v6-c-icon__content pf-m-danger"
+                            class="pf-v6-c-icon__content"
                           >
                             <svg
                               aria-hidden="true"
@@ -2843,384 +1954,22 @@ exports[`SystemDetail.js Should match the snapshots 1`] = `
                               width="1em"
                             >
                               <path
-                                d="M400 54.1c63 45 104 118.6 104 201.9 0 136.8-110.8 247.7-247.5 248C120 504.3 8.2 393 8 256.4 7.9 173.1 48.9 99.3 111.8 54.2c11.7-8.3 28-4.8 35 7.7L162.6 90c5.9 10.5 3.1 23.8-6.6 31-41.5 30.8-68 79.6-68 134.9-.1 92.3 74.5 168.1 168 168.1 91.6 0 168.6-74.2 168-169.1-.3-51.8-24.7-101.8-68.1-134-9.7-7.2-12.4-20.5-6.5-30.9l15.8-28.1c7-12.4 23.2-16.1 34.8-7.8zM296 264V24c0-13.3-10.7-24-24-24h-32c-13.3 0-24 10.7-24 24v240c0 13.3 10.7 24 24 24h32c13.3 0 24-10.7 24-24z"
+                                d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
                               />
                             </svg>
                           </span>
                         </span>
-                      </div>
-                      <div
-                        class="pf-v6-l-split__item pf-m-fill"
-                      >
-                        Reboot is required
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <a
-                  href="https://access.redhat.com/errata/RHSA-2020:2774"
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  View packages and errata at access.redhat.com
-                  <svg
-                    aria-hidden="true"
-                    class="pf-v6-svg pf-v6-u-ml-xs"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    viewBox="0 0 512 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
-                    />
-                  </svg>
-                </a>
-              </div>
-            </div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <div
-      class="pf-v6-c-toolbar ins-c-table__toolbar ins-m-footer"
-      data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-1"
-      data-ouia-component-type="RHI/TableToolbar"
-      data-ouia-safe="true"
-      id="pf-random-id-0"
-    >
-      <div
-        class="pf-v6-c-pagination pf-m-bottom"
-        data-ouia-component-id="bottom-system-advisories-pagination"
-        data-ouia-component-type="PF6/Pagination"
-        data-ouia-safe="true"
-        id="pagination-options-menu-bottom-bottom-pagination"
-        style="--pf-v6-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
-      >
-        <div
-          class="pf-v6-c-pagination__page-menu"
-        >
-          <button
-            aria-expanded="false"
-            aria-haspopup="listbox"
-            class="pf-v6-c-menu-toggle pf-m-plain pf-m-text"
-            data-ouia-component-id="OUIA-Generated-MenuToggle-plainText-2"
-            data-ouia-component-type="PF6/MenuToggle"
-            data-ouia-safe="true"
-            id="pagination-options-menu-bottom-bottom-toggle"
-            type="button"
-          >
-            <span
-              class="pf-v6-c-menu-toggle__text"
-            >
-              <b>
-                1 - 10
-              </b>
-               of 
-              <b>
-                10
-              </b>
-               
-            </span>
-            <span
-              class="pf-v6-c-menu-toggle__controls"
-            >
-              <span
-                class="pf-v6-c-menu-toggle__toggle-icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="pf-v6-svg"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 320 512"
-                  width="1em"
-                >
-                  <path
-                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                  />
-                </svg>
-              </span>
-            </span>
-          </button>
-        </div>
-        <nav
-          aria-label="Pagination"
-          class="pf-v6-c-pagination__nav"
-        >
-          <div
-            class="pf-v6-c-pagination__nav-control pf-m-first"
-          >
-            <button
-              aria-label="Go to first page"
-              class="pf-v6-c-button pf-m-plain"
-              data-action="first"
-              data-ouia-component-id="OUIA-Generated-Button-plain-4"
-              data-ouia-component-type="PF6/Button"
-              data-ouia-safe="true"
-              disabled=""
-              type="button"
-            >
-              <span
-                class="pf-v6-c-button__icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="pf-v6-svg"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 448 512"
-                  width="1em"
-                >
-                  <path
-                    d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
-                  />
-                </svg>
-              </span>
-            </button>
-          </div>
-          <div
-            class="pf-v6-c-pagination__nav-control"
-          >
-            <button
-              aria-label="Go to previous page"
-              class="pf-v6-c-button pf-m-plain"
-              data-action="previous"
-              data-ouia-component-id="OUIA-Generated-Button-plain-5"
-              data-ouia-component-type="PF6/Button"
-              data-ouia-safe="true"
-              disabled=""
-              type="button"
-            >
-              <span
-                class="pf-v6-c-button__icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="pf-v6-svg"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 256 512"
-                  width="1em"
-                >
-                  <path
-                    d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
-                  />
-                </svg>
-              </span>
-            </button>
-          </div>
-          <div
-            class="pf-v6-c-pagination__nav-page-select"
-          >
-            <span
-              class="pf-v6-c-form-control pf-m-disabled"
-            >
-              <input
-                aria-invalid="false"
-                aria-label="Current page"
-                data-ouia-component-id="OUIA-Generated-TextInputBase-2"
-                data-ouia-component-type="PF6/TextInput"
-                data-ouia-safe="true"
-                disabled=""
-                max="1"
-                min="1"
-                type="number"
-                value="1"
-              />
-            </span>
-            <span
-              aria-hidden="true"
-            >
-              of 1
-            </span>
-          </div>
-          <div
-            class="pf-v6-c-pagination__nav-control"
-          >
-            <button
-              aria-label="Go to next page"
-              class="pf-v6-c-button pf-m-plain"
-              data-action="next"
-              data-ouia-component-id="OUIA-Generated-Button-plain-6"
-              data-ouia-component-type="PF6/Button"
-              data-ouia-safe="true"
-              disabled=""
-              type="button"
-            >
-              <span
-                class="pf-v6-c-button__icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="pf-v6-svg"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 256 512"
-                  width="1em"
-                >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                  />
-                </svg>
-              </span>
-            </button>
-          </div>
-          <div
-            class="pf-v6-c-pagination__nav-control pf-m-last"
-          >
-            <button
-              aria-label="Go to last page"
-              class="pf-v6-c-button pf-m-plain"
-              data-action="last"
-              data-ouia-component-id="OUIA-Generated-Button-plain-7"
-              data-ouia-component-type="PF6/Button"
-              data-ouia-safe="true"
-              disabled=""
-              type="button"
-            >
-              <span
-                class="pf-v6-c-button__icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="pf-v6-svg"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 448 512"
-                  width="1em"
-                >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
-                  />
-                </svg>
-              </span>
-            </button>
-          </div>
-        </nav>
-      </div>
-      <div
-        class="pf-v6-c-toolbar__content pf-m-hidden"
-        hidden=""
-      >
-        <div
-          class="pf-v6-c-toolbar__group"
-        />
-      </div>
-    </div>
-  </section>
-  <section
-    aria-labelledby="pf-tab-1-system-packages-tab"
-    class="pf-v6-c-tab-content"
-    data-ouia-component-type="PF6/TabContent"
-    data-ouia-safe="true"
-    hidden=""
-    id="pf-tab-section-1-system-packages-tab"
-    role="tabpanel"
-    tabindex="0"
-  >
-    <div
-      class="pf-v6-c-toolbar  ins-c-primary-toolbar"
-      data-ouia-component-id="PrimaryToolbar"
-      data-ouia-component-type="PF6/Toolbar"
-      data-ouia-safe="true"
-      id="ins-primary-data-toolbar"
-    >
-      <div
-        class="pf-v6-c-toolbar__content"
-      >
-        <div
-          class="pf-v6-c-toolbar__content-section pf-m-align-items-center"
-        >
-          <div
-            class="pf-v6-c-toolbar__group pf-m-filter-group ins-c-primary-toolbar__group-filter pf-m-spacer-md pf-m-space-items-lg"
-          >
-            <div
-              class="pf-v6-c-toolbar__item"
-            >
-              <button
-                aria-expanded="false"
-                aria-label="Select"
-                class="pf-v6-c-menu-toggle pf-m-disabled"
-                data-ouia-component-id="BulkSelect"
-                data-ouia-component-type="PF6/MenuToggle"
-                data-ouia-safe="true"
-                disabled=""
-                type="button"
-              >
-                <span
-                  class="pf-v6-c-menu-toggle__text"
-                >
-                  <label
-                    class="pf-v6-c-check pf-m-standalone"
-                  >
-                    <input
-                      aria-invalid="false"
-                      aria-label="Select all"
-                      class="pf-v6-c-check__input"
-                      data-ouia-component-id="BulkSelectCheckbox"
-                      data-ouia-component-type="PF6/MenuToggleCheckbox"
-                      data-ouia-safe="true"
-                      name="toggle-checkbox"
-                      type="checkbox"
-                    />
-                  </label>
-                </span>
-                <span
-                  class="pf-v6-c-menu-toggle__controls"
-                >
-                  <span
-                    class="pf-v6-c-menu-toggle__toggle-icon"
-                  >
-                    <svg
-                      aria-hidden="true"
-                      class="pf-v6-svg"
-                      fill="currentColor"
-                      height="1em"
-                      role="img"
-                      viewBox="0 0 320 512"
-                      width="1em"
-                    >
-                      <path
-                        d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-                      />
-                    </svg>
-                  </span>
-                </span>
-              </button>
-            </div>
-            <div
-              class="pf-v6-c-toolbar__item ins-c-primary-toolbar__filter"
-            >
-              <div
-                class="pf-v6-l-split ins-c-conditional-filter ins-c-conditional-filter__split-items-space"
-              >
-                <div
-                  class="pf-v6-l-split__item"
-                >
-                  <button
-                    aria-expanded="false"
-                    aria-label="Conditional filter toggle"
-                    class="pf-v6-c-menu-toggle ins-c-conditional-filter__group"
-                    data-ouia-component-id="ConditionalFilterToggle"
-                    data-ouia-component-type="PF6/MenuToggle"
-                    data-ouia-safe="true"
-                    type="button"
-                  >
-                    <span
-                      class="pf-v6-c-menu-toggle__text"
-                    >
+                        <span
+                          class="ins-c-conditional-filter__value-selector"
+                        >
+                          Advisory
+                        </span>
+                      </span>
                       <span
-                        class="pf-v6-c-icon pf-m-md"
+                        class="pf-v6-c-menu-toggle__controls"
                       >
                         <span
-                          class="pf-v6-c-icon__content"
+                          class="pf-v6-c-menu-toggle__toggle-icon"
                         >
                           <svg
                             aria-hidden="true"
@@ -3228,20 +1977,194 @@ exports[`SystemDetail.js Should match the snapshots 1`] = `
                             fill="currentColor"
                             height="1em"
                             role="img"
-                            viewBox="0 0 512 512"
+                            viewBox="0 0 320 512"
                             width="1em"
                           >
                             <path
-                              d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
+                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
                             />
                           </svg>
                         </span>
                       </span>
+                    </button>
+                  </div>
+                  <div
+                    class="pf-v6-l-split__item pf-m-fill"
+                    data-ouia-component-id="ConditionalFilter"
+                  >
+                    <span
+                      class="pf-v6-c-form-control pf-m-icon ins-c-conditional-filter"
+                    >
+                      <input
+                        aria-invalid="false"
+                        aria-label="search-field"
+                        data-ouia-component-id="ConditionalFilter"
+                        data-ouia-component-type="PF6/TextInput"
+                        data-ouia-safe="true"
+                        placeholder="Filter by name or synopsis"
+                        type="text"
+                        value=""
+                        widget-type="InsightsInput"
+                      />
                       <span
-                        class="ins-c-conditional-filter__value-selector"
+                        class="pf-v6-c-form-control__utilities"
                       >
-                        Package
+                        <span
+                          class="pf-v6-c-form-control__icon"
+                        >
+                          <span
+                            class="pf-v6-c-icon pf-m-md ins-c-search-icon"
+                          >
+                            <span
+                              class="pf-v6-c-icon__content"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v6-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 512 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                        </span>
                       </span>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="pf-v6-c-toolbar__item ins-c-primary-toolbar__first-action pf-m-spacer-sm"
+            >
+              <div
+                buttonprops="[object Object]"
+                fallback="[object Object]"
+                module="./RemediationButton"
+                scope="remediations"
+              >
+                AsyncComponent
+              </div>
+            </div>
+            <div
+              class="pf-v6-c-toolbar__item pf-m-spacer-sm"
+            >
+              <div
+                style="display: contents;"
+              >
+                <button
+                  aria-expanded="false"
+                  aria-label="Export"
+                  class="pf-v6-c-menu-toggle pf-m-plain"
+                  data-ouia-component-id="OUIA-Generated-MenuToggle-plain-1"
+                  data-ouia-component-type="PF6/MenuToggle"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <span
+                    class="pf-v6-c-menu-toggle__icon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 1024 1024"
+                      width="1em"
+                    >
+                      <path
+                        d="M975.8,636.9 L870.9,741.8 L457.9,328.6 C452.1,322.8 445.4,319.9 437.9,319.9 C430.4,319.9 423.7,322.8 417.9,328.6 L328.8,417.7 C323,423.5 320.1,430.2 320.1,437.7 C320.1,445.2 323,451.9 328.8,457.7 L742,870.7 L636.9,975.8 C610.5,1002.2 619.4,1024 656.8,1024 L956,1024 C1014.5,1024 1024,1013.7 1024,955.9 L1024,656.7 C1023.9,619.4 1002.2,610.5 975.8,636.9 Z M128,128 L896,128 L896,361.7 C896.007942,370.182681 899.389907,378.313788 905.4,384.3 L996.7,475.6 C1006.8,485.7 1024,478.5 1024,464.3 L1024,22.7 C1024,16.1 1021.9,10.7 1017.6,6.4 C1013.3,2.1 1007.9,0 1001.3,0 L22.7,0 C16.1,0 10.7,2.1 6.4,6.4 C2.1,10.7 0,16.1 0,22.7 L0,1001.3 C0,1007.9 2.1,1013.3 6.4,1017.6 C10.7,1021.9 16.1,1024 22.7,1024 L463.4,1024 C469.862884,1023.98894 475.684489,1020.0908 478.156232,1014.11925 C480.627976,1008.14769 479.264428,1001.27548 474.7,996.7 L383.4,905.4 C377.413788,899.389907 369.282681,896.007942 360.8,896 L128,896 L128,128 Z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              class="pf-v6-c-toolbar__item  ins-c-primary-toolbar__actions pf-m-spacer-sm"
+            >
+              <button
+                aria-expanded="false"
+                aria-label="kebab dropdown toggle"
+                class="pf-v6-c-menu-toggle pf-m-plain"
+                data-ouia-component-id="BulkActionsToggle"
+                data-ouia-component-type="PF6/MenuToggle"
+                data-ouia-safe="true"
+                type="button"
+              >
+                <span
+                  class="pf-v6-c-menu-toggle__icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 192 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+            <div
+              class="pf-v6-c-toolbar__item ins-c-primary-toolbar__pagination"
+            >
+              <div
+                class="pf-v6-c-pagination"
+                data-ouia-component-id="top-system-advisories-pagination"
+                data-ouia-component-type="PF6/Pagination"
+                data-ouia-safe="true"
+                id="options-menu-top-pagination"
+                style="--pf-v6-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+              >
+                <div
+                  class="pf-v6-c-pagination__total-items"
+                >
+                  <b>
+                    1 - 10
+                  </b>
+                   of 
+                  <b>
+                    10
+                  </b>
+                   
+                </div>
+                <div
+                  class="pf-v6-c-pagination__page-menu"
+                >
+                  <button
+                    aria-expanded="false"
+                    aria-haspopup="listbox"
+                    class="pf-v6-c-menu-toggle pf-m-plain pf-m-text"
+                    data-ouia-component-id="OUIA-Generated-MenuToggle-plainText-1"
+                    data-ouia-component-type="PF6/MenuToggle"
+                    data-ouia-safe="true"
+                    id="options-menu-top-toggle"
+                    type="button"
+                  >
+                    <span
+                      class="pf-v6-c-menu-toggle__text"
+                    >
+                      <b>
+                        1 - 10
+                      </b>
+                       of 
+                      <b>
+                        10
+                      </b>
+                       
                     </span>
                     <span
                       class="pf-v6-c-menu-toggle__controls"
@@ -3266,32 +2189,1050 @@ exports[`SystemDetail.js Should match the snapshots 1`] = `
                     </span>
                   </button>
                 </div>
-                <div
-                  class="pf-v6-l-split__item pf-m-fill"
-                  data-ouia-component-id="ConditionalFilter"
+                <nav
+                  aria-label="Pagination"
+                  class="pf-v6-c-pagination__nav"
                 >
-                  <span
-                    class="pf-v6-c-form-control pf-m-icon ins-c-conditional-filter"
+                  <div
+                    class="pf-v6-c-pagination__nav-control"
                   >
-                    <input
-                      aria-invalid="false"
-                      aria-label="search-field"
-                      data-ouia-component-id="ConditionalFilter"
-                      data-ouia-component-type="PF6/TextInput"
+                    <button
+                      aria-label="Go to previous page"
+                      class="pf-v6-c-button pf-m-plain"
+                      data-action="previous"
+                      data-ouia-component-id="OUIA-Generated-Button-plain-1"
+                      data-ouia-component-type="PF6/Button"
                       data-ouia-safe="true"
-                      placeholder="Filter by name or summary"
-                      type="text"
-                      value=""
-                      widget-type="InsightsInput"
-                    />
-                    <span
-                      class="pf-v6-c-form-control__utilities"
+                      disabled=""
+                      type="button"
                     >
                       <span
-                        class="pf-v6-c-form-control__icon"
+                        class="pf-v6-c-button__icon"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="pf-v6-svg"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 256 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                          />
+                        </svg>
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    class="pf-v6-c-pagination__nav-control"
+                  >
+                    <button
+                      aria-label="Go to next page"
+                      class="pf-v6-c-button pf-m-plain"
+                      data-action="next"
+                      data-ouia-component-id="OUIA-Generated-Button-plain-2"
+                      data-ouia-component-type="PF6/Button"
+                      data-ouia-safe="true"
+                      disabled=""
+                      type="button"
+                    >
+                      <span
+                        class="pf-v6-c-button__icon"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="pf-v6-svg"
+                          fill="currentColor"
+                          height="1em"
+                          role="img"
+                          viewBox="0 0 256 512"
+                          width="1em"
+                        >
+                          <path
+                            d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                          />
+                        </svg>
+                      </span>
+                    </button>
+                  </div>
+                </nav>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="pf-v6-c-toolbar__content pf-m-hidden"
+          hidden=""
+        >
+          <div
+            class="pf-v6-c-toolbar__group"
+          />
+        </div>
+      </div>
+      <table
+        aria-label="Patch table view"
+        class="pf-v6-c-table pf-m-grid-md pf-m-compact pf-m-sticky-header"
+        data-ouia-component-id="system-advisories-table"
+        data-ouia-component-type="PF6/Table"
+        data-ouia-safe="true"
+        role="grid"
+      >
+        <thead
+          class="pf-v6-c-table__thead"
+        >
+          <tr
+            class="pf-v6-c-table__tr"
+            data-ouia-component-id="OUIA-Generated-TableRow-1"
+            data-ouia-component-type="PF6/TableRow"
+            data-ouia-safe="true"
+          >
+            <th
+              class="pf-v6-c-table__th"
+              data-key="0"
+              data-label=""
+              scope=""
+              tabindex="-1"
+            />
+            <th
+              class="pf-v6-c-table__th"
+              data-key="1"
+              data-label=""
+              scope=""
+              tabindex="-1"
+            />
+            <th
+              class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-15"
+              data-key="2"
+              data-label="Name"
+              scope="col"
+              tabindex="-1"
+            >
+              <button
+                class="pf-v6-c-table__button"
+                type="button"
+              >
+                <div
+                  class="pf-v6-c-table__button-content"
+                >
+                  <span
+                    class="pf-v6-c-table__text"
+                  >
+                    Name
+                  </span>
+                  <span
+                    class="pf-v6-c-table__sort-indicator"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 256 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </button>
+            </th>
+            <th
+              class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-35"
+              data-key="3"
+              data-label="Synopsis"
+              scope="col"
+              tabindex="-1"
+            >
+              <button
+                class="pf-v6-c-table__button"
+                type="button"
+              >
+                <div
+                  class="pf-v6-c-table__button-content"
+                >
+                  <span
+                    class="pf-v6-c-table__text"
+                  >
+                    Synopsis
+                  </span>
+                  <span
+                    class="pf-v6-c-table__sort-indicator"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 256 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </button>
+            </th>
+            <th
+              class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-10"
+              data-key="4"
+              data-label="Status"
+              scope="col"
+              tabindex="-1"
+            >
+              <button
+                class="pf-v6-c-table__button"
+                type="button"
+              >
+                <div
+                  class="pf-v6-c-table__button-content"
+                >
+                  <span
+                    class="pf-v6-c-table__text"
+                  >
+                    Status
+                  </span>
+                  <span
+                    class="pf-v6-c-table__sort-indicator"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 256 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </button>
+            </th>
+            <th
+              class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-10"
+              data-key="5"
+              data-label="Type"
+              scope="col"
+              tabindex="-1"
+            >
+              <button
+                class="pf-v6-c-table__button"
+                type="button"
+              >
+                <div
+                  class="pf-v6-c-table__button-content"
+                >
+                  <span
+                    class="pf-v6-c-table__text"
+                  >
+                    Type
+                  </span>
+                  <span
+                    class="pf-v6-c-table__sort-indicator"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 256 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </button>
+            </th>
+            <th
+              class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-10"
+              data-key="6"
+              data-label="Severity"
+              scope="col"
+              tabindex="-1"
+            >
+              <button
+                class="pf-v6-c-table__button"
+                type="button"
+              >
+                <div
+                  class="pf-v6-c-table__button-content"
+                >
+                  <span
+                    class="pf-v6-c-table__text"
+                  >
+                    Severity
+                  </span>
+                  <span
+                    class="pf-v6-c-table__sort-indicator"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 256 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </button>
+            </th>
+            <th
+              class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-10"
+              data-key="7"
+              data-label="Reboot"
+              scope="col"
+              tabindex="-1"
+            >
+              <button
+                class="pf-v6-c-table__button"
+                type="button"
+              >
+                <div
+                  class="pf-v6-c-table__button-content"
+                >
+                  <span
+                    class="pf-v6-c-table__text"
+                  >
+                    Reboot
+                  </span>
+                  <span
+                    class="pf-v6-c-table__sort-indicator"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 256 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </button>
+            </th>
+            <th
+              class="pf-v6-c-table__th pf-v6-c-table__sort pf-m-width-10"
+              data-key="8"
+              data-label="Publish date"
+              scope="col"
+              tabindex="-1"
+            >
+              <button
+                class="pf-v6-c-table__button"
+                type="button"
+              >
+                <div
+                  class="pf-v6-c-table__button-content"
+                >
+                  <span
+                    class="pf-v6-c-table__text"
+                  >
+                    Publish date
+                  </span>
+                  <span
+                    class="pf-v6-c-table__sort-indicator"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 256 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </button>
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="pf-v6-c-table__tbody"
+          role="rowgroup"
+        >
+          <tr
+            class="pf-v6-c-table__tr"
+            data-ouia-component-id="OUIA-Generated-TableRow-2"
+            data-ouia-component-type="PF6/TableRow"
+            data-ouia-safe="true"
+          >
+            <td
+              class="pf-v6-c-table__td pf-v6-c-table__toggle"
+              data-key="0"
+              tabindex="-1"
+            >
+              <button
+                aria-expanded="false"
+                aria-label="Details"
+                aria-labelledby="simple-node0 expandable-toggle0"
+                class="pf-v6-c-button pf-m-plain"
+                data-ouia-component-id="OUIA-Generated-Button-plain-3"
+                data-ouia-component-type="PF6/Button"
+                data-ouia-safe="true"
+                id="expandable-toggle0"
+                type="button"
+              >
+                <span
+                  class="pf-v6-c-button__icon"
+                >
+                  <div
+                    class="pf-v6-c-table__toggle-icon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 320 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"
+                      />
+                    </svg>
+                  </div>
+                </span>
+              </button>
+            </td>
+            <td
+              class="pf-v6-c-table__td pf-v6-c-table__check"
+              data-key="1"
+              tabindex="-1"
+            >
+              <label>
+                <input
+                  aria-label="Select row 0"
+                  checked=""
+                  name="checkrow0"
+                  type="checkbox"
+                />
+              </label>
+            </td>
+            <td
+              class="pf-v6-c-table__td"
+              data-key="2"
+              data-label="Name"
+              tabindex="-1"
+            >
+              <a
+                href="/insights/patch/advisories/RHSA-2020:2774"
+              >
+                RHSA-2020:2774
+              </a>
+            </td>
+            <td
+              class="pf-v6-c-table__td"
+              data-key="3"
+              data-label="Synopsis"
+              tabindex="-1"
+            >
+              <div
+                class="LinesEllipsis  "
+              >
+                Important
+                <wbr />
+              </div>
+            </td>
+            <td
+              class="pf-v6-c-table__td"
+              data-key="4"
+              data-label="Status"
+              tabindex="-1"
+            >
+              Installable
+            </td>
+            <td
+              class="pf-v6-c-table__td"
+              data-key="5"
+              data-label="Type"
+              tabindex="-1"
+            >
+              <div
+                class="pf-v6-l-split pf-m-gutter"
+              >
+                <div
+                  class="pf-v6-l-split__item"
+                >
+                  <span
+                    class="pf-v6-c-icon"
+                  >
+                    <span
+                      class="pf-v6-c-icon__content"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="pf-v6-svg"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 896 1024"
+                        width="1em"
+                      >
+                        <path
+                          d="M861.5,0 L34.5,0 C15.4,0 0,14.3 0,32 L0,452.1 C0,768 387.7,1024 448.5,1024 C509.3,1024 896,768 896,452.2 L896,32 C896,14.3 880.6,0 861.5,0 Z M490.7,768 L405.3,768 C393.5,767.8 384.2,757.5 384,744.7 L384,663.3 C384.2,650.5 393.6,640.3 405.3,640 L490.7,640 C502.5,640.2 511.8,650.5 512,663.3 L512,744.7 L512.1,744.7 C511.8,757.5 502.4,767.8 490.7,768 Z M543.9,162.7 L517.2,514.4 C515.8,530.9 502,544 485.3,544 L410.6,544 C394,544 380.1,531.2 378.7,514.7 L352.1,163 C350.5,144.3 365.3,128.3 384,128.3 L512,128 C530.7,128 545.4,144 543.9,162.7 Z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </div>
+                <div
+                  class="pf-v6-l-split__item pf-m-fill"
+                >
+                  Security
+                </div>
+              </div>
+            </td>
+            <td
+              class="pf-v6-c-table__td"
+              data-key="6"
+              data-label="Severity"
+              tabindex="-1"
+            >
+              <div
+                class="pf-v6-l-flex pf-m-nowrap pf-m-gap-sm"
+              >
+                <span
+                  class="pf-v6-c-icon pf-m-sm"
+                >
+                  <span
+                    class="pf-v6-c-icon__content"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      color="var(--pf-t--global--icon--color--severity--important--default)"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 1024 1024"
+                      width="1em"
+                    >
+                      <path
+                        d="M0,587.2c0,23.2,10.8,40.4,30.7,51.6,20.8,11.7,42.1,12.5,63.1-.5l378.4-235.4c26.5-16.7,51.7-16.4,78.7.5,123.4,77.2,247.5,153.4,371,230.5,22.9,14.3,44.9,18.7,69.3,5.3,24.5-13.5,32.5-35,32.3-61.4-.4-49.4,0-41.9,0-91.3s-.3-99.9,0-149.8c.2-27.6-11.5-47.8-35.1-61.8C841.4,187.2,694.4,99.5,547.5,11.7c-24.5-14.6-48.1-14.4-72.4.2C327.3,100.3,179.4,188.5,31.7,276.8c-21.1,12.6-31.7,31.5-31.7,56.1v254.3ZM1023.8,857.8c0,1.9,0-.6.2-10.3,0-2.1,0-4.1-.2-6.1v-35.1c0-29.9,0,8.8,0,33.8-1.8-23.9-13.4-41.7-34.9-54.4-147-87.7-294-175.4-441-263.3-24.5-14.6-48.1-14.4-72.4.2-147.7,88.4-295.6,176.6-443.4,265-21.1,12.6-31.7,31.4-31.7,56.1v120.3c0,23.2,10.8,40.4,30.7,51.6,20.8,11.7,42.1,12.5,63.1-.5l378.4-235.4c26.5-16.7,51.7-16.4,78.7.5,123.4,77.2,247.5,153.4,371,230.5,22.9,14.3,44.9,18.7,69.3,5.3,24.5-13.5,32.5-35,32.3-61.4-.2-32.3-.2-64.6-.2-96.9h.2Z"
+                      />
+                    </svg>
+                  </span>
+                </span>
+                Important
+              </div>
+            </td>
+            <td
+              class="pf-v6-c-table__td"
+              data-key="7"
+              data-label="Reboot"
+              tabindex="-1"
+            >
+              Required
+            </td>
+            <td
+              class="pf-v6-c-table__td"
+              data-key="8"
+              data-label="Publish date"
+              tabindex="-1"
+            >
+              30 June 2020
+            </td>
+          </tr>
+          <tr
+            class="pf-v6-c-table__tr pf-v6-c-table__expandable-row"
+            data-ouia-component-id="OUIA-Generated-TableRow-3"
+            data-ouia-component-type="PF6/TableRow"
+            data-ouia-safe="true"
+            hidden=""
+          >
+            <td
+              class="pf-v6-c-table__td"
+              data-key="0"
+              tabindex="-1"
+            />
+            <td
+              class="pf-v6-c-table__td"
+              data-key="1"
+              tabindex="-1"
+            />
+            <td
+              class="pf-v6-c-table__td"
+              colspan="7"
+              data-key="2"
+              id="expanded-content1-2"
+              tabindex="-1"
+            >
+              <div
+                class="pf-v6-c-table__expandable-row-content"
+              >
+                <div
+                  class="pf-v6-c-content patch-advisory-description"
+                  data-ouia-component-id="OUIA-Generated-Content-1"
+                  data-ouia-component-type="PF6/Content"
+                  data-ouia-safe="true"
+                  data-pf-content="true"
+                >
+                  <span
+                    class="patchman-label"
+                  >
+                    Description
+                  </span>
+                  <p
+                    class="pf-v6-c-content--p"
+                    data-ouia-component-id="OUIA-Generated-Content-2"
+                    data-ouia-component-type="PF6/Content"
+                    data-ouia-safe="true"
+                    data-pf-content="true"
+                    style="white-space: pre-line;"
+                  >
+                    Kernel-based Virtual.
+                  </p>
+                  <div
+                    class="pf-v6-l-flex pf-m-column"
+                  >
+                    <div
+                      class="pf-m-spacer-none"
+                    >
+                      <h6
+                        class="pf-v6-c-title pf-m-h6"
+                        data-ouia-component-id="OUIA-Generated-Title-1"
+                        data-ouia-component-type="PF6/Title"
+                        data-ouia-safe="true"
+                      >
+                        Reboot
+                      </h6>
+                    </div>
+                    <div
+                      class="pf-m-spacer-sm"
+                    >
+                      <div
+                        class="pf-v6-l-split pf-m-gutter"
+                      >
+                        <div
+                          class="pf-v6-l-split__item"
+                        >
+                          <span
+                            class="pf-v6-c-icon pf-m-md"
+                          >
+                            <span
+                              class="pf-v6-c-icon__content pf-m-danger"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v6-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 512 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M400 54.1c63 45 104 118.6 104 201.9 0 136.8-110.8 247.7-247.5 248C120 504.3 8.2 393 8 256.4 7.9 173.1 48.9 99.3 111.8 54.2c11.7-8.3 28-4.8 35 7.7L162.6 90c5.9 10.5 3.1 23.8-6.6 31-41.5 30.8-68 79.6-68 134.9-.1 92.3 74.5 168.1 168 168.1 91.6 0 168.6-74.2 168-169.1-.3-51.8-24.7-101.8-68.1-134-9.7-7.2-12.4-20.5-6.5-30.9l15.8-28.1c7-12.4 23.2-16.1 34.8-7.8zM296 264V24c0-13.3-10.7-24-24-24h-32c-13.3 0-24 10.7-24 24v240c0 13.3 10.7 24 24 24h32c13.3 0 24-10.7 24-24z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="pf-v6-l-split__item pf-m-fill"
+                        >
+                          Reboot is required
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <a
+                    href="https://access.redhat.com/errata/RHSA-2020:2774"
+                    rel="noreferrer"
+                    target="_blank"
+                  >
+                    View packages and errata at access.redhat.com
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg pf-v6-u-ml-xs"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 512 512"
+                      width="1em"
+                    >
+                      <path
+                        d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                      />
+                    </svg>
+                  </a>
+                </div>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div
+        class="pf-v6-c-toolbar ins-c-table__toolbar ins-m-footer"
+        data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-1"
+        data-ouia-component-type="RHI/TableToolbar"
+        data-ouia-safe="true"
+        id="pf-random-id-0"
+      >
+        <div
+          class="pf-v6-c-pagination pf-m-bottom"
+          data-ouia-component-id="bottom-system-advisories-pagination"
+          data-ouia-component-type="PF6/Pagination"
+          data-ouia-safe="true"
+          id="pagination-options-menu-bottom-bottom-pagination"
+          style="--pf-v6-c-pagination__nav-page-select--c-form-control--width-chars: 2;"
+        >
+          <div
+            class="pf-v6-c-pagination__page-menu"
+          >
+            <button
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              class="pf-v6-c-menu-toggle pf-m-plain pf-m-text"
+              data-ouia-component-id="OUIA-Generated-MenuToggle-plainText-2"
+              data-ouia-component-type="PF6/MenuToggle"
+              data-ouia-safe="true"
+              id="pagination-options-menu-bottom-bottom-toggle"
+              type="button"
+            >
+              <span
+                class="pf-v6-c-menu-toggle__text"
+              >
+                <b>
+                  1 - 10
+                </b>
+                 of 
+                <b>
+                  10
+                </b>
+                 
+              </span>
+              <span
+                class="pf-v6-c-menu-toggle__controls"
+              >
+                <span
+                  class="pf-v6-c-menu-toggle__toggle-icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 320 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </button>
+          </div>
+          <nav
+            aria-label="Pagination"
+            class="pf-v6-c-pagination__nav"
+          >
+            <div
+              class="pf-v6-c-pagination__nav-control pf-m-first"
+            >
+              <button
+                aria-label="Go to first page"
+                class="pf-v6-c-button pf-m-plain"
+                data-action="first"
+                data-ouia-component-id="OUIA-Generated-Button-plain-4"
+                data-ouia-component-type="PF6/Button"
+                data-ouia-safe="true"
+                disabled=""
+                type="button"
+              >
+                <span
+                  class="pf-v6-c-button__icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M223.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L319.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L393.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34zm-192 34l136 136c9.4 9.4 24.6 9.4 33.9 0l22.6-22.6c9.4-9.4 9.4-24.6 0-33.9L127.9 256l96.4-96.4c9.4-9.4 9.4-24.6 0-33.9L201.7 103c-9.4-9.4-24.6-9.4-33.9 0l-136 136c-9.5 9.4-9.5 24.6-.1 34z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+            <div
+              class="pf-v6-c-pagination__nav-control"
+            >
+              <button
+                aria-label="Go to previous page"
+                class="pf-v6-c-button pf-m-plain"
+                data-action="previous"
+                data-ouia-component-id="OUIA-Generated-Button-plain-5"
+                data-ouia-component-type="PF6/Button"
+                data-ouia-safe="true"
+                disabled=""
+                type="button"
+              >
+                <span
+                  class="pf-v6-c-button__icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+            <div
+              class="pf-v6-c-pagination__nav-page-select"
+            >
+              <span
+                class="pf-v6-c-form-control pf-m-disabled"
+              >
+                <input
+                  aria-invalid="false"
+                  aria-label="Current page"
+                  data-ouia-component-id="OUIA-Generated-TextInputBase-2"
+                  data-ouia-component-type="PF6/TextInput"
+                  data-ouia-safe="true"
+                  disabled=""
+                  max="1"
+                  min="1"
+                  type="number"
+                  value="1"
+                />
+              </span>
+              <span
+                aria-hidden="true"
+              >
+                of 1
+              </span>
+            </div>
+            <div
+              class="pf-v6-c-pagination__nav-control"
+            >
+              <button
+                aria-label="Go to next page"
+                class="pf-v6-c-button pf-m-plain"
+                data-action="next"
+                data-ouia-component-id="OUIA-Generated-Button-plain-6"
+                data-ouia-component-type="PF6/Button"
+                data-ouia-safe="true"
+                disabled=""
+                type="button"
+              >
+                <span
+                  class="pf-v6-c-button__icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 256 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+            <div
+              class="pf-v6-c-pagination__nav-control pf-m-last"
+            >
+              <button
+                aria-label="Go to last page"
+                class="pf-v6-c-button pf-m-plain"
+                data-action="last"
+                data-ouia-component-id="OUIA-Generated-Button-plain-7"
+                data-ouia-component-type="PF6/Button"
+                data-ouia-safe="true"
+                disabled=""
+                type="button"
+              >
+                <span
+                  class="pf-v6-c-button__icon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="pf-v6-svg"
+                    fill="currentColor"
+                    height="1em"
+                    role="img"
+                    viewBox="0 0 448 512"
+                    width="1em"
+                  >
+                    <path
+                      d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34zm192-34l-136-136c-9.4-9.4-24.6-9.4-33.9 0l-22.6 22.6c-9.4 9.4-9.4 24.6 0 33.9l96.4 96.4-96.4 96.4c-9.4 9.4-9.4 24.6 0 33.9l22.6 22.6c9.4 9.4 24.6 9.4 33.9 0l136-136c9.4-9.2 9.4-24.4 0-33.8z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </nav>
+        </div>
+        <div
+          class="pf-v6-c-toolbar__content pf-m-hidden"
+          hidden=""
+        >
+          <div
+            class="pf-v6-c-toolbar__group"
+          />
+        </div>
+      </div>
+    </div>
+  </section>
+  <section
+    aria-labelledby="pf-tab-1-system-packages-tab"
+    class="pf-v6-c-tab-content"
+    data-ouia-component-type="PF6/TabContent"
+    data-ouia-safe="true"
+    hidden=""
+    id="pf-tab-section-1-system-packages-tab"
+    role="tabpanel"
+    tabindex="0"
+  >
+    <div
+      class="pf-v6-u-mt-md"
+    >
+      <div
+        class="pf-v6-c-toolbar  ins-c-primary-toolbar"
+        data-ouia-component-id="PrimaryToolbar"
+        data-ouia-component-type="PF6/Toolbar"
+        data-ouia-safe="true"
+        id="ins-primary-data-toolbar"
+      >
+        <div
+          class="pf-v6-c-toolbar__content"
+        >
+          <div
+            class="pf-v6-c-toolbar__content-section pf-m-align-items-center"
+          >
+            <div
+              class="pf-v6-c-toolbar__group pf-m-filter-group ins-c-primary-toolbar__group-filter pf-m-spacer-md pf-m-space-items-lg"
+            >
+              <div
+                class="pf-v6-c-toolbar__item"
+              >
+                <button
+                  aria-expanded="false"
+                  aria-label="Select"
+                  class="pf-v6-c-menu-toggle pf-m-disabled"
+                  data-ouia-component-id="BulkSelect"
+                  data-ouia-component-type="PF6/MenuToggle"
+                  data-ouia-safe="true"
+                  disabled=""
+                  type="button"
+                >
+                  <span
+                    class="pf-v6-c-menu-toggle__text"
+                  >
+                    <label
+                      class="pf-v6-c-check pf-m-standalone"
+                    >
+                      <input
+                        aria-invalid="false"
+                        aria-label="Select all"
+                        class="pf-v6-c-check__input"
+                        data-ouia-component-id="BulkSelectCheckbox"
+                        data-ouia-component-type="PF6/MenuToggleCheckbox"
+                        data-ouia-safe="true"
+                        name="toggle-checkbox"
+                        type="checkbox"
+                      />
+                    </label>
+                  </span>
+                  <span
+                    class="pf-v6-c-menu-toggle__controls"
+                  >
+                    <span
+                      class="pf-v6-c-menu-toggle__toggle-icon"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="pf-v6-svg"
+                        fill="currentColor"
+                        height="1em"
+                        role="img"
+                        viewBox="0 0 320 512"
+                        width="1em"
+                      >
+                        <path
+                          d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                        />
+                      </svg>
+                    </span>
+                  </span>
+                </button>
+              </div>
+              <div
+                class="pf-v6-c-toolbar__item ins-c-primary-toolbar__filter"
+              >
+                <div
+                  class="pf-v6-l-split ins-c-conditional-filter ins-c-conditional-filter__split-items-space"
+                >
+                  <div
+                    class="pf-v6-l-split__item"
+                  >
+                    <button
+                      aria-expanded="false"
+                      aria-label="Conditional filter toggle"
+                      class="pf-v6-c-menu-toggle ins-c-conditional-filter__group"
+                      data-ouia-component-id="ConditionalFilterToggle"
+                      data-ouia-component-type="PF6/MenuToggle"
+                      data-ouia-safe="true"
+                      type="button"
+                    >
+                      <span
+                        class="pf-v6-c-menu-toggle__text"
                       >
                         <span
-                          class="pf-v6-c-icon pf-m-md ins-c-search-icon"
+                          class="pf-v6-c-icon pf-m-md"
                         >
                           <span
                             class="pf-v6-c-icon__content"
@@ -3306,41 +3247,147 @@ exports[`SystemDetail.js Should match the snapshots 1`] = `
                               width="1em"
                             >
                               <path
-                                d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                                d="M487.976 0H24.028C2.71 0-8.047 25.866 7.058 40.971L192 225.941V432c0 7.831 3.821 15.17 10.237 19.662l80 55.98C298.02 518.69 320 507.493 320 487.98V225.941l184.947-184.97C520.021 25.896 509.338 0 487.976 0z"
                               />
                             </svg>
                           </span>
                         </span>
+                        <span
+                          class="ins-c-conditional-filter__value-selector"
+                        >
+                          Package
+                        </span>
+                      </span>
+                      <span
+                        class="pf-v6-c-menu-toggle__controls"
+                      >
+                        <span
+                          class="pf-v6-c-menu-toggle__toggle-icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="pf-v6-svg"
+                            fill="currentColor"
+                            height="1em"
+                            role="img"
+                            viewBox="0 0 320 512"
+                            width="1em"
+                          >
+                            <path
+                              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                    </button>
+                  </div>
+                  <div
+                    class="pf-v6-l-split__item pf-m-fill"
+                    data-ouia-component-id="ConditionalFilter"
+                  >
+                    <span
+                      class="pf-v6-c-form-control pf-m-icon ins-c-conditional-filter"
+                    >
+                      <input
+                        aria-invalid="false"
+                        aria-label="search-field"
+                        data-ouia-component-id="ConditionalFilter"
+                        data-ouia-component-type="PF6/TextInput"
+                        data-ouia-safe="true"
+                        placeholder="Filter by name or summary"
+                        type="text"
+                        value=""
+                        widget-type="InsightsInput"
+                      />
+                      <span
+                        class="pf-v6-c-form-control__utilities"
+                      >
+                        <span
+                          class="pf-v6-c-form-control__icon"
+                        >
+                          <span
+                            class="pf-v6-c-icon pf-m-md ins-c-search-icon"
+                          >
+                            <span
+                              class="pf-v6-c-icon__content"
+                            >
+                              <svg
+                                aria-hidden="true"
+                                class="pf-v6-svg"
+                                fill="currentColor"
+                                height="1em"
+                                role="img"
+                                viewBox="0 0 512 512"
+                                width="1em"
+                              >
+                                <path
+                                  d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                        </span>
                       </span>
                     </span>
-                  </span>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-          <div
-            class="pf-v6-c-toolbar__item ins-c-primary-toolbar__first-action pf-m-spacer-sm"
-          >
             <div
-              buttonprops="[object Object]"
-              fallback="[object Object]"
-              module="./RemediationButton"
-              scope="remediations"
+              class="pf-v6-c-toolbar__item ins-c-primary-toolbar__first-action pf-m-spacer-sm"
             >
-              AsyncComponent
+              <div
+                buttonprops="[object Object]"
+                fallback="[object Object]"
+                module="./RemediationButton"
+                scope="remediations"
+              >
+                AsyncComponent
+              </div>
             </div>
-          </div>
-          <div
-            class="pf-v6-c-toolbar__item pf-m-spacer-sm"
-          >
             <div
-              style="display: contents;"
+              class="pf-v6-c-toolbar__item pf-m-spacer-sm"
+            >
+              <div
+                style="display: contents;"
+              >
+                <button
+                  aria-expanded="false"
+                  aria-label="Export"
+                  class="pf-v6-c-menu-toggle pf-m-plain"
+                  data-ouia-component-id="OUIA-Generated-MenuToggle-plain-3"
+                  data-ouia-component-type="PF6/MenuToggle"
+                  data-ouia-safe="true"
+                  type="button"
+                >
+                  <span
+                    class="pf-v6-c-menu-toggle__icon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="pf-v6-svg"
+                      fill="currentColor"
+                      height="1em"
+                      role="img"
+                      viewBox="0 0 1024 1024"
+                      width="1em"
+                    >
+                      <path
+                        d="M975.8,636.9 L870.9,741.8 L457.9,328.6 C452.1,322.8 445.4,319.9 437.9,319.9 C430.4,319.9 423.7,322.8 417.9,328.6 L328.8,417.7 C323,423.5 320.1,430.2 320.1,437.7 C320.1,445.2 323,451.9 328.8,457.7 L742,870.7 L636.9,975.8 C610.5,1002.2 619.4,1024 656.8,1024 L956,1024 C1014.5,1024 1024,1013.7 1024,955.9 L1024,656.7 C1023.9,619.4 1002.2,610.5 975.8,636.9 Z M128,128 L896,128 L896,361.7 C896.007942,370.182681 899.389907,378.313788 905.4,384.3 L996.7,475.6 C1006.8,485.7 1024,478.5 1024,464.3 L1024,22.7 C1024,16.1 1021.9,10.7 1017.6,6.4 C1013.3,2.1 1007.9,0 1001.3,0 L22.7,0 C16.1,0 10.7,2.1 6.4,6.4 C2.1,10.7 0,16.1 0,22.7 L0,1001.3 C0,1007.9 2.1,1013.3 6.4,1017.6 C10.7,1021.9 16.1,1024 22.7,1024 L463.4,1024 C469.862884,1023.98894 475.684489,1020.0908 478.156232,1014.11925 C480.627976,1008.14769 479.264428,1001.27548 474.7,996.7 L383.4,905.4 C377.413788,899.389907 369.282681,896.007942 360.8,896 L128,896 L128,128 Z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              class="pf-v6-c-toolbar__item  ins-c-primary-toolbar__actions pf-m-spacer-sm"
             >
               <button
                 aria-expanded="false"
-                aria-label="Export"
+                aria-label="kebab dropdown toggle"
                 class="pf-v6-c-menu-toggle pf-m-plain"
-                data-ouia-component-id="OUIA-Generated-MenuToggle-plain-3"
+                data-ouia-component-id="BulkActionsToggle"
                 data-ouia-component-type="PF6/MenuToggle"
                 data-ouia-safe="true"
                 type="button"
@@ -3354,170 +3401,139 @@ exports[`SystemDetail.js Should match the snapshots 1`] = `
                     fill="currentColor"
                     height="1em"
                     role="img"
-                    viewBox="0 0 1024 1024"
+                    viewBox="0 0 192 512"
                     width="1em"
                   >
                     <path
-                      d="M975.8,636.9 L870.9,741.8 L457.9,328.6 C452.1,322.8 445.4,319.9 437.9,319.9 C430.4,319.9 423.7,322.8 417.9,328.6 L328.8,417.7 C323,423.5 320.1,430.2 320.1,437.7 C320.1,445.2 323,451.9 328.8,457.7 L742,870.7 L636.9,975.8 C610.5,1002.2 619.4,1024 656.8,1024 L956,1024 C1014.5,1024 1024,1013.7 1024,955.9 L1024,656.7 C1023.9,619.4 1002.2,610.5 975.8,636.9 Z M128,128 L896,128 L896,361.7 C896.007942,370.182681 899.389907,378.313788 905.4,384.3 L996.7,475.6 C1006.8,485.7 1024,478.5 1024,464.3 L1024,22.7 C1024,16.1 1021.9,10.7 1017.6,6.4 C1013.3,2.1 1007.9,0 1001.3,0 L22.7,0 C16.1,0 10.7,2.1 6.4,6.4 C2.1,10.7 0,16.1 0,22.7 L0,1001.3 C0,1007.9 2.1,1013.3 6.4,1017.6 C10.7,1021.9 16.1,1024 22.7,1024 L463.4,1024 C469.862884,1023.98894 475.684489,1020.0908 478.156232,1014.11925 C480.627976,1008.14769 479.264428,1001.27548 474.7,996.7 L383.4,905.4 C377.413788,899.389907 369.282681,896.007942 360.8,896 L128,896 L128,128 Z"
+                      d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
                     />
                   </svg>
                 </span>
               </button>
             </div>
-          </div>
-          <div
-            class="pf-v6-c-toolbar__item  ins-c-primary-toolbar__actions pf-m-spacer-sm"
-          >
-            <button
-              aria-expanded="false"
-              aria-label="kebab dropdown toggle"
-              class="pf-v6-c-menu-toggle pf-m-plain"
-              data-ouia-component-id="BulkActionsToggle"
-              data-ouia-component-type="PF6/MenuToggle"
-              data-ouia-safe="true"
-              type="button"
-            >
-              <span
-                class="pf-v6-c-menu-toggle__icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="pf-v6-svg"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 192 512"
-                  width="1em"
-                >
-                  <path
-                    d="M96 184c39.8 0 72 32.2 72 72s-32.2 72-72 72-72-32.2-72-72 32.2-72 72-72zM24 80c0 39.8 32.2 72 72 72s72-32.2 72-72S135.8 8 96 8 24 40.2 24 80zm0 352c0 39.8 32.2 72 72 72s72-32.2 72-72-32.2-72-72-72-72 32.2-72 72z"
-                  />
-                </svg>
-              </span>
-            </button>
-          </div>
-          <div
-            class="pf-v6-c-toolbar__item ins-c-primary-toolbar__pagination"
-          >
             <div
-              class="pf-v6-c-skeleton pf-m-text-xl"
-              style="--pf-v6-c-skeleton--Width: 200px; margin: 10px;"
+              class="pf-v6-c-toolbar__item ins-c-primary-toolbar__pagination"
             >
-              <span
-                class="pf-v6-screen-reader"
-              />
+              <div
+                class="pf-v6-c-skeleton pf-m-text-xl"
+                style="--pf-v6-c-skeleton--Width: 200px;"
+              >
+                <span
+                  class="pf-v6-screen-reader"
+                />
+              </div>
             </div>
           </div>
         </div>
-      </div>
-      <div
-        class="pf-v6-c-toolbar__content pf-m-hidden"
-        hidden=""
-      >
         <div
-          class="pf-v6-c-toolbar__group"
-        />
-      </div>
-    </div>
-    <table
-      aria-label="Loading"
-      class="pf-v6-c-table pf-m-grid-md pf-m-compact"
-      data-ouia-component-id="SkeletonTable"
-      data-ouia-component-type="PF6/Table"
-      data-ouia-safe="true"
-      numberofcolumns="6"
-      role="grid"
-      rows="20"
-    >
-      <thead
-        class="pf-v6-c-table__thead"
-        data-ouia-component-id="SkeletonTable-thead"
-      >
-        <tr
-          class="pf-v6-c-table__tr"
-          data-ouia-component-id="SkeletonTable-tr-head"
-          data-ouia-component-type="PF6/TableRow"
-          data-ouia-safe="true"
+          class="pf-v6-c-toolbar__content pf-m-hidden"
+          hidden=""
         >
-          <th
-            class="pf-v6-c-table__th"
-            data-ouia-component-id="SkeletonTable-th-0"
-            scope="col"
-            tabindex="-1"
-          >
-            <div
-              class="pf-v6-c-skeleton"
-            >
-              <span
-                class="pf-v6-screen-reader"
-              />
-            </div>
-          </th>
-        </tr>
-      </thead>
-      <tbody
-        class="pf-v6-c-table__tbody"
-        data-ouia-component-id="SkeletonTable-tbody"
-        role="rowgroup"
-      >
-        <tr
-          class="pf-v6-c-table__tr"
-          data-ouia-component-id="SkeletonTable-tr-0"
-          data-ouia-component-type="PF6/TableRow"
-          data-ouia-safe="true"
-        />
-        <tr
-          class="pf-v6-c-table__tr"
-          data-ouia-component-id="SkeletonTable-tr-1"
-          data-ouia-component-type="PF6/TableRow"
-          data-ouia-safe="true"
-        />
-        <tr
-          class="pf-v6-c-table__tr"
-          data-ouia-component-id="SkeletonTable-tr-2"
-          data-ouia-component-type="PF6/TableRow"
-          data-ouia-safe="true"
-        />
-        <tr
-          class="pf-v6-c-table__tr"
-          data-ouia-component-id="SkeletonTable-tr-3"
-          data-ouia-component-type="PF6/TableRow"
-          data-ouia-safe="true"
-        />
-        <tr
-          class="pf-v6-c-table__tr"
-          data-ouia-component-id="SkeletonTable-tr-4"
-          data-ouia-component-type="PF6/TableRow"
-          data-ouia-safe="true"
-        />
-      </tbody>
-    </table>
-    <div
-      class="pf-v6-c-toolbar ins-c-table__toolbar ins-m-footer"
-      data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-2"
-      data-ouia-component-type="RHI/TableToolbar"
-      data-ouia-safe="true"
-      id="pf-random-id-1"
-    >
-      <div
-        class="pf-v6-c-pagination pf-m-bottom"
-      >
-        <div
-          class="pf-v6-c-skeleton pf-m-text-xl"
-          style="--pf-v6-c-skeleton--Width: 350px; margin: 10px;"
-        >
-          <span
-            class="pf-v6-screen-reader"
+          <div
+            class="pf-v6-c-toolbar__group"
           />
         </div>
       </div>
+      <table
+        aria-label="Loading"
+        class="pf-v6-c-table pf-m-grid-md pf-m-compact"
+        data-ouia-component-id="SkeletonTable"
+        data-ouia-component-type="PF6/Table"
+        data-ouia-safe="true"
+        numberofcolumns="6"
+        role="grid"
+        rows="20"
+      >
+        <thead
+          class="pf-v6-c-table__thead"
+          data-ouia-component-id="SkeletonTable-thead"
+        >
+          <tr
+            class="pf-v6-c-table__tr"
+            data-ouia-component-id="SkeletonTable-tr-head"
+            data-ouia-component-type="PF6/TableRow"
+            data-ouia-safe="true"
+          >
+            <th
+              class="pf-v6-c-table__th"
+              data-ouia-component-id="SkeletonTable-th-0"
+              scope="col"
+              tabindex="-1"
+            >
+              <div
+                class="pf-v6-c-skeleton"
+              >
+                <span
+                  class="pf-v6-screen-reader"
+                />
+              </div>
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="pf-v6-c-table__tbody"
+          data-ouia-component-id="SkeletonTable-tbody"
+          role="rowgroup"
+        >
+          <tr
+            class="pf-v6-c-table__tr"
+            data-ouia-component-id="SkeletonTable-tr-0"
+            data-ouia-component-type="PF6/TableRow"
+            data-ouia-safe="true"
+          />
+          <tr
+            class="pf-v6-c-table__tr"
+            data-ouia-component-id="SkeletonTable-tr-1"
+            data-ouia-component-type="PF6/TableRow"
+            data-ouia-safe="true"
+          />
+          <tr
+            class="pf-v6-c-table__tr"
+            data-ouia-component-id="SkeletonTable-tr-2"
+            data-ouia-component-type="PF6/TableRow"
+            data-ouia-safe="true"
+          />
+          <tr
+            class="pf-v6-c-table__tr"
+            data-ouia-component-id="SkeletonTable-tr-3"
+            data-ouia-component-type="PF6/TableRow"
+            data-ouia-safe="true"
+          />
+          <tr
+            class="pf-v6-c-table__tr"
+            data-ouia-component-id="SkeletonTable-tr-4"
+            data-ouia-component-type="PF6/TableRow"
+            data-ouia-safe="true"
+          />
+        </tbody>
+      </table>
       <div
-        class="pf-v6-c-toolbar__content pf-m-hidden"
-        hidden=""
+        class="pf-v6-c-toolbar ins-c-table__toolbar ins-m-footer"
+        data-ouia-component-id="OUIA-Generated-RHI/TableToolbar-true-2"
+        data-ouia-component-type="RHI/TableToolbar"
+        data-ouia-safe="true"
+        id="pf-random-id-1"
       >
         <div
-          class="pf-v6-c-toolbar__group"
-        />
+          class="pf-v6-c-pagination pf-m-bottom"
+        >
+          <div
+            class="pf-v6-c-skeleton pf-m-text-xl"
+            style="--pf-v6-c-skeleton--Width: 350px; margin: 10px;"
+          >
+            <span
+              class="pf-v6-screen-reader"
+            />
+          </div>
+        </div>
+        <div
+          class="pf-v6-c-toolbar__content pf-m-hidden"
+          hidden=""
+        >
+          <div
+            class="pf-v6-c-toolbar__group"
+          />
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
`Dark Mode Support`: 
This fixes the look of the system detail page and tabs when dark mode is
used.

_Also fixes broken spacing view and removes custom CSS in favor of
PatternFly styling utilities._

`Flickering when revisiting pages`:
This fixes the flickering and unnecessary reloads on repeated navigation
to the Advisories and Packages pages, by using layout effects to force
loading before paint.


Associated Jira ticket: [#RHINENG-25703](https://redhat.atlassian.net/browse/RHINENG-25703)

## How to test the PR
Check that dark mode looks good. _(ignore tag icon in inventory tables, that will be fixed by inventory)_
Verify that Advisories and Packages table don't flicker old data when revisiting them.
