### PR TITLE
chore(deps): ignore Babel 8 majors in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,9 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "jest-environment-jsdom"
         update-types: ["version-update:semver-major"]
+      # Babel 8 ships ESM-only helpers that break Jest 29 until we migrate
+      - dependency-name: "@babel/*"
+        update-types: ["version-update:semver-major"]
       # eslint-plugin-react is not yet compatible with ESLint 10 (context API)
       # TODO: Revert this change when possible (HMS-10187)
       - dependency-name: "eslint"


### PR DESCRIPTION
## Summary
- Ignore `@babel/*` major updates in Dependabot so Babel stays on v7
- Babel 8 ships ESM-only helpers that break Jest 29 (same approach as content-sources-frontend)
- Supersedes / closes #1703, which fails install with `@babel/eslint-parser@8.0.1` peer conflict on `@babel/core@^8`

## Test plan
- [ ] Confirm Dependabot config validates
- [ ] Close #1703 after merge so Dependabot stops retrying the Babel 8 bump

Made with [Cursor](https://cursor.com)