### PR TITLE
fix: remove space after filter in table toolbar

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -13,10 +13,6 @@ table.patchCompactInventory {
     }
   }
 
-  .ins-c-primary-toolbar__filter {
-    margin-right: 16px;
-  }
-
   .ins-c-inventory__list-tags {
     display: block !important;
   }


### PR DESCRIPTION
# Description
Associated Jira ticket: [HMS-10843](https://redhat.atlassian.net/browse/HMS-10843)

Remote unnecessarily large spacing for toolbar filter. 

# How to test the PR
confirm visually

# Before the change
<img width="588" height="62" alt="image" src="https://github.com/user-attachments/assets/3dd00cf0-aa3a-48bf-b43c-fac039f25673" />

# After the change
<img width="588" height="62" alt="image" src="https://github.com/user-attachments/assets/8bff06fe-6501-4749-bb39-3e57aef0f460" />


# Checklist:
- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work


[HMS-10843]: https://redhat.atlassian.net/browse/HMS-10843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ