### PR TITLE
fix: ensure filters produce chips with the same label

### DIFF
--- a/src/Messages.ts
+++ b/src/Messages.ts
@@ -535,7 +535,7 @@ export default defineMessages({
   titlesAdvisoryType: {
     id: 'titlesAdvisoryType',
     description: 'title with capital letter',
-    defaultMessage: 'Advisory type',
+    defaultMessage: 'Type',
   },
   titlesAffectedSystems: {
     id: 'affectedSystems',

--- a/src/PresentationalComponents/AdvisoryHeader/__snapshots__/AdvisoryHeader.test.js.snap
+++ b/src/PresentationalComponents/AdvisoryHeader/__snapshots__/AdvisoryHeader.test.js.snap
@@ -57,7 +57,7 @@ exports[`AdvisoryHeader Should match the snapshots when loaded 1`] = `
                     data-ouia-component-type="PF6/Title"
                     data-ouia-safe="true"
                   >
-                    Advisory type
+                    Type
                   </h5>
                 </div>
                 <div
@@ -218,7 +218,7 @@ exports[`AdvisoryHeader Should match the snapshots when loading 1`] = `
                     data-ouia-component-type="PF6/Title"
                     data-ouia-safe="true"
                   >
-                    Advisory type
+                    Type
                   </h5>
                 </div>
                 <div

--- a/src/Utilities/Helpers.js
+++ b/src/Utilities/Helpers.js
@@ -483,15 +483,11 @@ export const buildFilterChips = (filters, search, searchChipLabel = 'Search', pa
       (item) => filters[item] !== '' && [].concat(filters[item]).length !== 0,
     );
     filterConfig = filterConfig.concat(
-      categories.map((category) => {
-        const label =
-          (category === 'installed_evra' && 'Package version') || filterCategories[category].label;
-        return {
-          category: label,
-          id: category,
-          chips: buildChips(filters, category),
-        };
-      }),
+      categories.map((category) => ({
+        category: filterCategories[category].label,
+        id: category,
+        chips: buildChips(filters, category),
+      })),
     );
   };
 

--- a/src/Utilities/Helpers.test.js
+++ b/src/Utilities/Helpers.test.js
@@ -298,7 +298,7 @@ describe('Helpers tests', () => {
     filters | search | result
     ${{ advisory_type_name: 'bugfix' }} | ${undefined} | ${[
   {
-    category: 'Advisory type',
+    category: 'Type',
     chips: [{ id: 'bugfix', name: 'Bugfix', value: 'bugfix' }],
     id: 'advisory_type_name',
   },
@@ -376,7 +376,7 @@ describe('Helpers tests', () => {
       deleteTitle: 'Clear filters',
       filters: [
         {
-          category: 'Advisory type',
+          category: 'Type',
           chips: [{ id: 'bugfix', name: 'Bugfix', value: 'bugfix' }],
           id: 'advisory_type_name',
         },

--- a/src/Utilities/constants.js
+++ b/src/Utilities/constants.js
@@ -239,7 +239,7 @@ export const rebootRequired = [
 
 export const filterCategories = {
   advisory_type_name: {
-    label: 'Advisory type',
+    label: 'Type',
     values: advisoryTypes,
   },
   severity: {
@@ -247,7 +247,7 @@ export const filterCategories = {
     values: advisorySeverities,
   },
   public_date: {
-    label: 'Public date',
+    label: 'Publish date',
     values: publicDateOptions,
   },
   update_status: {
@@ -282,6 +282,9 @@ export const filterCategories = {
   },
   group_name: {
     label: 'Group',
+  },
+  installed_evra: {
+    label: 'Version',
   },
 };
 


### PR DESCRIPTION
# Description
Associated Jira ticket: [HMS-10988](https://redhat.atlassian.net/browse/HMS-10988)

Ensure that filter-by options produce chips with the same label.

# Before the change
<img width="378" height="107" alt="image" src="https://github.com/user-attachments/assets/0a4c29cf-970a-4d37-ae44-881329a10477" />
<img width="432" height="107" alt="image" src="https://github.com/user-attachments/assets/cac38b45-5f29-4587-a144-4f145ad65d7d" />
<img width="413" height="106" alt="image" src="https://github.com/user-attachments/assets/7ca2ab41-b39f-48d9-b90a-90fe27003645" />

# After the change
<img width="377" height="107" alt="image" src="https://github.com/user-attachments/assets/5d31495b-cda7-4cc3-a3b9-45422a764386" />
<img width="432" height="107" alt="image" src="https://github.com/user-attachments/assets/653dcd9e-fe9c-4c00-944d-ed6745c5482b" />
<img width="413" height="106" alt="image" src="https://github.com/user-attachments/assets/afa64ccd-46a0-44a1-a17e-015e664e5d26" />

# Checklist:
- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [x] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work


[HMS-10988]: https://redhat.atlassian.net/browse/HMS-10988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ