### PR TITLE
Test: Skip post-merge commit lint

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -17,9 +17,6 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run lint
-      - name: Validate current commit (last commit) with commitlint
-        if: github.event_name == 'push'
-        run: npx commitlint --last --verbose
       - name: Validate PR commits with commitlint
         if: github.event_name == 'pull_request' && github.event.pull_request.user.login != 'red-hat-konflux[bot]' && github.event.pull_request.user.login != 'dependabot[bot]'
         run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose


### PR DESCRIPTION


# Description
Skip post-merge commit lint
Bot PRs are not checked on PR open and then fail post-merge 
but it is too late to shorten the commit message.





# Checklist:

- [ ] The commit message has the Jira ticket linked
- [x ] PR has a short description
- [ ] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
