### PR TITLE
fix: fix advisories cards breakpoints and spacing

### DIFF
--- a/src/PresentationalComponents/StatusReports/AdvisoriesStatusReport.js
+++ b/src/PresentationalComponents/StatusReports/AdvisoriesStatusReport.js
@@ -12,6 +12,8 @@ import { processDate } from '@redhat-cloud-services/frontend-components-utilitie
 import AdvisorySeverity from '../AdvisorySeverity/AdvisorySeverity';
 import RebootRequired from '../Snippets/RebootRequired';
 
+import './Card.css';
+
 const StatusCard = ({ advisory: { attributes, id } }) => (
   <Card isFullHeight>
     <CardTitle>{handlePatchLink(entityTypes.advisories, id)}</CardTitle>
@@ -29,6 +31,8 @@ const StatusCard = ({ advisory: { attributes, id } }) => (
           {attributes.reboot_required && <RebootRequired />}
         </GridItem>
       </Grid>
+    </CardBody>
+    <CardBody>
       {handlePatchLink(
         entityTypes.advisories,
         id,
@@ -36,8 +40,8 @@ const StatusCard = ({ advisory: { attributes, id } }) => (
           systemsCount: attributes.applicable_systems,
         }),
       )}
-      {handleLongSynopsis(attributes.synopsis)}
     </CardBody>
+    <CardBody>{handleLongSynopsis(attributes.synopsis)}</CardBody>
   </Card>
 );
 

--- a/src/PresentationalComponents/StatusReports/AdvisoriesStatusReport.js
+++ b/src/PresentationalComponents/StatusReports/AdvisoriesStatusReport.js
@@ -64,7 +64,7 @@ const AdvisoriesStatusBar = () => {
 
         <Grid hasGutter>
           {advisories.data.map((advisory) => (
-            <GridItem key={advisory.id} lg={3} md={3} sm={12}>
+            <GridItem key={advisory.id} xl2={3} xl={6} lg={6} md={6} sm={12}>
               <StatusCard advisory={advisory} />
             </GridItem>
           ))}

--- a/src/PresentationalComponents/StatusReports/Card.css
+++ b/src/PresentationalComponents/StatusReports/Card.css
@@ -1,0 +1,3 @@
+.pf-v6-c-card__body:not(:last-of-type) {
+  padding-block-end: var(--pf-t--global--spacer--md);
+}


### PR DESCRIPTION
# Description
Associated Jira ticket: [HMS-10843](https://redhat.atlassian.net/browse/HMS-10843)

Fix advisories cards brakpoints to prevent the left and right side from touching.
Increase line height in the card so that the item are not so squashed.

# How to test the PR


# Before the change
<img width="910" height="256" alt="Screenshot From 2026-07-30 11-09-24" src="https://github.com/user-attachments/assets/7da73b6e-10b6-4a05-b23c-a64b31a9c42b" />

# After the change
<img width="1035" height="453" alt="image" src="https://github.com/user-attachments/assets/18e219b5-55e7-40da-b501-c989b5c86f5d" />

# Checklist:
- [x] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work


[HMS-10843]: https://redhat.atlassian.net/browse/HMS-10843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ