### PR TITLE
fix: fix advisory type=other icon

### DIFF
--- a/src/PresentationalComponents/AdvisoryType/AdvisoryType.js
+++ b/src/PresentationalComponents/AdvisoryType/AdvisoryType.js
@@ -6,9 +6,10 @@ import IconWithLabel from '../Snippets/IconWithLabel';
 const AdvisoryType = ({ type = TYPE_OTHER, size = 'sm' }) =>
   useMemo(() => {
     const advisoryType =
-      advisoryTypes.find((item) => item.value === type) ?? advisoryTypes[TYPE_OTHER];
+      advisoryTypes.find((item) => item.value === type) ??
+      advisoryTypes.find((item) => item.value === TYPE_OTHER);
     return <IconWithLabel icon={advisoryType.icon} size={size} label={advisoryType.label} />;
-  }, [type]);
+  }, [type, size]);
 
 AdvisoryType.propTypes = {
   type: PropTypes.string,


### PR DESCRIPTION
# Description

Associated Jira ticket: # (issue)

Fix advisory type other icon, it should be used as a fallback.

# How to test the PR
Open an advisories page with type=other.

# Before the change
<img width="380" height="72" alt="image" src="https://github.com/user-attachments/assets/38b4ca78-cd8e-4e11-b6df-ba1bc87c90f4" />

# After the change
<img width="127" height="38" alt="image" src="https://github.com/user-attachments/assets/74ab17f5-3b65-40e5-bca0-a7fb8af3301d" />

# Checklist:

- [ ] The commit message has the Jira ticket linked
- [x] PR has a short description
- [x] Screenshots before and after the change are added
- [ ] Tests for the changes have been added
- [ ] README.md is updated if necessary
- [ ] Needs additional dependent work
