### PR TITLE
fix(SystemsTable): correct search by name filter

### DIFF
--- a/playwright/UI/FilterTypePatch.spec.ts
+++ b/playwright/UI/FilterTypePatch.spec.ts
@@ -266,8 +266,8 @@ test.describe('Patch Filters', () => {
       await verifyFilterTypeExists(page, 'Tags');
     });
 
-    await test.step('Verify "System" filter exists', async () => {
-      await verifyFilterTypeExists(page, 'System', true);
+    await test.step('Verify "Name" filter exists', async () => {
+      await verifyFilterTypeExists(page, 'Name', true);
     });
 
     await test.step('Verify "Status" filter exists', async () => {
@@ -283,7 +283,7 @@ test.describe('Patch Filters', () => {
 });
 
 /**
- * Verify filter contents (OS, Workspace, Tags, System, Patch status).
+ * Verify filter contents (OS, Workspace, Tags, Name, Patch status).
  * Note: Workspace and Tag options come from the Inventory service (not Patch).
  */
 test('Verify filter contents', async ({ page, systems }) => {
@@ -356,10 +356,10 @@ test('Verify filter contents', async ({ page, systems }) => {
     await resetFilters(page);
   });
 
-  await test.step('Verify "System" filter contents', async () => {
+  await test.step('Verify "Name" filter contents', async () => {
     await openConditionalFilter(page);
-    // System filter shows "Filter by name" input, not a checkbox menu
-    await applyFilterSubtype(page, 'System', {
+    // Name filter shows "Filter by name" input, not a checkbox menu
+    await applyFilterSubtype(page, 'Name', {
       name: baseSystem.name,
       inputType: 'search',
     });
@@ -377,9 +377,9 @@ test('Verify filter contents', async ({ page, systems }) => {
       inputType: 'checkbox',
     });
     await page.locator('td[data-label="Name"]').first().scrollIntoViewIfNeeded();
-    await expect(page.locator('td[data-label="Name"]').first()).toContainText(
-      baseSystem.name,
-    );
+    await expect(
+      page.locator('td[data-label="Name"]').filter({ hasText: baseSystem.name }).first(),
+    ).toBeVisible();
     await resetFilters(page);
   });
 });

--- a/playwright/UI/PaginationTests.spec.ts
+++ b/playwright/UI/PaginationTests.spec.ts
@@ -61,6 +61,7 @@ test.describe('Pagination', () => {
     await test.step('Set pagination to 10 using top paginator', async () => {
       await toolbarPaginationButton.click();
       await page.getByRole('menuitem', { name: '10 per page' }).click();
+      await waitForTableLoad(page);
 
       await expect(toolbarPaginationButton).toHaveText('1 - 10 of 12');
       await expect(page.getByText(`${prefix}-10`)).toBeVisible();
@@ -78,6 +79,7 @@ test.describe('Pagination', () => {
 
     await test.step('Top paginator: click go to next page button', async () => {
       await topNextButton.click();
+      await waitForTableLoad(page);
 
       await expect(toolbarPaginationButton).toHaveText('11 - 12 of 12');
       await expect(page.getByText(`${prefix}-11`)).toBeVisible();
@@ -96,6 +98,7 @@ test.describe('Pagination', () => {
 
     await test.step('Top paginator: click go to previous page button', async () => {
       await topPreviousButton.click();
+      await waitForTableLoad(page);
 
       await expect(toolbarPaginationButton).toHaveText('1 - 10 of 12');
       await expect(page.getByText(`${prefix}-10`)).toBeVisible();
@@ -113,6 +116,7 @@ test.describe('Pagination', () => {
 
     await test.step('Bottom paginator: click go to next page button', async () => {
       await bottomNextButton.click();
+      await waitForTableLoad(page);
 
       await expect(toolbarPaginationButton).toHaveText('11 - 12 of 12');
       await expect(page.getByText(`${prefix}-11`)).toBeVisible();
@@ -131,6 +135,7 @@ test.describe('Pagination', () => {
 
     await test.step('Bottom paginator: click go to previous page button', async () => {
       await bottomPreviousButton.click();
+      await waitForTableLoad(page);
 
       await expect(toolbarPaginationButton).toHaveText('1 - 10 of 12');
       await expect(page.getByText(`${prefix}-10`)).toBeVisible();
@@ -148,6 +153,7 @@ test.describe('Pagination', () => {
 
     await test.step('Bottom paginator: click go to last page button', async () => {
       await bottomLastPageButton.click();
+      await waitForTableLoad(page);
 
       await expect(toolbarPaginationButton).toHaveText('11 - 12 of 12');
       await expect(page.getByText(`${prefix}-11`)).toBeVisible();
@@ -166,6 +172,7 @@ test.describe('Pagination', () => {
 
     await test.step('Bottom paginator: click go to first page button', async () => {
       await bottomFirstPageButton.click();
+      await waitForTableLoad(page);
 
       await expect(toolbarPaginationButton).toHaveText('1 - 10 of 12');
       await expect(page.getByText(`${prefix}-10`)).toBeVisible();
@@ -184,6 +191,7 @@ test.describe('Pagination', () => {
     await test.step('Bottom paginator: input page number', async () => {
       await currentPageNumber.fill('2');
       await currentPageNumber.press('Enter');
+      await waitForTableLoad(page);
 
       await expect(toolbarPaginationButton).toHaveText('11 - 12 of 12');
       await expect(page.getByText(`${prefix}-11`)).toBeVisible();
@@ -203,6 +211,7 @@ test.describe('Pagination', () => {
     await test.step('Bottom paginator: set pagination to 20', async () => {
       await toolbarPaginationButton.click();
       await page.getByRole('menuitem', { name: '20 per page' }).click();
+      await waitForTableLoad(page);
 
       await expect(toolbarPaginationButton).toHaveText('1 - 12 of 12');
       await expect(targetRows).toHaveCount(12);

--- a/playwright/UI/VerifyExportingFeature.spec.ts
+++ b/playwright/UI/VerifyExportingFeature.spec.ts
@@ -118,6 +118,7 @@ test.describe('Verify exporting feature', () => {
 
     const row = page.locator('tbody[role="rowgroup"]').first();
     await expect(row).toBeVisible();
+    await expect(row).toContainText(system.name);
 
     const [osCell, installedPackagesCell] = await Promise.all([
       getRowCellByHeader(page, row, 'OS'),

--- a/playwright/test-utils/helpers/filters.ts
+++ b/playwright/test-utils/helpers/filters.ts
@@ -51,6 +51,16 @@ import { expect, waitForTableLoad } from 'test-utils';
 
 type FilterInputType = 'checkbox' | 'option' | 'search';
 
+const NAME_FILTER_PLACEHOLDER = /^Filter by name.*$/;
+
+const fillSearchFilterInput = async (page: Page, filterType: string, value: string) => {
+  if (filterType === 'Name') {
+    await page.getByPlaceholder(NAME_FILTER_PLACEHOLDER).fill(value);
+  } else {
+    await page.getByRole('textbox', { name: 'search-field' }).fill(value);
+  }
+};
+
 export interface FilterConfig {
   name: string; // Button/dropdown name (e.g., 'Type', 'Severity')
   type: FilterInputType; // How to interact with the filter
@@ -80,7 +90,7 @@ export const openConditionalFilter = async (page: Page) => {
  *
  * @param page - Playwright Page object
  * @param filterType - Name of the filter type (e.g., 'Type', 'Severity', 'Advisory')
- * @param exact - If true, match the filter type name exactly (e.g. "System" not "Operating system")
+ * @param exact - If true, match the filter type name exactly (e.g. "Name" not "Operating system")
  */
 export const verifyFilterTypeExists = async (page: Page, filterType: string, exact?: boolean) => {
   const menuitem = page.getByRole('menuitem', { name: filterType, exact: exact ?? false });
@@ -186,7 +196,7 @@ export const applyFilterSubtype = async (
   // Apply the subtype based on its input type
   switch (subtype.inputType) {
     case 'search':
-      await page.getByRole('textbox', { name: 'search-field' }).fill(subtype.name);
+      await fillSearchFilterInput(page, filterType, subtype.name);
       break;
 
     case 'checkbox': {
@@ -287,7 +297,7 @@ export const verifyFilterSubtypesExist = async (
  */
 export const applyFilter = async (page: Page, filter: FilterConfig) => {
   if (filter.type === 'search') {
-    await page.getByRole('textbox', { name: 'search-field' }).fill(filter.value);
+    await fillSearchFilterInput(page, filter.name, filter.value);
   } else {
     const dropdown = page.getByRole('button', { name: 'Options menu' });
     await dropdown.click();

--- a/src/SmartComponents/Systems/SystemTable.test.js
+++ b/src/SmartComponents/Systems/SystemTable.test.js
@@ -89,7 +89,6 @@ describe('SystemsTable', () => {
           customFilters: {
             patchParams: {
               filter: { packages_updatable: 'eq:0' },
-              search: undefined,
               selectedTags: ['tags=test-tag'],
               systemProfile: { ansible: { controller_version: 'not_nil' } },
             },
@@ -106,6 +105,7 @@ describe('SystemsTable', () => {
       expect.objectContaining({
         hideFilters: {
           all: true,
+          name: false,
           tags: false,
           hostGroupFilter: false,
           operatingSystem: false,
@@ -152,16 +152,6 @@ describe('SystemsTable', () => {
         expect.objectContaining({
           filterConfig: {
             items: [
-              {
-                filterValues: {
-                  'aria-label': 'search-field',
-                  onChange: expect.any(Function),
-                  placeholder: 'Filter by name',
-                  value: undefined,
-                },
-                label: 'System',
-                type: 'text',
-              },
               {
                 filterValues: {
                   items: [

--- a/src/SmartComponents/Systems/SystemsTable.js
+++ b/src/SmartComponents/Systems/SystemsTable.js
@@ -61,7 +61,6 @@ const SystemsTable = ({ apply, setSearchParams, activateRemediationModal, decode
     systemProfile,
     selectedTags,
     filter: queryParamsFilter,
-    search,
     page,
     perPage,
     sort,
@@ -99,8 +98,8 @@ const SystemsTable = ({ apply, setSearchParams, activateRemediationModal, decode
     dispatch(changeTags(tags));
   };
 
-  const [deleteFilters] = useRemoveFilter({ search, ...filter }, apply, pageDefaultFilters.systems);
-  const filterConfig = buildFilterConfig(search, filter, apply);
+  const [deleteFilters] = useRemoveFilter(filter, apply, pageDefaultFilters.systems);
+  const filterConfig = buildFilterConfig(filter, apply);
   const applyInventorySnapshot = React.useCallback((nextSnapshot) => {
     setInventorySnapshot((previousSnapshot) =>
       isDeepEqualReact(previousSnapshot, nextSnapshot) ? previousSnapshot : nextSnapshot,
@@ -114,18 +113,13 @@ const SystemsTable = ({ apply, setSearchParams, activateRemediationModal, decode
     );
 
   const activeFiltersConfig = React.useMemo(() => {
-    const config = buildActiveFiltersConfig(
-      filter,
-      search,
-      deleteFilters,
-      pageDefaultFilters.systems,
-    );
+    const config = buildActiveFiltersConfig(filter, '', deleteFilters, pageDefaultFilters.systems);
 
     return {
       ...config,
       showDeleteButton: config.showDeleteButton || hasInventoryFilterDeviation,
     };
-  }, [deleteFilters, filter, hasInventoryFilterDeviation, search]);
+  }, [deleteFilters, filter, hasInventoryFilterDeviation]);
 
   const onSelect = useOnSelect(systems, selectedRows, {
     endpoint: ID_API_ENDPOINTS.systems,
@@ -179,7 +173,13 @@ const SystemsTable = ({ apply, setSearchParams, activateRemediationModal, decode
         isFullView
         autoRefresh
         initialLoading
-        hideFilters={{ all: true, tags: false, hostGroupFilter: false, operatingSystem: false }}
+        hideFilters={{
+          all: true,
+          name: false,
+          tags: false,
+          hostGroupFilter: false,
+          operatingSystem: false,
+        }}
         columns={(inventoryColumns) =>
           mergeInventoryColumns(
             appliedColumns.filter((column) => column.isShown),
@@ -194,7 +194,6 @@ const SystemsTable = ({ apply, setSearchParams, activateRemediationModal, decode
               }
             : {}),
           patchParams: {
-            search,
             filter,
             systemProfile,
             selectedTags,
@@ -209,7 +208,7 @@ const SystemsTable = ({ apply, setSearchParams, activateRemediationModal, decode
               ...defaultReducers,
               ...mergeWithEntities(
                 inventoryEntitiesReducer(SYSTEMS_LIST_COLUMNS, modifyInventory),
-                persistantParams({ page, perPage, sort, search }, decodedParams),
+                persistantParams({ page, perPage, sort }, decodedParams),
               ),
             }),
           );

--- a/src/Utilities/SystemsHelpers.js
+++ b/src/Utilities/SystemsHelpers.js
@@ -1,4 +1,3 @@
-import searchFilter from '../PresentationalComponents/Filters/SearchFilter';
 import staleFilter from '../PresentationalComponents/Filters/SystemStaleFilter';
 import systemsUpdatableFilter from '../PresentationalComponents/Filters/SystemsUpdatableFilter';
 import { buildActiveFilterConfig } from './Helpers';
@@ -6,17 +5,8 @@ import { intl } from './IntlProvider';
 import messages from '../Messages';
 import { defaultCompoundSortValues } from './constants';
 
-export const buildFilterConfig = (search, filter, apply) => ({
-  items: [
-    searchFilter(
-      apply,
-      search,
-      intl.formatMessage(messages.labelsFiltersSystemsSearchTitle),
-      intl.formatMessage(messages.labelsFiltersSystemsSearchPlaceholder),
-    ),
-    staleFilter(apply, filter),
-    systemsUpdatableFilter(apply, filter),
-  ],
+export const buildFilterConfig = (filter, apply) => ({
+  items: [staleFilter(apply, filter), systemsUpdatableFilter(apply, filter)],
 });
 
 export const buildActiveFiltersConfig = (filter, search, deleteFilters, defaultFilters) =>

--- a/src/Utilities/hooks/Hooks.js
+++ b/src/Utilities/hooks/Hooks.js
@@ -232,6 +232,7 @@ export const useGetEntities = (
   ) => {
     const { selectedTags: activeTags = [] } = patchParams;
     const { selectedTags } = mapGlobalFilters(filters.tagFilters);
+    const search = filters?.hostnameOrId || '';
 
     const sort = createSystemsSortBy(orderBy, orderDirection, packageName);
     const filter = buildApiFilters(patchParams.filter, filters);
@@ -249,6 +250,7 @@ export const useGetEntities = (
       page,
       perPage,
       ...patchParams,
+      search,
       filter,
       selectedTags: nextSelectedTags,
       sort,
@@ -261,6 +263,7 @@ export const useGetEntities = (
         page,
         perPage,
         sort,
+        search,
       });
 
       applyMetadata && applyMetadata(items.meta);


### PR DESCRIPTION
# Description

This PR corrects systems `Name` filter:

1. Before the change patch was passing it's own `search` filter but it's not needed as we can re-use same filter but from inventory.
2. Filter name consistency - to be consistent across all apps, we should name filter as `Name` and not `Search`.  On a background we will call api with `search` param as we don't want to change API, but UI should be consistent.
3. Filter option `Name` is now pre-selected when you navigate to Systems page and if you open filter menu filter by Name is on top.



# How to test the PR

1. Navigate to patch systems page
2. Observe that `Name` filter is pre-selected
3. Try to filter systems by name
4. Clear filter and see it's not applied anymore

# Before the change
1. Filter named `Search`
2. Search filter is not on top in the menu
3. Search filter is not pre-selected when you navigate on page initially

<img width="718" height="531" alt="Screenshot 2026-07-09 at 13 16 09" src="https://github.com/user-attachments/assets/47836bff-d141-46d9-ac0c-137d4490b278" />


# After the change
1. Filter named `Name`
2. It's on top in the menu
3. Filter is pre-selected when you navigate on systems page

<img width="718" height="531" alt="Screenshot 2026-07-09 at 13 16 54" src="https://github.com/user-attachments/assets/1ef97333-e3f1-4c6c-959e-3d3157e51f62" />

# Dependent work link


# Checklist:

- [ ] The commit message has the Jira ticket linked
- [ ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
