### PR TITLE
fix: prevent version-pinned info icon from wrapping

### DIFF
--- a/playwright/UI/SystemsTests.spec.ts
+++ b/playwright/UI/SystemsTests.spec.ts
@@ -145,7 +145,7 @@ test.describe('Systems Tests', () => {
 
     await test.step('Tooltip is displayed showing the system is version-locked', async () => {
       const OScell = await getRowCellByHeader(page, row, 'OS');
-      await OScell.hover();
+      await OScell.getByTestId('tooltip-target').hover();
       await expect(page.getByText(`This system is locked to version ${version}`)).toBeVisible();
     });
 

--- a/playwright/UI/VerifyExportingFeature.spec.ts
+++ b/playwright/UI/VerifyExportingFeature.spec.ts
@@ -139,7 +139,8 @@ test.describe('Verify exporting feature', () => {
     const matchingCsvRow = csvData.find((row) => row.display_name === system.name);
     expect(matchingCsvRow).toBeDefined();
 
-    expect(matchingCsvRow!.os).toBe(osText);
+    const expectedOsText = osText?.replace('\u00A0', ' ')
+    expect(matchingCsvRow!.os).toBe(expectedOsText);
     expect(matchingCsvRow!.packages_installed).toBe(installedPackagesText);
 
     expect(jsonData).toHaveLength(1);
@@ -149,7 +150,7 @@ test.describe('Verify exporting feature', () => {
     expect(matchingJsonRow).toBeDefined();
 
     // Compare UI data with JSON data
-    expect(matchingJsonRow!.os).toBe(osText);
+    expect(matchingJsonRow!.os).toBe(expectedOsText);
     expect(String(matchingJsonRow!.packages_installed)).toBe(installedPackagesText);
   });
 

--- a/src/Utilities/Helpers.js
+++ b/src/Utilities/Helpers.js
@@ -3,7 +3,7 @@ import {
   BugIcon,
   EnhancementIcon,
   FlagIcon,
-  InfoCircleIcon,
+  LockIcon,
   SecurityIcon,
 } from '@patternfly/react-icons';
 import { SortByDirection } from '@patternfly/react-table';
@@ -619,23 +619,33 @@ export function sortCves(cves, index, direction) {
   };
 }
 
-export const createOSColumn = ({ osName, rhsm }) =>
-  !rhsm ? (
+export const createOSColumn = ({ osName, rhsm }) => {
+  // replace the last space with nbsp;
+  // this assumes the last space in `osName` string separates name from version like "RHEL 9.10" or "CentOS Linux 7.10"
+  osName = osName.replace(/ (?!.* )/, '\u00A0');
+  return !rhsm ? (
     osName
   ) : (
-    <Tooltip
-      content={intl.formatMessage(messages.textLockVersionTooltip, {
-        lockedVersion: rhsm,
-      })}
-    >
-      <Flex flex={{ default: 'flexDefault' }} gap={{ default: 'gapSm' }}>
-        <FlexItem>{osName}</FlexItem>
-        <FlexItem>
-          <InfoCircleIcon size='sm' color='var(--pf-t--global--color--status--info--100)' />
-        </FlexItem>
-      </Flex>
-    </Tooltip>
+    <span>
+      {osName}
+      <Tooltip
+        content={intl.formatMessage(messages.textLockVersionTooltip, {
+          lockedVersion: rhsm,
+        })}
+      >
+        <span className='pf-v6-u-text-nowrap'>
+          {'\u200d'}
+          <LockIcon
+            size='sm'
+            color='var(--pf-t--global--color--status--info--default)'
+            className='pf-v6-u-mx-xs'
+            data-testid='tooltip-target'
+          />
+        </span>
+      </Tooltip>
+    </span>
   );
+};
 
 export const removeUndefinedObjectKeys = (selectedRows) =>
   Object.keys(selectedRows).filter((row) => selectedRows[row]);


### PR DESCRIPTION
# Description
Associated Jira ticket: [HMS-10988](https://redhat.atlassian.net/browse/HMS-10988)

Fix icon wrapping similar to [#1682 ]
Also switches the color to the default info purple that is automatically responsive to light/dark mode.

# Before the change
<img width="87" height="58" alt="image" src="https://github.com/user-attachments/assets/5dbace5a-6c2e-413a-8962-d10d5121697b" />

# After the change
<img width="262" height="105" alt="image" src="https://github.com/user-attachments/assets/a8397581-e43e-4b0a-8da5-64b9b23d4879" />


# Checklist:
- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work


[HMS-10988]: https://redhat.atlassian.net/browse/HMS-10988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ