### PR TITLE
feat: add OpenSourceBadge to advisories page

### DIFF
--- a/src/SmartComponents/Advisories/Advisories.js
+++ b/src/SmartComponents/Advisories/Advisories.js
@@ -1,4 +1,5 @@
 import { Main } from '@redhat-cloud-services/frontend-components/Main';
+import { OpenSourceBadge } from '@redhat-cloud-services/frontend-components';
 import React, { useEffect, useState, useMemo, useCallback, useLayoutEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import messages from '../../Messages';
@@ -174,6 +175,12 @@ const Advisories = () => {
                 style={{ verticalAlign: '2px' }}
               />
             </Popover>
+            <span style={{ verticalAlign: '2px' }}>
+              <OpenSourceBadge
+                size='sm'
+                repositoriesURL='https://github.com/RedHatInsights/patchman-ui'
+              />
+            </span>
           </>
         }
         headerOUIA='advisories'


### PR DESCRIPTION
# Description
Associated Jira ticket: [HMS-10988](https://redhat.atlassian.net/browse/HMS-10988)

This PR adds About open source badge next to the Advisories title. The component comes from frontend-components and the spacing and placement is the same as in the Templates page.

# How to test the PR
Please include steps to test your PR.

# Before the change

# After the change
<img width="367" height="244" alt="Screenshot From 2026-07-13 10-37-57" src="https://github.com/user-attachments/assets/95d7d38a-c2ba-47ef-b9e4-6e3a3fee1f1c" />

# Additional notes
Merge https://github.com/RedHatInsights/patchman-ui/pull/1683 first.

# Checklist:
- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work


[HMS-10988]: https://redhat.atlassian.net/browse/HMS-10988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ