### PR TITLE
fix(test): remove workaround for multi-user UI tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -50,44 +50,26 @@ export default defineConfig({
     video: 'on',
   },
   projects: [
-    { name: 'setup', testMatch: /auth\.setup\.ts/, use: { trace: 'off' } },
-    ...(process.env.INTEGRATION
-      ? [
-          {
-            name: 'Integration',
-            use: {
-              ...devices['Desktop Chrome'],
-              storageState: '.auth/ADMIN_TOKEN.json',
-            },
-            testDir: './playwright/Integration/',
-            dependencies: ['setup'],
+    { name: 'setup', testMatch: /.*\.setup\.ts/, use: { trace: 'off' } },
+    process.env.INTEGRATION
+      ? {
+          name: 'Integration',
+          use: {
+            ...devices['Desktop Chrome'],
+            storageState: '.auth/ADMIN_TOKEN.json',
           },
-        ]
-      : [
-          {
-            name: 'UI-default-user',
-            use: {
-              ...devices['Desktop Chrome'],
-              storageState: '.auth/ADMIN_TOKEN.json',
-            },
-            testDir: './playwright/UI/',
-            testIgnore: ['**/AdvisoriesTests.spec.ts'],
-            dependencies: ['setup'],
+          testDir: './playwright/Integration/',
+          dependencies: ['setup'],
+        }
+      : 
+        {
+          name: 'UI',
+          use: {
+            ...devices['Desktop Chrome'],
+            storageState: '.auth/ADMIN_TOKEN.json',
           },
-          {
-            name: 'UI-advisory-remediation-user',
-            use: {
-              ...devices['Desktop Chrome'],
-              storageState: '.auth/ADVISORY_REMEDIATION_TOKEN.json',
-              extraHTTPHeaders: process.env.ADVISORY_REMEDIATION_TOKEN
-                ? { Authorization: process.env.ADVISORY_REMEDIATION_TOKEN }
-                : {},
-            },
-            testDir: './playwright/UI/',
-            testMatch: ['**/AdvisoriesTests.spec.ts'],
-            // Run after all default-user UI tests to prevent auth state conflicts
-            dependencies: ['setup', 'UI-default-user'],
-          },
-        ]),
+          testDir: './playwright/UI/',
+          dependencies: ['setup'],
+        },
   ],
 });

--- a/playwright/UI/AdvisoriesTests.spec.ts
+++ b/playwright/UI/AdvisoriesTests.spec.ts
@@ -9,6 +9,13 @@ import {
 import { cleanupRemediationPlan } from 'test-utils/helpers/cleaners';
 
 test.describe('Advisories Tests', () => {
+  test.use({
+    storageState: '.auth/ADVISORY_REMEDIATION_TOKEN.json',
+    extraHTTPHeaders: process.env.ADVISORY_REMEDIATION_TOKEN
+      ? { Authorization: process.env.ADVISORY_REMEDIATION_TOKEN }
+      : {},
+  });
+  
   // Disable retries for this test, systems are not deleted immediately in patch so second attempt will likely fail
   test.describe.configure({ retries: 0 });
 


### PR DESCRIPTION
# Description

- Reverts the workaround we had that split users into different UI projects to prevent auth state conflicts
- The conflicts were caused by the frontend-development-proxy caching parallel responses by URL, and this was [fixed](https://github.com/RedHatInsights/frontend-development-proxy/pull/137) in the latest proxy image

# How to test the PR

UI tests pass with no auth-related failures