### PR TITLE
test: reduce filter test runtime

### DIFF
--- a/playwright/UI/FilterTypePatch.spec.ts
+++ b/playwright/UI/FilterTypePatch.spec.ts
@@ -297,8 +297,6 @@ test('Verify filter contents', async ({ page, systems }) => {
 
   await navigateToSystems(page);
   await closePopupsIfExist(page);
-  await openConditionalFilter(page);
-  await resetFilters(page);
 
   await test.step('Verify "Operating system" filter contents', async () => {
     await openConditionalFilter(page);

--- a/playwright/test-utils/helpers/filters.ts
+++ b/playwright/test-utils/helpers/filters.ts
@@ -169,13 +169,7 @@ export const applyFilterSubtype = async (
         'i',
       ),
     });
-    let openedViaGroupFilter = false;
-    try {
-      await groupFilterBtn.waitFor({ state: 'visible', timeout: 10000 });
-      openedViaGroupFilter = true;
-    } catch {
-      // Group filter not visible; will try Menu toggle or Options menu
-    }
+    const openedViaGroupFilter = await groupFilterBtn.isVisible();
     if (openedViaGroupFilter) {
       await groupFilterBtn.click();
     } else if (subtype.inputType !== 'search') {


### PR DESCRIPTION
# Description

Removes unnecessary waits from the filter test helpers. This should reduce the runtime of the  "Patch Filters" > "Filter types on Advisories page" UI test.  

# How to test the PR

UI filter tests shouldn't time out 