### PR TITLE
fix: resolve advisory table empty state off center

### DIFF
--- a/src/Utilities/DataMappers.js
+++ b/src/Utilities/DataMappers.js
@@ -76,7 +76,7 @@ export const createAdvisoriesRows = (rows, expandedRows, selectedRows) => {
         heightAuto: true,
         cells: [
           {
-            props: { colSpan: 5 },
+            props: { colSpan: 7 },
             title: <EmptyAdvisoryList />,
           },
         ],
@@ -134,7 +134,7 @@ export const createSystemAdvisoriesRows = (rows, expandedRows, selectedRows, met
         heightAuto: true,
         cells: [
           {
-            props: { colSpan: 6 },
+            props: { colSpan: 7 },
             title: (!metadata.search &&
               metadata.filter &&
               Object.keys(metadata.filter).length === 0 && <SystemUpToDate />) || (

--- a/src/Utilities/DataMappers.test.js
+++ b/src/Utilities/DataMappers.test.js
@@ -40,7 +40,7 @@ describe('DataMappers', () => {
   it('Should createAdvisoriesRows handle empty row data', () => {
     const result = createAdvisoriesRows([], [], []);
     expect(result[0].heightAuto).toBeTruthy();
-    expect(result[0].cells[0].props).toEqual({ colSpan: 5 });
+    expect(result[0].cells[0].props).toEqual({ colSpan: 7 });
     expect(result[0].cells[0].title.type).toEqual(EmptyAdvisoryList);
   });
 
@@ -69,14 +69,14 @@ describe('DataMappers', () => {
   it('Should createSystemAdvisoriesRows handle empty row data and show SystemUpToDate', () => {
     const result = createSystemAdvisoriesRows([], [], [], { filter: {} });
     expect(result[0].heightAuto).toBeTruthy();
-    expect(result[0].cells[0].props).toEqual({ colSpan: 6 });
+    expect(result[0].cells[0].props).toEqual({ colSpan: 7 });
     expect(result[0].cells[0].title.type).toEqual(SystemUpToDate);
   });
 
   it('Should createSystemAdvisoriesRows handle empty row data and show EmptyAdvisoryList', () => {
     const result = createSystemAdvisoriesRows([], [], [], { filter: { search: 'test' } });
     expect(result[0].heightAuto).toBeTruthy();
-    expect(result[0].cells[0].props).toEqual({ colSpan: 6 });
+    expect(result[0].cells[0].props).toEqual({ colSpan: 7 });
     expect(result[0].cells[0].title.type).toEqual(EmptyAdvisoryList);
   });
 


### PR DESCRIPTION
# Description
Associated Jira ticket: [HMS-10975](https://redhat.atlassian.net/browse/HMS-10975)

The empty state of the Advisories table and System advisories table were not centered properly. This PR sets the element to span all columns to fix the issue. 

# How to test the PR
confirm visually

# Before the change
<img width="2226" height="194" alt="Screenshot From 2026-07-07 13-09-35" src="https://github.com/user-attachments/assets/ccf08842-e119-4945-934e-92a8920ae398" />

# After the change
<img width="2226" height="194" alt="Screenshot From 2026-07-07 13-08-13" src="https://github.com/user-attachments/assets/f2b6cbd8-008a-4f01-8b6e-27a3fa0a016b" />

# Checklist:

- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work


[HMS-10975]: https://redhat.atlassian.net/browse/HMS-10975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ