### PR TITLE
RHINENG-25944: ensure correct encoding of tag filters

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,4 +16,5 @@ module.exports = {
   transformIgnorePatterns: [
     '<rootDir>/node_modules/(?!(@patternfly/react-core/|@patternfly/react-icons/|@redhat-cloud-services|@openshift|lodash-es|@patternfly/react-table|@patternfly/react-tokens|p-all)).*$',
   ],
+  maxWorkers: 4,
 };

--- a/src/Utilities/Helpers.js
+++ b/src/Utilities/Helpers.js
@@ -703,18 +703,40 @@ export const isRHAdvisory = (name) => /^(RHEA|RHBA|RHSA)/.test(name);
 export const buildTagString = (tag) =>
   `${tag.category}/${tag.values?.tagKey}=${tag.value?.tagValue}`;
 
+/**
+ * Build one `tags=…` query fragment with a single URI encode pass. Inventory / insights-chrome
+ * sometimes passes tag strings that are already `tags=` segments or percent-encoded and encoding
+ * again turns `%2F` into `%252F` and breaks the patch API.
+ */
+const buildTagsQuerySegment = (rawTagInput) => {
+  if (rawTagInput === undefined || rawTagInput === null) {
+    return '';
+  }
+  let inner = String(rawTagInput).trim();
+  if (inner.startsWith('tags=')) {
+    inner = inner.slice(5);
+  }
+  let decoded = inner;
+  try {
+    decoded = decodeURIComponent(inner);
+  } catch {
+    decoded = inner;
+  }
+  return `tags=${encodeURIComponent(decoded)}`;
+};
+
 export const mapGlobalFilters = (tags, workloads = {}) => {
   let tagsInUrlFormat = [];
   tags &&
     tags.forEach((tag, index) => {
       let tagGruop = tag;
-      if (typeof tag === 'object') {
-        tagGruop = tag?.values.map(
-          (value) => `tags=${encodeURIComponent(`${tag.category}/${value.tagKey}=${value.value}`)}`,
+      if (typeof tag === 'object' && tag !== null) {
+        tagGruop = tag?.values.map((value) =>
+          buildTagsQuerySegment(`${tag.category}/${value.tagKey}=${value.value}`),
         );
         tagsInUrlFormat[index] = (Array.isArray(tagGruop) && flatten(tagGruop)) || tagGruop;
-      } else {
-        tagsInUrlFormat[index] = `tags=${encodeURIComponent(tagGruop)}`;
+      } else if (typeof tag === 'string') {
+        tagsInUrlFormat[index] = buildTagsQuerySegment(tagGruop);
       }
     });
 
@@ -730,7 +752,9 @@ export const mapGlobalFilters = (tags, workloads = {}) => {
     }),
   };
 
-  tagsInUrlFormat && (globalFilterConfig.selectedTags = tagsInUrlFormat);
+  if (tagsInUrlFormat?.length) {
+    globalFilterConfig.selectedTags = flatten(tagsInUrlFormat).filter(Boolean);
+  }
 
   return globalFilterConfig;
 };

--- a/src/Utilities/hooks/Hooks.test.js
+++ b/src/Utilities/hooks/Hooks.test.js
@@ -215,7 +215,7 @@ describe('Custom hooks tests', () => {
         os: 'RHEL 8.8',
       },
       filters: params.filters,
-      selectedTags: ['tags=owner%2Fteam%3Dplatform', ['tags=env%2Fstage%3Dprod']],
+      selectedTags: ['tags=owner%2Fteam%3Dplatform', 'tags=env%2Fstage%3Dprod'],
       systemProfile: { ansible: { controller_version: 'not_nil' } },
     });
     expect(applyInventorySnapshot.mock.invocationCallOrder[0]).toBeLessThan(


### PR DESCRIPTION
## Summary
This makes sure the global tag filters are correctly URI encoded, only a
single encode pass. Previously they could be double encoded which made
the API always return no systems.

Associated Jira ticket: [#RHINENG-25944](https://redhat.atlassian.net/browse/RHINENG-25944)

> Also includes a QOL fix for local development, _that sets the maxWorkers 
> in the Jest config to prevent accidental computer lock-ups/freezes when running
> tests, because the default is using the maximum of available resources._

## Testing steps
Test out filtering with both the "local" tag filters (in the table toolbar) and with the global filters at the top.
Both of them should now work.

